### PR TITLE
updated migration to expand size of description column on type table

### DIFF
--- a/traffic_ops/app/db/migrations/20150530100000_add_any_remap.sql
+++ b/traffic_ops/app/db/migrations/20150530100000_add_any_remap.sql
@@ -18,6 +18,7 @@
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
 alter table deliveryservice add column `remap_text` varchar(2048) default NULL;
+alter table type MODIFY `description` varchar(256);
 insert into type (name, description, use_in_table) values ('ANY_MAP', 'No Content Routing - arbitrary remap at the edge, no Traffic Router config', 'deliveryservice');
 
 -- +goose Down


### PR DESCRIPTION
The migration was trying to insert a description of 75 characters when the max was 45