### PR TITLE
This changes the fixed duration to a random duration.

### DIFF
--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -872,7 +872,8 @@ sub check_syncds_state {
 }
 
 sub sleep_rand {
-	my $duration = shift;
+	# This should set it to a random number between 1 and whatever is passed in. 
+	my $duration = int(rand(shift)) + 1;
 
 	($log_level >> $WARN) && print "WARN Sleeping for $duration seconds: ";
 


### PR DESCRIPTION
Jan and I very, very briefly discussed this--when traffic_ops_ort runs they all run on the 15 and all delay 5 seconds, which means they all hit more-or-less at once. 

sleep_rand didn't have any rand in it, so I made it randier. 