### PR TITLE
Adding Mid remap line for cache_range_request plugin

### DIFF
--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -839,6 +839,9 @@ sub remap_dot_config {
 			if ( defined( $remap->{cacheurl} ) && $remap->{cacheurl} ne "" ) {
 				$mid_remap{ $remap->{org} } .= " \@plugin=cacheurl.so \@pparam=" . $remap->{cacheurl_file};
 			}
+                        if ( $remap->{range_request_handling} == 2 ) {
+                                $mid_remap{ $remap->{org} } .= " \@plugin=cache_range_requests.so";
+                        }
 		}
 		foreach my $key ( keys %mid_remap ) {
 			$text .= "map " . $key . " " . $key . $mid_remap{$key} . "\n";


### PR DESCRIPTION
I tested over 1.1.3 but couldn't test with master. This fix is trivial that should be fine.
I didn't add the "background fetch" for Mid handling but it should probably be there as well. If that's required let's create a new issue. 
Fixes #391