### PR TITLE
allow extension to override interval size

### DIFF
--- a/traffic_ops/app/lib/Extensions/TrafficStats/Delegate/Statistics.pm
+++ b/traffic_ops/app/lib/Extensions/TrafficStats/Delegate/Statistics.pm
@@ -167,10 +167,11 @@ sub build_totals {
 	my $average     = $summary->{summary}{average};
 	my $count       = $summary->{summary}{count};
 
-	# seconds in capture interval can be overridden by an extension.
-	my $sec_per_int = $summary->{summary}{intervalSize} // SECONDS_IN_CAPTURE_INTERVAL;
+	# Use intervalInSeconds to calculate total for the time period.
+	#  Default is 10s, but can be overridden by an extension.
+	my $interval_in_sec = $summary->{summary}{intervalInSeconds} // SECONDS_IN_CAPTURE_INTERVAL;
 
-	my $total_tps = ( $count * $sec_per_int ) * $average;    # since each value represents 10 seconds, need to multiply by 10 to get the 'ps' (per second)
+	my $total_tps = ( $count * $interval_in_sec ) * $average;
 
 	if ( $metric_type =~ /kbps/ ) {
 

--- a/traffic_ops/app/lib/Extensions/TrafficStats/Delegate/Statistics.pm
+++ b/traffic_ops/app/lib/Extensions/TrafficStats/Delegate/Statistics.pm
@@ -166,8 +166,11 @@ sub build_totals {
 	my $summary     = shift;
 	my $average     = $summary->{summary}{average};
 	my $count       = $summary->{summary}{count};
-	my $total_tps =
-		( $count * SECONDS_IN_CAPTURE_INTERVAL ) * $average;   # since each value represents 10 seconds, need to multiply by 10 to get the 'ps' (per second)
+
+	# seconds in capture interval can be overridden by an extension.
+	my $sec_per_int = $summary->{summary}{intervalSize} // SECONDS_IN_CAPTURE_INTERVAL;
+
+	my $total_tps = ( $count * $sec_per_int ) * $average;    # since each value represents 10 seconds, need to multiply by 10 to get the 'ps' (per second)
 
 	if ( $metric_type =~ /kbps/ ) {
 


### PR DESCRIPTION
Change for #515: Currently assumes interval size is 10s -- this allows an extension to override that.