### PR TITLE
added syslog and IPv6 checking to ToDSCPCheck.pl

### DIFF
--- a/traffic_ops/app/bin/checks/IPv6.pm
+++ b/traffic_ops/app/bin/checks/IPv6.pm
@@ -1,0 +1,378 @@
+#
+# IPv6.pm
+# NetPacket::IPv6
+#
+# Decode Internet Protocol v6 packet header.
+#
+# References:
+# RFC2460 - IPv6 Specification
+#
+# Copyright (c) 2003-2009 Joel Knight <knight.joel@gmail.com>
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+#
+# $jwk: IPv6.pm,v 1.15 2009/03/01 19:12:03 jwk Exp $
+
+package NetPacket::IPv6;
+
+use strict;
+use vars qw($VERSION @ISA @EXPORT @EXPORT_OK %EXPORT_TAGS);
+use NetPacket;
+
+my $myclass;
+BEGIN {
+    $myclass = __PACKAGE__;
+    $VERSION = "0.43.0";
+}
+sub Version () { "$myclass v$VERSION" }
+
+BEGIN {
+    @ISA = qw(Exporter NetPacket);
+
+    @EXPORT = qw( );
+
+    @EXPORT_OK = qw(
+		ipv6_strip
+		IP_PROTO_IPV6 IP_PROTO_ICMPV6
+		IP_VERSION_IPv6 IPV6_VERSION
+		IPV6_MAXPACKET
+    );
+
+    %EXPORT_TAGS = (
+    ALL         => [@EXPORT, @EXPORT_OK],
+    protos      => [qw(IP_PROTO_IPV6 IP_PROTO_ICMPV6)],
+    versions    => [qw(IP_VERSION_IPv6 IPV6_VERSION)],
+    strip       => [qw(ipv6_strip)],
+);
+
+}
+
+# possible 'next-header' values
+use constant IP_PROTO_IPV6   => 41;		# IPv6
+use constant IP_PROTO_ICMPV6 => 58;		# ICMPv6
+
+use constant IP_VERSION_IPv6 => 6;
+use constant IPV6_VERSION => IP_VERSION_IPv6;
+
+# size of the ipv6 header in bytes
+use constant IPV6_HDRLEN => 40;
+
+# maximum ipv6 packet size in bytes
+use constant IPV6_MAXPACKET => 65535 + IPV6_HDRLEN;
+
+# convert 4, 32-bit integers to a hex string with every two bytes
+# separated by a colon
+sub int_to_hexstr {
+	my @int = @_;
+
+	my @n;
+	foreach my $i (0..3) {
+		push @n, (($int[$i] & 0xffff0000) >> 16);
+		push @n, ($int[$i] & 0x0000ffff);
+	}
+
+	return sprintf("%x:%x:%x:%x:%x:%x:%x:%x", @n[0..7]);
+}
+
+# convert a string of 8, 16-bit hex numbers to 4, 32-bit integers
+sub hexstr_to_int {
+	my @n = split m/:/, $_[0];
+
+	my @int;
+	foreach my $i (0,2,4,6) {
+		my $h = hex $n[$i];
+		my $l = hex $n[$i+1];
+		my $int;
+		$int = $l & 0x0000ffff;
+		$int = $int | (($h << 16 ) & 0xffff0000);
+		push @int, $int;
+	}
+	
+	return @int;
+}
+
+# decode ipv6 header, return a NetPacket::IPv6 object
+sub decode {
+	my $class = shift;
+	my ($pkt, $parent, @rest) = @_;
+	my $self = {};
+
+	# Class fields
+
+	$self->{_parent} = $parent;
+	$self->{_frame} = $pkt;
+
+	# Decode packet
+
+	if (defined $pkt) {
+		my ($tmp, @src, @dst);
+		
+		($tmp, $self->{plen}, $self->{nxt}, $self->{hlim}, @src[0..3], 
+			@dst[0..3], $self->{data}) = unpack('NncCNNNNNNNNa*', $pkt);
+
+		$self->{ver} = ($tmp & 0xf0000000) >> 28;
+		$self->{class} = ($tmp & 0x0ff00000) >> 20;
+		$self->{flow} = ($tmp & 0x000fffff);
+
+		$self->{src_ip} = int_to_hexstr(@src);
+		$self->{dest_ip} = int_to_hexstr(@dst);
+	}
+
+	bless ($self, $class);
+	return $self;
+}
+
+undef &ipv6_strip;           # Create alias
+*ipv6_strip = \&strip;
+
+# return the data portion of an ipv6 packet
+sub strip {
+	my ($pkt, @rest) = @_;
+
+	my $ipv6_obj = NetPacket::IPv6->decode($pkt);
+	return $ipv6_obj->{data};
+}   
+
+# reverse the decoding process and return the raw, encoded packet.
+# take into account any member data that may have changed.
+sub encode {
+	my $class = shift;
+	my $self = shift;
+
+	$self->{plen} = length $self->{data};
+
+	my $tmp;
+	$tmp = $self->{flow} & 0x000fffff;
+	$tmp = $tmp | (($self->{class} << 20) & 0x0ff00000);
+	$tmp = $tmp | (($self->{ver} << 28) & 0xf0000000);
+
+	my @src = hexstr_to_int($self->{src_ip});
+	my @dst = hexstr_to_int($self->{dest_ip});
+
+	my $packet = pack('NncCNNNNNNNNa*', $tmp, $self->{plen},
+		$self->{nxt}, $self->{hlim}, @src[0..3], @dst[0..3],
+		$self->{data});
+
+	return($packet);
+}
+
+1;
+
+__END__
+
+
+=head1 NAME
+
+C<NetPacket::IPv6> - Assembling and disassembling IPv6 (Internet
+Protocol Version 6) packets.
+
+=head1 SYNOPSIS
+
+  use NetPacket::IPv6;
+
+  $ip6_obj = NetPacket::IPv6->decode($raw_pkt);
+  $ip6_pkt = NetPacket::IPv6->encode();
+  $ip6_data = NetPacket::IPv6::strip($raw_pkt);
+
+=head1 DESCRIPTION
+
+C<NetPacket::IPv6> provides a set of routines for assembling and
+disassembling IPv6 (Internet Protocol Version 6) packets.  
+
+=head2 Methods
+
+=over
+
+=item C<NetPacket::IPv6-E<gt>decode([RAW PACKET])>
+
+Decode the raw packet data given and return an object containing
+instance data.  This method will quite happily decode garbage input. It
+is the responsibility of the programmer to ensure valid packet data is
+passed to this method.
+
+=item C<NetPacket::IPv6-E<gt>encode()>
+
+Return an IPv6 packet encoded with the instance data specified. This
+will infer the packet length automatically from the payload length.
+
+=back
+
+=head2 Functions
+
+=over
+
+=item C<NetPacket::IPv6::strip([RAW PACKET])>
+
+Return the encapsulated data (or payload) contained in the IPv6
+packet.  This data is suitable to be used as input for other
+C<NetPacket::*> modules.
+
+This function is equivalent to creating an object using the
+C<decode()> constructor and returning the C<data> field of that
+object.
+
+=back
+
+=head2 Instance data
+
+The instance data for the C<NetPacket::IPv6> object consists of
+the following fields.
+
+=over
+
+=item ver
+
+The IPv6 version number of this packet. This must always be 6.
+
+=item class
+
+The IPv6 traffic class.
+
+=item flow
+
+The IPv6 flow label.
+
+=item plen
+
+The payload length. This is the length of the payload (data); it does
+not include the length of the packet header.
+
+=item nxt
+
+The next header. This field identifies the type of header that follows
+the IPv6 header. It uses the same values as the IPv4 C<protocol> header.
+
+=item hlim
+
+The hop limit. Each router that handles the packet will decrement this
+field by 1. Once the field reaches 0, the packet is discarded. Similar
+to the C<TTL> field in the IPv4 header.
+
+=item src_ip
+
+The source IPv6 address. The address is expressed as a colon-separated
+hex string. Leading zeros within the hex numbers are removed.
+
+=item dest_ip
+
+The destination IPv6 address. The address is expressed as a
+colon-separated hex string. Leading zeros within the hex numbers are
+removed.
+
+=item data
+
+The encapsulated data (payload).
+
+=back
+
+=head2 Exports
+
+=over
+
+=item default
+
+none
+
+=item exportable
+
+Protocols:
+
+  IP_PROTO_IPV6 IP_PROTO_ICMPV6 
+
+IPv6 version number:
+
+  IP_VERSION_IPv6 IPV6_VERSION
+
+Maximum IPv6 packet size:
+
+  IPV6_MAXPACKET 
+
+Strip function:
+
+  ipv6_strip
+
+=item tags
+
+The following tags can be used to export certain items:
+
+=over
+
+=item C<:protos>
+
+IP_PROTO_IPV6 IP_PROTO_ICMPV6
+
+=item C<:versions>
+
+IP_VERSION_IPv6 IPV6_VERSION
+
+=item C<:strip>
+
+The function C<ipv6_strip>
+
+=item C<:ALL>
+
+All the above exportable items
+
+=back
+
+=back
+
+=head1 EXAMPLE
+
+The following prints the source and destination IPv6 address along 
+with the value of the C<next header> field.
+
+  #!/usr/bin/perl -w
+
+  use strict;
+  use Net::PcapUtils;
+  use NetPacket::Ethernet qw(:strip);
+  use NetPacket::IPv6;
+
+  sub process_pkt {
+      my ($user, $hdr, $pkt) = @_;
+
+      my $ip6_obj = NetPacket::IPv6->decode(eth_strip($pkt));
+      print("$ip6_obj->{src_ip} -> $ip6_obj->{dest_ip} ");
+      print("$ip6_obj->{nxt}\n");
+  }
+
+  Net::PcapUtils::loop(\&process_pkt, FILTER => 'ip6');
+
+=head1 TODO
+
+Nothing at this time.
+
+=head1 COPYRIGHT
+
+Copyright (c) 2003, 2004 Joel Knight <knight.joel@gmail.com>
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+=head1 AUTHOR
+
+Joel Knight E<lt>knight.joel@gmail.comE<gt>
+
+=cut
+

--- a/traffic_ops/app/bin/checks/ToDSCPCheck.pl
+++ b/traffic_ops/app/bin/checks/ToDSCPCheck.pl
@@ -17,10 +17,13 @@
 # DSCP check extension. Populates the 'DSCP' column.
 #
 
+# example cron entry
+# 0 * * * * root /opt/traffic_ops/app/bin/checks/ToDSCPCheck.pl -c "{\"base_url\": \"https://localhost\", \"check_name\": \"DSCP\", \"name\": \"Delivery Service\", \"cms_interface\": \"eth0\"}"
+# example cron entry with syslog
+# 0 * * * * root /opt/traffic_ops/app/bin/checks/ToDSCPCheck.pl -c "{\"base_url\": \"https://localhost\", \"check_name\": \"DSCP\", \"name\": \"Delivery Service\", \"cms_interface\": \"eth0\", \"syslog_facility\": \"local0\"}"
+
 use strict;
 use warnings;
-
-$|++;
 
 use Data::Dumper;
 use Getopt::Std;
@@ -28,39 +31,57 @@ use Log::Log4perl qw(:easy);
 use Net::PcapUtils;
 use NetPacket::Ethernet qw(:strip);
 use NetPacket::IP qw(:strip);
+use NetPacket::IPv6 qw(:strip);
 use NetPacket::TCP;
 use JSON;
 use Extensions::Helper;
+use Sys::Syslog qw(:standard :macros);
+use IO::Handle;
 
-my $VERSION = "0.01";
-my $hostn   = `hostname`;
-chomp($hostn);
+my $VERSION = "0.02";
+
+STDOUT->autoflush(1);
 
 my %args = ();
 getopts( "l:c:", \%args );
 
 Log::Log4perl->easy_init($ERROR);
 if ( defined( $args{l} ) ) {
-	if    ( $args{l} == 1 ) { Log::Log4perl->easy_init($INFO); }
-	elsif ( $args{l} == 2 ) { Log::Log4perl->easy_init($DEBUG); }
-	elsif ( $args{l} == 3 ) { Log::Log4perl->easy_init($TRACE); }
-	elsif ( $args{l} > 3 )  { Log::Log4perl->easy_init($TRACE); }
-	else                    { Log::Log4perl->easy_init($INFO); }
+   if    ( $args{l} == 1 ) { Log::Log4perl->easy_init($INFO); }
+   elsif ( $args{l} == 2 ) { Log::Log4perl->easy_init($DEBUG); }
+   elsif ( $args{l} == 3 ) { Log::Log4perl->easy_init($TRACE); }
+   elsif ( $args{l} > 3 )  { Log::Log4perl->easy_init($TRACE); }
+   else                    { Log::Log4perl->easy_init($INFO); }
 }
 
 DEBUG( "Including DEBUG messages in output. Config is \'" . $args{c} . "\'" );
 TRACE( "Including TRACE messages in output. Config is \'" . $args{c} . "\'" );
 
 if ( !defined( $args{c} ) ) {
-	&help();
-	exit(1);
+   &help();
+   exit(1);
 }
 
 my $jconf = undef;
 eval { $jconf = decode_json( $args{c} ) };
 if ($@) {
-	ERROR("Bad json config: $@");
-	exit(1);
+   ERROR("Bad json config: $@");
+   exit(1);
+}
+
+my $sslg = undef;
+if (defined($jconf->{syslog_facility})) {
+   setlogmask(LOG_UPTO(LOG_INFO));
+   openlog ('ToChecks', '', $jconf->{syslog_facility});
+   $sslg = 1;
+}
+
+my $cms_int = undef;
+if (defined($jconf->{cms_interface})) {
+   $cms_int = $jconf->{cms_interface};
+} else {
+   ERROR "cms_interface must be defined.";
+   exit(1);
 }
 
 TRACE Dumper($jconf);
@@ -68,108 +89,240 @@ my $b_url = $jconf->{base_url};
 Extensions::Helper->import();
 my $ext = Extensions::Helper->new( { base_url => $b_url, token => '91504CE6-8E4A-46B2-9F9F-FE7C15228498' } );
 
-my $match = $jconf->{match};
-
 my $check_name = $jconf->{check_name};
 if ( $check_name ne "DSCP" ) {
-	ERROR "This Check Extension is exclusively for DSCP.";
-	exit(4);
+   ERROR "This Check Extension is exclusively for DSCP.";
+   exit(4);
 }
+
+my $chck_lng_nm = $jconf->{name};
 
 my %ds_info           = ();
 my $jdeliveryservices = $ext->get( Extensions::Helper::DSLIST_PATH );
 
+# Get all the Deliver Services
 foreach my $ds ( @{$jdeliveryservices} ) {
-	$ds_info{ $ds->{id} } = $ds;
+   $ds_info{ $ds->{id} } = $ds;
 }
 
 my %domain_name_for_profile = ();
-my $jdataserver             = $ext->get( Extensions::Helper::SERVERLIST_PATH );
+my $jdataserver = $ext->get( Extensions::Helper::SERVERLIST_PATH );
 foreach my $server ( @{$jdataserver} ) {
-	next unless $server->{type} eq 'EDGE';    # We know this is DSCP, so we know we want edges only
-	my $ip        = $server->{ipAddress};
-	my $host_name = $server->{hostName};
-	my $details   = $ext->get( '/api/1.1/servers/hostname/' . $host_name . '/details.json' );
-	foreach my $dsid ( @{ $details->{deliveryservices} } ) {
-		my $ds = $ds_info{$dsid};
-		if ( $ds->{active} && defined( $ds->{checkPath} ) && $ds->{checkPath} ne "" && $ds->{protocol} == 0 ) {
-			my $prefix = $host_name;
-			if ( $ds->{type} =~ /^DNS/ ) {
-				$prefix = 'edge';
-			}
-			my $url = 'http://' . $prefix;
-			foreach my $match ( @{ $ds->{matchList} } ) {
-				if ( $match->{type} eq 'HOST_REGEXP' ) {
-					$url .= $match->{pattern};
-					$url =~ s/\\//g;
-					$url =~ s/\.\*//g;
-				}
-			}
-			if ( !defined( $domain_name_for_profile{ $ds->{profileName} } ) ) {
-				my $param_list = $ext->get( '/api/1.1/parameters/profile/' . $ds->{profileName} . '.json' );    ## TODO: create /api, use that
-				foreach my $p ( @{$param_list} ) {
-					if ( $p->{name} eq 'domain_name' ) {
-						$domain_name_for_profile{ $ds->{profileName} } = $p->{value};
-					}
-				}
-			}
-			$url .= $domain_name_for_profile{ $ds->{profileName} };
-			$url .= $ds->{checkPath};
+   next unless $server->{type} eq 'EDGE';    # We know this is DSCP, so we know we want edges only
+   my $ip         = trim($server->{ipAddress});
+   my $ip6        = trim($server->{ip6Address});
+   my $host_name  = trim($server->{hostName});
+   my $fqdn       = $host_name.".".trim($server->{domainName});
+   my $interface  = trim($server->{interfaceName});
+   my $details    = $ext->get( '/api/1.1/servers/hostname/' . $host_name . '/details.json' );
+   my $successful = 1; # assume all is good
+   $ip6 =~ s/\/\d+$//;
 
-			my $dscp_found = &get_dscp( $url, $server->{ipAddress}, "p3p1" );
-			if ( $dscp_found == $ds->{dscp} ) {
-				TRACE "Success";
-				$ext->post_result( $server->{id}, $check_name, 1 );
-			} else {
-				TRACE "Fail";
-				$ext->post_result( $server->{id}, $check_name, 0 );
-			}
-			last;
-		}
-	}
+   TRACE "Checking: ".$host_name;
+
+   # Loop thru each delivery service associated with this server
+   foreach my $dsid ( @{ $details->{deliveryservices} } ) {
+      my $ds = $ds_info{$dsid};
+      TRACE "Profile: ".$ds->{profileName}." xmlId: ".$ds->{xmlId}." active: ".$ds->{active}." checkpath: ".$ds->{checkPath}." protocol: ".$ds->{protocol};
+      #if (!defined($ds->{checkPath}) || $ds->{checkPath} eq "") {
+      #   #WARN "checkPath for ".$host_name."/".$ds->{xmlId}." not defined.";
+      #   if ($sslg) {
+      #      my @tmp = ($fqdn, $check_name, $chck_lng_nm, 'FAIL',$ds->{xmlId},
+      #                 "\'Check Path\' is not defined for this Delivery Service in Traffic Ops");
+      #      syslog(LOG_WARNING, "hostname=%s check=%s name=\"%s\" result=%s target=%s msg=\"%s\"", @tmp);
+      #   }
+      #   $successful = 0;
+      #   next;
+      #}
+      if ( $ds->{active} && defined( $ds->{checkPath} ) && $ds->{checkPath} ne "" && $ds->{protocol} == 0 ) {
+         foreach my $match ( @{ $ds->{matchList} } ) {
+            my $header;
+            my $prefix;
+            if ( $match->{type} eq 'HOST_REGEXP' ) {
+               if ($match->{pattern} =~ /\*/) {
+                  my $tmp = $match->{pattern};
+                  $tmp =~ s/\\//g;
+                  $tmp =~ s/\.\*//g;
+                  $header .= $tmp;
+                  if ( !defined( $domain_name_for_profile{ $ds->{profileName} } ) ) {
+                     my $param_list = $ext->get( '/api/1.1/parameters/profile/' . $ds->{profileName} . '.json' );    ## TODO: create /api, use that
+                     foreach my $p ( @{$param_list} ) {
+                        if ( $p->{name} eq 'domain_name' ) {
+                           $domain_name_for_profile{ $ds->{profileName} } = $p->{value};
+                        }
+                     }
+                  }
+                  if ( $ds->{type} =~ /^DNS/ ) {
+                     $prefix = 'edge';
+                  } else {
+                     $prefix = $host_name;
+                  }
+                  $header .= $domain_name_for_profile{ $ds->{profileName} };
+                  $header = $prefix.$header;
+               } else {
+                  $header = $match->{pattern};
+               }
+            }
+
+            ## check ipv4
+            # TODO "http://" should be a var so that we can also check https
+            my $url = "http://".$ip.$ds->{checkPath};
+
+            TRACE "About to check header: ".$header." url: ".$url;
+
+            my $dscp_found = &get_dscp( $url, $ip, $cms_int, $header, "ipv4");
+            my $target = $ds->{xmlId}.":ipv4";
+            if ($dscp_found == -1) {
+               $successful = 0;
+               TRACE "Failed deliveryService: ".$ds->{profileName};
+               if ($sslg) {
+                  my @tmp = ($fqdn, $check_name, $chck_lng_nm, 'FAIL',
+                             $target,$header,"Unable to connect to server");
+                  syslog(LOG_INFO, "hostname=%s check=%s name=\"%s\" result=%s target=%s url=%s msg=\"%s\"", @tmp);
+               }
+            } elsif ( $dscp_found == $ds->{dscp} ) {
+               TRACE "Success deliveryService: ".$ds->{profileName}." xmlId: ".$ds->{xmlId};
+               if ($sslg) {
+                  my @tmp = ($fqdn,$check_name,$chck_lng_nm,'OK',$target,$header);
+                  syslog(LOG_INFO, "hostname=%s check=%s name=\"%s\" result=%s target=%s url=%s", @tmp);
+               }
+            } else {
+               $successful = 0;
+               TRACE "Fail deliveryService: ".$ds->{profileName};
+               if ($sslg) {
+                  my @tmp = ($fqdn,$check_name,$chck_lng_nm,'FAIL',
+                             $target,$header,"Expected DSCP value of $ds->{dscp} got $dscp_found");
+                  syslog(LOG_ERR, "hostname=%s check=%s name=\"%s\" result=%s target=%s url=%s msg=\"%s\"", @tmp);
+               }
+            }
+
+
+            ## check ipv6
+            # TODO "http://" should be a var so that we can also check https
+            # TODO "80" should be var when we add https
+            $url = "http://".$ip6.":80".$ds->{checkPath};
+
+            TRACE "About to check header: ".$header." url: ".$url;
+
+            $dscp_found = &get_dscp( $url, $ip6, $cms_int, $header, "ipv6");
+            $target = $ds->{xmlId}.":ipv6";
+            if ($dscp_found == -1) {
+               $successful = 0;
+               TRACE "Failed deliveryService: ".$ds->{profileName};
+               if ($sslg) {
+                  my @tmp = ($fqdn, $check_name, $chck_lng_nm, 'FAIL',
+                             $target,$header,"Unable to connect to server");
+                  syslog(LOG_INFO, "hostname=%s check=%s name=\"%s\" result=%s target=%s url=%s msg=\"%s\"", @tmp);
+               }
+            } elsif ( $dscp_found == $ds->{dscp} ) {
+               TRACE "Success deliveryService: ".$ds->{profileName};
+               if ($sslg) {
+                  my @tmp = ($fqdn, $check_name, $chck_lng_nm, 'OK',$target,$header);
+                  syslog(LOG_INFO, "hostname=%s check=%s name=\"%s\" result=%s target=%s url=%s", @tmp);
+               }
+            } else {
+               $successful = 0;
+               TRACE "Fail deliveryService: ".$ds->{profileName};
+               if ($sslg) {
+                  my $target = $ds->{xmlId}.":ipv6";
+                  my @tmp = ($fqdn, $check_name, $chck_lng_nm, 'FAIL',
+                             $target,$header,"Expected DSCP value of $ds->{dscp} got $dscp_found");
+                  syslog(LOG_ERR, "hostname=%s check=%s name=\"%s\" result=%s target=%s url=%s msg=\"%s\"", @tmp);
+               }
+            }
+         }
+
+         TRACE "Finished checking";
+         #last;
+      }
+   }
+   if ($successful) {
+      $ext->post_result( $server->{id}, $check_name, 1 );
+   } else {
+      $ext->post_result( $server->{id}, $check_name, 0 );
+   }
 }
+
+closelog();
 
 sub get_dscp() {
-	my $url = shift;
-	my $ip  = shift;
-	my $dev = shift;
+   my $url      = shift;
+   my $ip       = shift;
+   my $dev      = shift;
+   my $header   = shift;
+   my $protocol = shift;
 
-	my $tos     = 0;
-	my $max_len = 0;
+   my $tos     = undef;
+   my $max_len = 0;
 
-	my $src_port = int( rand( 65535 - 1024 ) ) + 1024;
-	TRACE "get_dscp ip:" . $ip . " url:" . $url . " dev:" . $dev . " port:" . $src_port . "\n";
+   my $src_port = int( rand( 65535 - 1024 ) ) + 1024;
+   TRACE "get_dscp ip:" . $ip . " url:" . $url . " dev:" . $dev . " port:" . $src_port . " ip protocol: ".$protocol;
 
-	# Use curl to get some traffic from the URL, but send the command to the background, so the capture that follows
-	# is while traffic is being returned
-	system( "(sleep 1; curl --local-port " . $src_port . " --ipv4 -s $url 2>&1 > /dev/null || ping -c 10 $ip 2>&1 > /dev/null)  &" );
+   # Use curl to get some traffic from the URL, but send the command to the background, so the capture that follows
+   # is while traffic is being returned
+   if ($ip =~ m/:/) {
+      TRACE "running ip6";
+      my $curl = "curl --local-port " . $src_port . " --".$protocol." -s ".$url." -H \"Host: ".$header."\" 2>&1 > /dev/null";
+      TRACE "curl: ".$curl;
+      system( "(sleep 1; ".$curl." || ping6 -c 10 $ip 2>&1 > /dev/null)  &" );
+   } else {
+      system( "(sleep 1; curl --local-port " . $src_port . " --".$protocol." -s ".$url." -H \"Host: ".$header."\" 2>&1 > /dev/null || ping -c 10 $ip 2>&1 > /dev/null)  &" );
+   }
 
-	Net::PcapUtils::loop(
-		sub {
-			my ( $user, $hdr, $pkt ) = @_;
-			my $ip_obj = NetPacket::IP->decode( eth_strip($pkt) );
+   Net::PcapUtils::loop(
+      sub {
+         my ( $user, $hdr, $pkt ) = @_;
+         my $ip_obj;
+         if ($protocol eq "ipv4") {
+            $ip_obj = NetPacket::IP->decode( eth_strip($pkt) );
+            TRACE " <=> $ip_obj->{src_ip} -> $ip_obj->{dest_ip} proto: $ip_obj->{proto} tos $ip_obj->{tos} len $ip_obj->{len}\n";
+            my $tcp_obj = NetPacket::TCP->decode( $ip_obj->{data} );
+            TRACE " TCP1 $ip_obj->{src_ip}:$tcp_obj->{src_port} -> $ip_obj->{dest_ip}:$tcp_obj->{dest_port} proto: $ip_obj->{proto} tos $ip_obj->{tos} len $ip_obj->{len}\n";
+            if ( $ip_obj->{src_ip} eq $ip && $ip_obj->{len} > $max_len && $ip_obj->{proto} == 6 ) {
+               my $tcp_obj = NetPacket::TCP->decode( $ip_obj->{data} );
+               TRACE " TCP2 $ip_obj->{src_ip}:$tcp_obj->{src_port} -> $ip_obj->{dest_ip}:$tcp_obj->{dest_port} $ip_obj->{proto} tos $ip_obj->{tos} len $ip_obj->{len}\n";
+               if ( ($tcp_obj->{src_port} == 80) && ($tcp_obj->{dest_port} == $src_port) ) {
+                  TRACE " TCP3 $ip_obj->{src_ip}:$tcp_obj->{src_port} -> $ip_obj->{dest_ip}:$tcp_obj->{dest_port} $ip_obj->{proto} tos $ip_obj->{tos} len $ip_obj->{len}\n";
+                  $max_len = $ip_obj->{len};
+                  $tos     = $ip_obj->{tos};
+               }
+            }
+         } elsif ($protocol eq "ipv6") {
+            $ip_obj = NetPacket::IPv6->decode( eth_strip($pkt) );
+            TRACE " <=> $ip_obj->{src_ip} -> $ip_obj->{dest_ip} proto: $ip_obj->{nxt} tos $ip_obj->{class} len $ip_obj->{plen}\n";
+            my $tcp_obj = NetPacket::TCP->decode( $ip_obj->{data} );
+            TRACE " TCP1 $ip_obj->{src_ip}:$tcp_obj->{src_port} -> $ip_obj->{dest_ip}:$tcp_obj->{dest_port} proto: $ip_obj->{nxt} tos $ip_obj->{class} len $ip_obj->{plen}\n";
+            if ( $ip_obj->{src_ip} eq $ip && $ip_obj->{plen} > $max_len && $ip_obj->{nxt} == 6 ) {
+               my $tcp_obj = NetPacket::TCP->decode( $ip_obj->{data} );
+               TRACE " TCP2 $ip_obj->{src_ip}:$tcp_obj->{src_port} -> $ip_obj->{dest_ip}:$tcp_obj->{dest_port} $ip_obj->{nxt} tos $ip_obj->{class} len $ip_obj->{plen}\n";
+               if ( $tcp_obj->{src_port} == 80 && $tcp_obj->{dest_port} == $src_port ) {
+                  TRACE " TCP3 $ip_obj->{src_ip}:$tcp_obj->{src_port} -> $ip_obj->{dest_ip}:$tcp_obj->{dest_port} $ip_obj->{nxt} tos $ip_obj->{class} len $ip_obj->{plen}\n";
+                  $max_len = $ip_obj->{plen};
+                  $tos     = $ip_obj->{class};
+               }
+            }
+         }
 
-			TRACE " <=> $ip_obj->{src_ip} -> $ip_obj->{dest_ip} $ip_obj->{proto} tos $ip_obj->{tos} len $ip_obj->{len}\n";
-			my $tcp_obj = NetPacket::TCP->decode( $ip_obj->{data} );
-			TRACE " TCP1 $ip_obj->{src_ip}:$tcp_obj->{src_port} -> $ip_obj->{dest_ip}:$tcp_obj->{dest_port} $ip_obj->{proto} tos $ip_obj->{tos} len $ip_obj->{len}\n";
-			if ( $ip_obj->{src_ip} eq $ip && $ip_obj->{len} > $max_len && $ip_obj->{proto} == 6 ) {
-				my $tcp_obj = NetPacket::TCP->decode( $ip_obj->{data} );
-				TRACE " TCP2 $ip_obj->{src_ip}:$tcp_obj->{src_port} -> $ip_obj->{dest_ip}:$tcp_obj->{dest_port} $ip_obj->{proto} tos $ip_obj->{tos} len $ip_obj->{len}\n";
-				if ( $tcp_obj->{src_port} == 80 && $tcp_obj->{dest_port} == $src_port ) {
-					TRACE " TCP3 $ip_obj->{src_ip}:$tcp_obj->{src_port} -> $ip_obj->{dest_ip}:$tcp_obj->{dest_port} $ip_obj->{proto} tos $ip_obj->{tos} len $ip_obj->{len}\n";
-					$max_len = $ip_obj->{len};
-					$tos     = $ip_obj->{tos};
-				}
-			}
-		},
-		FILTER     => 'host ' . $ip,
-		DEV        => $dev,
-		NUMPACKETS => 7,
-		TIMEOUT    => 10
-	);
+      },
+      FILTER     => 'host ' . $ip,
+      DEV        => $dev,
+      NUMPACKETS => 7,
+      TIMEOUT    => 10
+   );
 
-	my $dscp = $tos >> 2;
-	TRACE "returning " . $dscp;
-	return $dscp;
+
+   #TRACE "tos: ".$tos;
+   my $dscp;
+   if (defined($tos)) {
+      $dscp = $tos >> 2;
+   } else {
+      $dscp = -1;
+   }
+   #my $dscp = $tos >> 2;
+   TRACE "returning " . $dscp;
+   return $dscp;
 }
 
+sub ltrim { my $s = shift; $s =~ s/^\s+//;       return $s };
+sub rtrim { my $s = shift; $s =~ s/\s+$//;       return $s };
+sub  trim { my $s = shift; $s =~ s/^\s+|\s+$//g; return $s };


### PR DESCRIPTION
1. traffic_ops/app/bin/checks/IPv6.pm - new file, cannot be installed
by CPAN.
2. traffic_ops/app/bin/checks/ToDSCPCheck.pl
  * added IPv6 checking
  * incremented version
  * removed $hostn
  * changed the way autoflush is handled
  * added $cms_int var now required on the command line in jconf
  * removed $match because it was not being used
  * added $chck_lng_nm for syslog messages
  * I was going to put in to have it fail if the ‘checkPath’ wasn’t
defined but, opted not to. Left the code in but commented.
  * changed curl to use the -H option and the url now uses the IP
address
  * changed get_dscp to also return -1 so that if we can’t connect to
the server we will know.
  * added trim functions.