### PR TITLE
Updated Traffic Stats Documentation

### DIFF
--- a/docs/source/admin/traffic_stats.rst
+++ b/docs/source/admin/traffic_stats.rst
@@ -18,7 +18,7 @@
 Traffic Stats Administration
 ****************************
 
-In order for full integration of Traffic Stats three components need to be installed and configured:  Traffic Stats, InfluxDb, and Grafana.  Below are instructions on installing and configuring each component.
+Traffic Stats actually consists of three sperate components:  Traffic Stats, InfluxDB, and Grafana.  See below for information on installing and configuring each component as well as configuring the integration between the three and Traffic Ops.
 
 Installation
 ========================
@@ -29,15 +29,15 @@ Installation
 	- Copy the Traffic Stats RPM to your server
 	- sudo rpm -ivh <traffic_stats rpm>
 
-      Note:  This installation actually creates two separate services:  write_traffic_stats and ts_daily_summary.  More information on these services can be found in the overview section.     
+      Note:  This installation actually creates two separate services:  write_traffic_stats and ts_daily_summary.  More information on these services can be found in the `overview <../overview/traffic_stats.html>`_  section.     
 
-**Installing InfluxDb:**
+**Installing InfluxDB:**
 
-	In order to store traffic stats data you will need to install InfluxDb.  It is recommended InfluxDb be installed in a 3 server cluster; VMs are acceptable. The documentation for installing InfluxDb can be found on the InfluxDb `website <https://influxdb.com/docs/v0.9/introduction/installation.html>`_.
+	In order to store traffic stats data you will need to install InfluxDB.  It is recommended InfluxDB be installed in a 3 server cluster; VMs are acceptable. The documentation for installing InfluxDB can be found on the InfluxDB `website <https://influxdb.com/docs/v0.9/introduction/installation.html>`_.
 
 **Installing Grafana:**
 
-	Grafana is used to display Traffic Stats/InfluxDb data in Traffic Ops.  Grafana is typically run on the same server as Traffic Stats but this is not a requirement.  Grafana can be installed on any server that can access InfluxDb and be accessed by Traffic Ops.  Documentation on installing Grafana can be found `here <http://docs.grafana.org/installation/>`_.
+	Grafana is used to display Traffic Stats/InfluxDB data in Traffic Ops.  Grafana is typically run on the same server as Traffic Stats but this is not a requirement.  Grafana can be installed on any server that can access InfluxDB and be accessed by Traffic Ops.  Documentation on installing Grafana can be found `here <http://docs.grafana.org/installation/>`_.
 
 Configuration
 =========================
@@ -50,20 +50,20 @@ Configuration
 	     - *toUser:* The user used to connect to Traffic Ops
 	     - *toPasswd:*  The password to use when connecting to Traffic Ops
 	     - *toUrl:*  The URL of the Traffic Ops server used by Traffic Stats
-	     - *influxUser:*  The user to use when connecting to InfluxDb (if configured on InfluxDb, else leave default)
-	     - *influxPassword:*  That password to use when connecting to InfluxDb (if configured, else leave blank)
-	     - *polling interval:*  The interval at which Traffic Monitor is polled and stats are stored in InfluxDb
+	     - *influxUser:*  The user to use when connecting to InfluxDB (if configured on InfluxDB, else leave default)
+	     - *influxPassword:*  That password to use when connecting to InfluxDB (if configured, else leave blank)
+	     - *polling interval:*  The interval at which Traffic Monitor is polled and stats are stored in InfluxDB
 	     - *statusToMon:*  The status of Traffic Monitor to poll (poll ONLINE or OFFLINE traffic monitors)
 	     - *seelogConfig:*  The absolute path of the seelong config file
 	     - *dailySummaryPollingInterval:* The interval, in seconds, at which Traffic Stats checks to see if daily stats need to be computed and stored.
 	     - *cacheRetentionPolicy:* The default retention policy for cache stats
 	     - *dsRetentionPolicy:* The default retention policy for deliveryservice stats
 
-**Configuring InfluxDb:**
+**Configuring InfluxDB:**
 
-	It is HIGHLY recommended that InfluxDb be configured for clutstering.  Documentation on clustering configuration can be found on the clustering page of the `InfluxDb Website <https://influxdb.com/docs/v0.9/concepts/clustering.html>`_.
+	It is HIGHLY recommended that InfluxDB be configured for clutstering.  Documentation on clustering configuration can be found on the clustering page of the `InfluxDB Website <https://influxdb.com/docs/v0.9/concepts/clustering.html>`_.
 	
-	Once InfluxDb is installed and clustering is configured, Databases and Retention Policies need to be created.  Traffic Stats writes to three different databases: cache_stats, deliveryservice_stats, and daily_stats.  More information about the databases and what data is stored in each can be found on the `overview <../overview/traffic_stats.html>`_ page.
+	Once InfluxDB is installed and clustering is configured, Databases and Retention Policies need to be created.  Traffic Stats writes to three different databases: cache_stats, deliveryservice_stats, and daily_stats.  More information about the databases and what data is stored in each can be found on the `overview <../overview/traffic_stats.html>`_ page.
 
 	By default the cache_stats and deliveryservice_stats databases are set to store raw data for 26 hours with a retention policy called "daily"; the daily_stats datatbase is set to store data infintely with a retention policy called "daily_stats".The following commands can be completed via the influxdb `client <https://influxdb.com/download/index.html>`_ or via the admin user interface (http://influxdb_url:8083).  
 
@@ -89,7 +89,7 @@ Configuration
 		- Login to grafana as an admin user http://grafana_url:3000/login
 		- Choose Data Sources and then Add New
 		- Name your data source (we name our data sources to match the database name, cache_stats and delivery_service stats)
-		- Change the type to InfluxDb 0.9.x
+		- Change the type to InfluxDB 0.9.x
 		- For URL use https://grafana_url (see below on setting up the httpd proxy)
 		- For Access choose 'direct'
 		- Under the InfluxDB Details section enter the name of your database and enter a username and password for InfluxDB if you created one. If you did not create a username and password for influxdb just enter anything.
@@ -106,12 +106,13 @@ Configuration
 
 	In order for Traffic Ops users to see Grafana graphs, Grafana will need to allow anonymous access.  Information on how to configure anonymous access can be found on the configuration page of the `Grafana Website  <http://docs.grafana.org/installation/configuration/#authanonymous>`_. 
 
-	Traffic Ops uses custom dashboards to display information about individual delivery services or cachegroups.  In order for the custom graphs to display correctly, you will need to install the `traffic_ops_scripted.js <https://github.com/Comcast/traffic_control/blob/master/traffic_stats/grafana/traffic_ops_scripted.js>`_ file to the ``/usr/share/grafana/public/dashboards/`` directory on the grafana server.  More information on custom scipted graphs can be found in the `scripted dashboards <http://docs.grafana.org/reference/scripting/>`_ section of the Grafana documentation.
+	Traffic Ops uses custom dashboards to display information about individual delivery services or cachegroups.  In order for the custom graphs to display correctly, you will need to install the `traffic_ops_scripted.js <https://github.com/Comcast/traffic_control/blob/master/traffic_stats/grafana/traffic_ops_scripted.js>`_ file to the ``/usr/share/grafana/public/dashboards/`` directory on the grafana server.  More information on custom scripted graphs can be found in the `scripted dashboards <http://docs.grafana.org/reference/scripting/>`_ section of the Grafana documentation.
 
 **Configuring httpd proxying for SSL**
-	Currently InfluxDb does not support HTTPS for queries (This should be implemented very soon).  Since Traffic Ops is HTTPS, we need to be able to make HTTPS requests to grafana and influxdb.  We can accomplish the need to use HTTPS by installing httpd with the mod_ssl plugin and then configuring proxying of grafana and influxdb https calls to http. Below are the steps for setting up the https to http proxy.  This should be performed on the same server that is running grafana.
+	
+	Currently InfluxDB does not support HTTPS for queries (should be implemented very soon).  Since Traffic Ops is HTTPS, we need to be able to make HTTPS requests to grafana and influxdb.  We can accomplish the need to use HTTPS by installing httpd with the mod_ssl plugin and then configuring proxying of grafana and influxdb HTTPS calls to HTTP. Below are the steps for setting up the HTTPS to HTTP proxy.  This should be performed on the same server that is running grafana.
 
-	1. Download and install httpd  `download here <http://httpd.apache.org/download.cgi>`_
+	1. Download and install httpd  `from here <http://httpd.apache.org/download.cgi>`_
 	2. Create SSL certs
 	3. Install and configure mod_ssl per `this link <http://dev.antoinesolutions.com/apache-server/mod_ssl>`_ 
 	4. Create a file called grafana_proxy.conf in the /etc/httpd/conf.d directory
@@ -143,11 +144,13 @@ Configuration
 
 
 **Configuring Traffic Ops for Traffic Stats:**
-	- The influxDb servers need to be added to Traffic Ops with profile = InfluxDb.  Make sure to use port 8086 in the configuration.
+
+	- The influxDb servers need to be added to Traffic Ops with profile = InfluxDB.  Make sure to use port 8086 in the configuration.
 	- The traffic stats server should be added to Traffic Ops with profile = Traffic Stats.
 	- Parameters for which stats will be collected are added with the release, but any changes can be made via parameters that are assigned to the Traffic Stats profile.
 
 **Configuring Traffic Ops to use Grafana Dashboards**
+
 	To configure Traffic Ops to use Grafana Dashboards, you need to enter the following parameters and assign them to the GLOBAL profile.  This assumes you followed the above instructions to install and configure InfluxDB and Grafana.  You will need to place 'cdn-stats' and 'deliveryservice-stats' with the name of your dashboards.
 
 	+---------------------------+------------------------------------------------------------------------------------------------+

--- a/docs/source/admin/traffic_stats.rst
+++ b/docs/source/admin/traffic_stats.rst
@@ -17,9 +17,11 @@
 ****************************
 Traffic Stats Administration
 ****************************
+
+In order for full integration of Traffic Stats three components need to be installed and configured:  Traffic Stats, InfluxDb, and Grafana.  Below are instructions on installing and configuring each component.
+
 Installation
 ========================
-Traffic Stats consists of three components:  Traffic Stats, InfluxDb, and Grafana.  Below are instructions on installing each component.
 
 **Installing Traffic Stats:**
 
@@ -54,18 +56,39 @@ Configuration
 	     - *statusToMon:*  The status of Traffic Monitor to poll (poll ONLINE or OFFLINE traffic monitors)
 	     - *seelogConfig:*  The absolute path of the seelong config file
 	     - *dailySummaryPollingInterval:* The interval, in seconds, at which Traffic Stats checks to see if daily stats need to be computed and stored.
+	     - *cacheRetentionPolicy:* The default retention policy for cache stats
+	     - *dsRetentionPolicy:* The default retention policy for deliveryservice stats
 
 **Configuring InfluxDb:**
 
-	At a minimum, InfluxDb will need to be configured for clutstering.  Documentation on clustering configuration can be found on the clustering page of the `InfluxDb Website <https://influxdb.com/docs/v0.9/concepts/clustering.html>`_.
+	It is HIGHLY recommended that InfluxDb be configured for clutstering.  Documentation on clustering configuration can be found on the clustering page of the `InfluxDb Website <https://influxdb.com/docs/v0.9/concepts/clustering.html>`_.
+	
+	Once InfluxDb is installed and clustering is configured, Databases and Retention Policies need to be created.  Traffic Stats writes to three different databases: cache_stats, deliveryservice_stats, and daily_stats.  More information about the databases and what data is stored in each can be found on the `overview <../overview/traffic_stats.html>`_ page.
+
+	By default the cache_stats and deliveryservice_stats databases are set to store raw data for 26 hours with a retention policy called "daily" and the daily_stats datatbase is set to store data infintely with a retention policy called "daily_stats".
+
+	*Creating Databases:*
+		``create database cache_stats``
+
+		``create database deliveryservice_stats``
+
+		``create database daily_stats``
+
+	*Creating Retention Policies:*
+		``create retention policy daily on cache_stats duration 26h replication 3 DEFAULT``
+
+		``create retention policy daily on deliveryservice_stats duration 26h replication 3 DEFAULT``
+
+		``create retention policy daily_stats on daily_stats duration INF replication 3 DEFAULT``
+
+
+
 
 **Configuring Grafana:**
 
-	In order for grafana to integrate with Traffic Ops, it will need to be configured to allow anonymous authorization.  More information can be found on the configuration page of the `Grafana Website  <http://docs.grafana.org/installation/configuration/#authanonymous>`_. 
+	In order for Traffic Ops users to see Grafana graphs, Grafan will need to allow anonymous access.  Information on how to configure anonymous access can be found on the configuration page of the `Grafana Website  <http://docs.grafana.org/installation/configuration/#authanonymous>`_. 
 
-	Traffic Ops uses Grafana to display stats data to users.  In order for the graphs to display correctly, you will need to install the ``traffic_ops_scripted.js`` file from ``/traffic_control/traffic_stats/grafana`` to the ``/usr/share/grafana/public/dashboards/`` on the grafana server.  
-
-	More information can be found in the `scripted dashboards <http://docs.grafana.org/reference/scripting/>`_ section of the Grafana documentation.
+	In order for the custom graphs to display correctly (such as graphs for a chosen delivery service), you will need to install the ``traffic_ops_scripted.js`` file from ``/traffic_control/traffic_stats/grafana`` to the ``/usr/share/grafana/public/dashboards/`` on the grafana server.  More information on custom scipted graphs can be found in the `scripted dashboards <http://docs.grafana.org/reference/scripting/>`_ section of the Grafana documentation.
 
 **Configuring Traffic Ops for Traffic Stats:**
 

--- a/docs/source/overview/traffic_stats.rst
+++ b/docs/source/overview/traffic_stats.rst
@@ -24,12 +24,18 @@ Traffic Stats is a collection of utilities written in `Go <http.golang.org>`_ th
 
 |arrow| Write Traffic Stats
 ---------------------------
-Write Traffic Stats gathers stat data for Edge Caches and Delivery Services at a configurable interval from the Traffic Monitor API's and stores the data in InfluxDb. 
+Write Traffic Stats gathers stat data for Edge Caches and Delivery Services at a configurable interval from the Traffic Monitor API's and stores the data in InfluxDb.  Write Traffic Stats stores data in two seperate databases: cache_stats and deliveryservice_stats. 
+
+	- cache_stats:  The cache_stats database is used to store data gathered from edge caches.  The `measurements <https://influxdb.com/docs/v0.9/concepts/glossary.html#measurement>`_ stored by cache are: bandwidth, maxKbps, and client_connections (ats.proxy.process.http.current_client_connections).  Cache Data is stored with `tags <https://influxdb.com/docs/v0.9/concepts/glossary.html#tag>`_ for hostname, cachegroup, and CDN.  Data can be queried using tags.
+
+
+	- deliveryservice_stats:  The deliveryservice_stats database is used to store data for delivery services.  The measurements stored by delivery service are:  kbps, status_4xx, status_5xx, tps_2xx, tps_3xx, tps_4xx, tps_5xx, and tps_total.  Delivery Service stats are stored with tags for cachegroup, CDN, and Deliveryservice xml_id.  
 
 |arrow| TS Daily Summary
 --------------------------
-TS (Traffic Stats) Daily Summary is a process that runs once a day, gathers summary data for the previous day from InfluxDb, and stores it in the Traffic Ops Database.  The stats that are currently summarized are Max Bandwidth and Bytes Served.
+TS (Traffic Stats) Daily Summary is a process that runs once a day, gathers summary data for the previous day from InfluxDb, and stores it in the Traffic Ops Database as well as the daily_stats table in influxDb.  The stats that are currently summarized are Max Bandwidth and Bytes Served and they are stored by CDN.
 
+------------
 
 Any number of Traffic Stats instances may run on a given CDN to collect metrics from Traffic Monitor, however, integration with a long term metrics storage system is implementation dependent. 
 

--- a/traffic_stats/traffic_stats.cfg
+++ b/traffic_stats/traffic_stats.cfg
@@ -8,6 +8,6 @@
 	"statusToMon": "ONLINE",
 	"seelogConfig": "/opt/traffic_stats/conf/traffic_stats_seelog.xml",
 	"dailySummaryPollingInterval": 60,
-	"cacheRetentionPolicy": "weekly",
-	"dsRetentionPolicy": "weekly"
+	"cacheRetentionPolicy": "daily",
+	"dsRetentionPolicy": "daily"
 }


### PR DESCRIPTION
Documentation is now more comprehensive.  Provided all information that should be needed to configure traffic stats, grafana, and influxdb.  Provided all information that should be needed to configure integration between traffic stats (grafana) and Traffic Ops.