### PR TITLE
changed the tag release format to accommodate traffic ops

### DIFF
--- a/traffic_ops/rpm/build/build_rpm.sh
+++ b/traffic_ops/rpm/build/build_rpm.sh
@@ -262,13 +262,13 @@ initBuildArea
 if [ "$BRANCH" != "master" ]; then
     echo "Executing RELEASE Flow"
     moveAndPushBranch $BRANCH
-    tagRelease ${BRANCH}-release
+    tagRelease traffic_ops-release-${BRANCH}
     buildRpm 
     installRpm
     copyToReleases
 elif [ "$HOTFIX_BRANCH" != "hotfix" ]; then
     echo "Executing HOTFIX Flow"
-    tagRelease ${HOTFIX_BRANCH}-hotfix
+    tagRelease traffic_ops-hotfix-${HOTFIX_BRANCH}
     buildRpm 
     installRpm
     copyToReleases


### PR DESCRIPTION
This will tag the release according to this format: traffic_ops-release-1.x