### PR TITLE
Fixes #328 - stashing cachegroup value when creating new server

### DIFF
--- a/traffic_ops/app/templates/server/add.html.ep
+++ b/traffic_ops/app/templates/server/add.html.ep
@@ -33,7 +33,7 @@ $(function(){
 		$.get("/api/1.1/cachegroups.json", function(data){
 		var response = data['response'];
 		$.each(response, function(idx, val) {
-			if (response[idx].name == "<%= stash 'cachegroup' %>") {
+			if (response[idx].id == "<%= stash 'cachegroup' %>") {
 				$("#cachegroup").append("<option selected=\"selected\" value=" + response[idx].id + ">" + response[idx].name + "</option>");
 			} else {
 				$("#cachegroup").append("<option value=" + response[idx].id + ">" + response[idx].name + "</option>");


### PR DESCRIPTION
A cachegroup id is stashed when you create a new serve.  When a error is returned the javascript is comparing the stashed cachegroup id to a cachegroup name so there is never a match.  Updated the code to compare the stashed value to the cachegroup id.