### PR TITLE
if user is disallowed, don't return credentials

### DIFF
--- a/traffic_ops/app/lib/TrafficOps.pm
+++ b/traffic_ops/app/lib/TrafficOps.pm
@@ -229,13 +229,16 @@ sub setup_mojo_plugins {
 					$local_user = $user_data->local_user;
 				}
 
+				if ( $role eq 'disallowed') {
+					return undef;
+				}
+
 				return {
 					'username'   => $username,
 					'role'       => $role,
 					'priv'       => $priv,
 					'local_user' => $local_user,
 				};
-				return undef;
 			},
 			validate_user => sub {
 				my ( $app, $username, $pass, $options ) = @_;


### PR DESCRIPTION
Closes #387.  Don't return a token for user if role is 'disallowed'