### PR TITLE
Change the way GenISO creates images. 

### DIFF
--- a/traffic_ops/app/lib/UI/GenIso.pm
+++ b/traffic_ops/app/lib/UI/GenIso.pm
@@ -27,36 +27,36 @@ my $ksfiles_configfile_name = "mkisofs";
 sub geniso {
 	my $self = shift;
 
-    &navbarpage($self);
-    my %serverselect;
-    my $rs_server = $self->db->resultset('Server')->search( undef, { columns => [qw/id host_name domain_name/], orderby => "host_name" } );
+	&navbarpage($self);
+	my %serverselect;
+	my $rs_server = $self->db->resultset('Server')->search( undef, { columns => [qw/id host_name domain_name/], orderby => "host_name" } );
 
-    while ( my $row = $rs_server->next ) {
-        my $fqdn = $row->host_name . "." . $row->domain_name;
-        $serverselect{$fqdn} = $row->id;
-    }
+	while ( my $row = $rs_server->next ) {
+		my $fqdn = $row->host_name . "." . $row->domain_name;
+		$serverselect{$fqdn} = $row->id;
+	}
 
-    my $osversionsdir;
-    my $ksdir = $self->db->resultset('Parameter')->search( { -and => [ name => $ksfiles_parm_name, config_file => $ksfiles_configfile_name ] } )->get_column('value')->single();
-    if (defined $ksdir && $ksdir ne "") {
-        $osversionsdir = $ksdir;
-    } else {
-        $osversionsdir = $filebasedir;
-    }
+	my $osversionsdir;
+	my $ksdir = $self->db->resultset('Parameter')->search( { -and => [ name => $ksfiles_parm_name, config_file => $ksfiles_configfile_name ] } )->get_column('value')->single();
+	if (defined $ksdir && $ksdir ne "") {
+		$osversionsdir = $ksdir;
+	} else {
+		$osversionsdir = $filebasedir;
+	}
 
-    my %osversions;
+	my %osversions;
 
-    {
-        open(CFG, "<$osversionsdir/osversions.cfg") || die("$osversionsdir/osversions.cfg:$!");
-        local $/;
-        eval <CFG>;
-        close CFG;
-    }
+	{
+		open(CFG, "<$osversionsdir/osversions.cfg") || die("$osversionsdir/osversions.cfg:$!");
+		local $/;
+		eval <CFG>;
+		close CFG;
+	}
 
-    $self->stash(
-        serverselect => \%serverselect,
-        osversions   => \%osversions,
-    );
+	$self->stash(
+		serverselect => \%serverselect,
+		osversions   => \%osversions,
+	);
 }
 
 sub iso_download {
@@ -81,11 +81,11 @@ sub iso_download {
 
 	my $dir;
 	my $ksdir = $self->db->resultset('Parameter')->search( { -and => [ name => $ksfiles_parm_name, config_file => $ksfiles_configfile_name ] } )->get_column('value')->single();
-    if (defined $ksdir && $ksdir ne "") {
-        $dir = $ksdir . "/" . $osversion;
-    } else {
-        $dir = $filebasedir . "/" . $osversion;
-    }
+	if (defined $ksdir && $ksdir ne "") {
+		$dir = $ksdir . "/" . $osversion;
+	} else {
+		$dir = $filebasedir . "/" . $osversion;
+	}
 
 	my $cmd = "mkisofs -input-charset utf-8 -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -R -J -v -T $dir";
 
@@ -160,7 +160,7 @@ sub iso_download {
 				$line = $string . "\n" . $setupslavestring . "\n" . $line;
 			}
 		}
-			
+
 		print OUT $line;
 	}
 
@@ -169,5 +169,5 @@ sub iso_download {
 	my $data = `$cmd`;
 	$self->render( data => $data );
 }
-	
+
 1;

--- a/traffic_ops/app/lib/UI/GenIso.pm
+++ b/traffic_ops/app/lib/UI/GenIso.pm
@@ -111,28 +111,33 @@ sub iso_download {
 		$dir = $filebasedir . "/" . $osversion;
 	}
 	my $cfg_dir = "$dir/$install_cfg";
+
+	# This just writes the string we're going to use to generate the ISO. You 
+	# won't need it unless you're debugging stuff, but it doesn't really hurt. 
 	open (STUF,">$cfg_dir/state.out") or die "can't open state"; 
 	print STUF "Dir== $dir\n";
 	my $cmd = "mkisofs -joliet-long -input-charset utf-8 -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -R -J -v -T $dir";
 	print STUF "$cmd\n";
 	close STUF;
+
 	# This constructs the network.cfg file that gets written in the $install_cfg directory
 	# in network.cfg
 	# This is what we need to create:
-	# IP='69.252.248.230'
+	# IP='192.168.0.2'
 	# IPV6='...'
-	# NETMASK='255.255.255.252'
-	# GATEWAY='69.252.248.229'
-	# NAMESERVER='69.252.80.80'
-	# HOSTNAME='ipcdn-cache-30.cdnlab.comcast.net' 
-	# MTU='9000' 
-	# BOND_DEVICE='bond0'
+	# NETMASK='255.255.255.0'
+	# GATEWAY='192.168.0.1'
+	# NAMESERVER='8.8.8.8,8.8.4.4'
+	# HOSTNAME='mid-cache-01.mycdn.mydomain.net' 
+	# MTU='1500' 
+	# BOND_DEVICE='em0'
 	# BONDOPTS='mode=802.3ad,lacp_rate=fast,xmit_hash_policy=layer3+4'
 	my $network_string = "IPADDR=\"$ipaddr\"\nNETMASK=\"$netmask\"\nGATEWAY=\"$gateway\"\nBOND_DEVICE=\"$dev\"\nMTU=\"$mtu\"\nNAMESERVER=\"$nameservers\"\nHOSTNAME=\"$hostname\"\nNETWORKING_IPV6=\"yes\"\nIPV6ADDR=\"$ip6_address\"\nIPV6_DEFAULTGW=\"$ip6_gateway\"\nBONDING_OPTS=\"miimon=100 mode=4 lacp_rate=fast xmit_hash_policy=layer3+4\"\nDHCP=\"$dhcp\"";
 	# Write out the networking config: 
 	open(NF,">$cfg_dir/network.cfg") or die "Could not open network.cfg";
 	print NF $network_string;
 	close NF;
+
 	my $root_pass_string;
 	if ($rootpass eq "") {
 		# The following password SHOULD be "Fred". YMMV, you should change this. 


### PR DESCRIPTION
Instead of directly editing ks.src into ks.cfg, this change will write three files: disk.cfg, network.cfg and password.cfg. 

Additionally this change uses crypt to hash a provided password (Also sets a default if no password is provided. The default in the code is "Fred".) 

password.cfg is straight-up included into ks.cfg as an %include file. 

disk.cfg and network.cfg are intended to be processed by scripts. 