### PR TITLE
exit with bad status if ant fails

### DIFF
--- a/traffic_ops/rpm/build/build_rpm.sh
+++ b/traffic_ops/rpm/build/build_rpm.sh
@@ -34,6 +34,7 @@ function buildRpm () {
 
     if [ $? != 0 ]; then
         echo -e "\nRPM BUILD FAILED.\n\n"
+        exit $?
     else
 	echo
 	echo "========================================================================================"


### PR DESCRIPTION
jenkins wasn't showing failed status because script continued on after ant failure