### PR TITLE
remove stty call -- wrong path and not needed

### DIFF
--- a/traffic_ops/install/bin/postinstall
+++ b/traffic_ops/install/bin/postinstall
@@ -269,7 +269,6 @@ EOF
 		$verifyTmAdminPw = InstallUtils::promptUser( "Verify the password for $tmAdminUser",     "", 1 );
 	}
 
-	InstallUtils::execCommand( "/usr/bin/stty", "echo" );
 	$user{"password"} = sha1_hex($tmAdminPw);
 
 	my $users_text = JSON->new->utf8->encode( \%user );


### PR DESCRIPTION
this error was hidden until redo of executeCommand. /usr/bin/stty is incorrect on CentOS.  'stty echo' not needed because promptUser resets echo. 