### PR TITLE
Fixes #322 - logging error using carp/cluck instead of carp/confess.

### DIFF
--- a/traffic_ops/app/lib/MojoPlugins/TrafficMonitorConnection.pm
+++ b/traffic_ops/app/lib/MojoPlugins/TrafficMonitorConnection.pm
@@ -47,7 +47,8 @@ sub register {
 					last;
 				}
 				if ( !defined($traffic_monitor_row) ) {
-					confess("No TrafficMonitor servers found for: $cdn");
+					cluck("No TrafficMonitor servers found for: $cdn");
+					return;
 				}
 				$hostname = $traffic_monitor_row->host_name . "." . $traffic_monitor_row->domain_name;
 				$port     = $traffic_monitor_row->tcp_port;


### PR DESCRIPTION
Fixes #322 - logging error using carp/cluck instead of carp/confess.
carp/confess shows a backtrace but is fatal.  carp/cluck shows a backtrace but is not fatal.