### PR TITLE
Issue173

### DIFF
--- a/traffic_ops/app/lib/MojoPlugins/Email.pm
+++ b/traffic_ops/app/lib/MojoPlugins/Email.pm
@@ -70,6 +70,7 @@ sub register {
 			my $token    = shift || confess("Please supply a GUID token");
 
 			my $portal_base_url = $self->config->{'portal'}{'base_url'};
+			my $portal_email_from = $self->config->{'portal'}{'email_from'};
 
 			$self->app->log->info( "MOJO_CONFIG: " . $ENV{MOJO_CONFIG} );
 			$self->app->log->info( "portal_base_url: " . $portal_base_url );
@@ -85,7 +86,11 @@ sub register {
 				->single();
 			$self->stash( tm_user => $tm_user, fbox_layout => 1, mode => 'add' );
 			if ( defined($email_to) ) {
-				$self->mail( subject => "Welcome to the " . $instance_name, to => $email_to, template => 'user/registration', format => 'mail' );
+                if ( defined($portal_email_from) ) {
+                    $self->mail( subject => "Welcome to the " . $instance_name, from => $portal_email_from, to => $email_to, template => 'user/registration', format => 'mail' );
+                } else {
+                    $self->mail( subject => "Welcome to the " . $instance_name, to => $email_to, template => 'user/registration', format => 'mail' );
+                }
 
 				my $email_notice = 'Successfully sent registration email to: ' . $email_to;
 				$self->app->log->info($email_notice);

--- a/traffic_ops/app/lib/MojoPlugins/Email.pm
+++ b/traffic_ops/app/lib/MojoPlugins/Email.pm
@@ -69,7 +69,7 @@ sub register {
 			my $email_to = shift || confess("Please supply an email address.");
 			my $token    = shift || confess("Please supply a GUID token");
 
-			my $portal_base_url = $self->config->{'portal'}{'base_url'};
+			my $portal_base_url   = $self->config->{'portal'}{'base_url'};
 			my $portal_email_from = $self->config->{'portal'}{'email_from'};
 
 			$self->app->log->info( "MOJO_CONFIG: " . $ENV{MOJO_CONFIG} );
@@ -85,12 +85,19 @@ sub register {
 				$self->db->resultset('Parameter')->search( { -and => [ name => 'tm.instance_name', config_file => 'global' ] } )->get_column('value')
 				->single();
 			$self->stash( tm_user => $tm_user, fbox_layout => 1, mode => 'add' );
-            if ( defined($email_to) ) {
-                if ( defined($portal_email_from) ) {
-                    $self->mail( subject => "Welcome to the " . $instance_name, from => $portal_email_from, to => $email_to, template => 'user/registration', format => 'mail' );
-                } else {
-                    $self->mail( subject => "Welcome to the " . $instance_name, to => $email_to, template => 'user/registration', format => 'mail' );
-                }
+			if ( defined($email_to) ) {
+				if ( defined($portal_email_from) ) {
+					$self->mail(
+						subject  => "Welcome to the " . $instance_name,
+						from     => $portal_email_from,
+						to       => $email_to,
+						template => 'user/registration',
+						format   => 'mail'
+					);
+				}
+				else {
+					$self->mail( subject => "Welcome to the " . $instance_name, to => $email_to, template => 'user/registration', format => 'mail' );
+				}
 
 				my $email_notice = 'Successfully sent registration email to: ' . $email_to;
 				$self->app->log->info($email_notice);

--- a/traffic_ops/app/lib/MojoPlugins/Email.pm
+++ b/traffic_ops/app/lib/MojoPlugins/Email.pm
@@ -85,7 +85,7 @@ sub register {
 				$self->db->resultset('Parameter')->search( { -and => [ name => 'tm.instance_name', config_file => 'global' ] } )->get_column('value')
 				->single();
 			$self->stash( tm_user => $tm_user, fbox_layout => 1, mode => 'add' );
-			if ( defined($email_to) ) {
+            if ( defined($email_to) ) {
                 if ( defined($portal_email_from) ) {
                     $self->mail( subject => "Welcome to the " . $instance_name, from => $portal_email_from, to => $email_to, template => 'user/registration', format => 'mail' );
                 } else {

--- a/traffic_ops/app/lib/TrafficOps.pm
+++ b/traffic_ops/app/lib/TrafficOps.pm
@@ -980,12 +980,12 @@ sub setup_mojo_plugins {
 
 	closedir(DIR);
 
-	my $registration_email_from = $config->{'portal'}{'registration_email_from'};
-	if ( defined($registration_email_from) ) {
+	my $to_email_from = $config->{'to'}{'email_from'};
+	if ( defined($to_email_from) ) {
 
 		$self->plugin(
 			mail => {
-				from => $registration_email_from,
+				from => $to_email_from,
 				type => 'text/html',
 			}
 		);
@@ -993,7 +993,7 @@ sub setup_mojo_plugins {
 		if ( $mode ne 'test' ) {
 
 			$self->app->log->info("...");
-			$self->app->log->info( "Registration Email From: " . $registration_email_from );
+			$self->app->log->info( "Traffic Ops Email From: " . $to_email_from );
 		}
 	}
 


### PR DESCRIPTION
Global TO email settings should not be specific to the TO Portal - this will also require a change to /opt/traffic_ops/app/conf/cdn.conf to  look like:

```
to => {
		email_from => 'no-reply@to.domain.com', 
		base_url => 'https://to.domain.com'
    },
	portal => {
		email_from => 'no-reply@portal.domain.com', 
		base_url => 'https://portal.domain.com'
    },
```