### PR TITLE
Modified the configuration info for the multi-site origin feature.

### DIFF
--- a/docs/source/admin/quick_howto/multi_site.rst
+++ b/docs/source/admin/quick_howto/multi_site.rst
@@ -44,7 +44,7 @@ Configure Multi Site Origin
 	:scale: 100%
 	:align: center
 
-5) Check the mutli-site check box in the delivery service screen:
+5) Check the multi-site check box in the delivery service screen and make sure that Content Routing Type is set to HTTP_LIVE_NATL:
 
 .. image:: 71DA92BB-8E1E-4921-BC95-574E659812FF.png
 	:scale: 100%


### PR DESCRIPTION
I've updated the traffic control documentation for the multi-site origin configuration.  On the delivery services details page, in addition to checking the multi-site origin feature to yes, make sure that the Content Routing type is set to HTTP_LIVE_NATL.  If this is not done, requests will be routed directly to the parent instead of the MID tier cache where the multi-site parent selection is configured.

We found this issue while testing the configuration Jan had written up.