### PR TITLE
Set http and dns routing names for StatTracker in the bean definition ra...

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/ZoneManager.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/ZoneManager.java
@@ -72,8 +72,6 @@ public class ZoneManager extends Resolver {
 	private final StatTracker statTracker;
 
 	public ZoneManager(final TrafficRouter tr, final StatTracker statTracker, final String drn, final String hrn) throws IOException {
-		statTracker.setDnsRoutingName(drn);
-		statTracker.setHttpRoutingName(hrn);
 		dnsRoutingName = drn;
 		httpRoutingName = hrn;
 

--- a/traffic_router/core/src/main/resources/applicationContext.xml
+++ b/traffic_router/core/src/main/resources/applicationContext.xml
@@ -20,7 +20,10 @@
 	default-init-method="init" default-destroy-method="destroy">
 
     <import resource="classpath:/applicationProperties.xml" />
-	<bean id="statTracker" class="com.comcast.cdn.traffic_control.traffic_router.core.router.StatTracker" />
+	<bean id="statTracker" class="com.comcast.cdn.traffic_control.traffic_router.core.router.StatTracker">
+		<property name="dnsRoutingName" value="$[dns.routing.name]" />
+		<property name="httpRoutingName" value="$[http.routing.name]" />
+	</bean>
 
 	<bean id="HashFunctionFactory"
 		class="com.comcast.cdn.traffic_control.traffic_router.core.hash.MD5HashFunctionPoolableObjectFactory" />


### PR DESCRIPTION
...ther than waiting for ZoneManager to set them.
