### PR TITLE
TO/mojolicious listen to both ip protocols

### DIFF
--- a/traffic_ops/app/conf/cdn.conf
+++ b/traffic_ops/app/conf/cdn.conf
@@ -1,6 +1,6 @@
 {
 	hypnotoad => {
-		listen  => ['https://*:443?cert=/etc/pki/tls/certs/localhost.crt&key=/etc/pki/tls/private/localhost.key&verify=0x00&ciphers=AES128-GCM-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH:!ED'],
+		listen  => ['https://[::]:443?cert=/etc/pki/tls/certs/localhost.crt&key=/etc/pki/tls/private/localhost.key&verify=0x00&ciphers=AES128-GCM-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH:!ED'],
 		user => 'trafops',
 		group => 'trafops',
 		pid_file => '/var/run/traffic_ops.pid',


### PR DESCRIPTION
1. traffic_ops/app/conf/cdn.conf - changed listen to https://[::]:443.
this will cause mojolicious to listen on both ip protocols

closes #264