### PR TITLE
make exec failures visible using IPC::Cmd instead of fork/exec

### DIFF
--- a/traffic_ops/install/lib/InstallUtils.pm
+++ b/traffic_ops/install/lib/InstallUtils.pm
@@ -18,15 +18,13 @@ sub new {
 
 sub execCommand {
 	my ($class, $command, @args) = @_;
-        print "execCommand $command @args\n";
 
-        print `/usr/bin/env`;
         my ($ok, $err, $full_buf, $stdout_buff, $stderr_buff) =
                 IPC::Cmd::run( command => $command, verbose => 1 );
 
         my $result = 0;
         if (!$ok) {
-                print "ERROR: $command failed: $err\n";
+                print "ERROR: $command failed\n";
                 $result = 1;
         }
         return $result;

--- a/traffic_ops/install/lib/InstallUtils.pm
+++ b/traffic_ops/install/lib/InstallUtils.pm
@@ -19,15 +19,15 @@ sub new {
 sub execCommand {
 	my ($class, $command, @args) = @_;
 
-        my ($ok, $err, $full_buf, $stdout_buff, $stderr_buff) =
-                IPC::Cmd::run( command => $command, verbose => 1 );
+	my ($ok, $err, $full_buf, $stdout_buff, $stderr_buff) =
+	IPC::Cmd::run( command => $command, verbose => 1 );
 
-        my $result = 0;
-        if (!$ok) {
-                print "ERROR: $command failed\n";
-                $result = 1;
-        }
-        return $result;
+	my $result = 0;
+	if (!$ok) {
+		print "ERROR: $command failed\n";
+		$result = 1;
+	}
+	return $result;
 }
 
 sub promptUser {


### PR DESCRIPTION
download_web_deps error was masked by this.   Error will look something like this:

Running [/sbin/service traffic_ops start]...
ERROR: /sbin/service traffic_ops start failed