### PR TITLE
DNSSEC UI changes

### DIFF
--- a/docs/source/admin/traffic_ops_using.rst
+++ b/docs/source/admin/traffic_ops_using.rst
@@ -958,7 +958,7 @@ The Manage DNSSEC Keys screen also allows a user to perform the following action
 
 **Activate/Deactivate DNSSEC for a CDN**
 
-Fairly straight forward, this button set the **dnssec.enabled** param to either **true** or **false** on the Traffic Router profile for the CDN.
+Fairly straight forward, this button set the **dnssec.enabled** param to either **true** or **false** on the Traffic Router profile for the CDN.  The Activate/Deactivate option is only available if DNSSEC keys exist for CDN.  In order to active DNSSEC for a CDN a user must first generate keys and then click the **Active DNSSEC** button.
 
 **Generate Keys**
 
@@ -973,7 +973,7 @@ Once these fields have been correctly entered, a user can click Generate Keys.  
 
 **Regenerate KSK**
 
-Regenerate will create a new Key Signing Key for the CDN TLD. A new DS Record will also be generated and need to be put into the parent zone in order for DNSSEC to work correctly.  When a user clicks on the **Regenerate KSK** button, they are presented with a screen with the following options:
+Regenerate KSK will create a new Key Signing Key for the CDN TLD. A new DS Record will also be generated and need to be put into the parent zone in order for DNSSEC to work correctly. The **Regenerate KSK** button is only available if keys have already been generated for a CDN.  The intent of the button is to provide a mechanism for generating a new KSK when a previous one expires or if necessary for other reasons such as a security breach.  When a user goes to generate a new KSK they are presented with a screen with the following options:
 
   - **CDN:** This is not editable and displays the CDN for which keys will be generated  
   - **KSK Expiration (Days):**  Sets how long (in days) the Key Signing Key will be valid for the CDN and associated Delivery Services. The default is 365 days.

--- a/traffic_ops/app/lib/UI/DeliveryService.pm
+++ b/traffic_ops/app/lib/UI/DeliveryService.pm
@@ -22,6 +22,7 @@ package UI::DeliveryService;
 use UI::Utils;
 use Mojo::Base 'Mojolicious::Controller';
 use Data::Dumper;
+use JSON;
 
 sub index {
 	my $self = shift;
@@ -827,10 +828,6 @@ sub create {
 	return $self->redirect_to("/modify_error") if !&is_oper($self);
 	my $new_id = -1;
 
-	#	if ( !&is_oper($self) ) {
-	#		my $err .= "You do not have enough privileges to modify this.\n";
-	#		return $self->flash( message => $err );
-	#	}
 	if ( $self->check_deliveryservice_input() ) {
 		my $insert = $self->db->resultset('Deliveryservice')->create(
 			{
@@ -938,6 +935,12 @@ sub create {
 		$self->regex_remap( $self->param('ds.profile'), $self->param('ds.xml_id'), $self->param('ds.regex_remap') );
 		$self->cacheurl( $self->param('ds.profile'), $self->param('ds.xml_id'), $self->param('ds.cacheurl') );
 
+		##create dnssec keys for the new DS if DNSSEC is enabled for the CDN 
+		my $dnssec_enabled_rs = $self->db->resultset('ProfileParameter')->search( { -and => [ 'parameter.name' => 'dnssec.enabled', 'profile.id' => $self->param('ds.profile') ] }, { prefetch => [ 'parameter', 'profile' ] } )->single();
+		if ($dnssec_enabled_rs) {
+			my $dnssec_enabled = $dnssec_enabled_rs->parameter->value;
+			$self->create_dnssec_keys($self->param('ds.profile'), $self->param('ds.xml_id'), $new_id);
+		}
 		$self->flash( message => "Success!" );
 		return $self->redirect_to( '/ds/' . $new_id );
 	}
@@ -952,11 +955,86 @@ sub create {
 			selected_profile => $selected_profile,
 			mode             => "add",
 		);
-
-		# print "no bueno\n";
 		$self->render('delivery_service/add');
 	}
 }
+
+sub create_dnssec_keys {
+	my $self = shift;
+	my $profile_id = shift;
+	my $xml_id = shift;
+	my $ds_id = shift;
+	
+	#get CDN name
+	my $dnskey_ttl;
+	my $cdn_rs = $self->db->resultset('ProfileParameter')->search( { -and => [ 'parameter.name' => 'CDN_name', 'profile.id' => $profile_id ] }, { prefetch => [ 'parameter', 'profile' ] } )->single();
+	my $cdn_name = $cdn_rs->parameter->value;
+	#get keys for cdn
+	my $keys;
+	my $response_container = $self->riak_get( "dnssec", $cdn_name);
+	my $get_keys = $response_container->{'response'};
+	$keys = decode_json( $get_keys->content );
+	
+	#get default expiration days and ttl for DSs from CDN record to use when generating new keys
+	my $default_k_exp_days = "365";
+	my $default_z_exp_days = "30";
+	my $cdn_ksk            = $keys->{$cdn_name}->{ksk};
+	foreach my $cdn_krecord (@$cdn_ksk) {
+		my $cdn_kstatus = $cdn_krecord->{status};
+		if ( $cdn_kstatus eq 'new' )
+		{    #ignore anything other than the 'new' record
+			my $cdn_k_exp   = $cdn_krecord->{expirationDate};
+			my $cdn_k_incep = $cdn_krecord->{inceptionDate};
+			$default_k_exp_days = ( $cdn_k_exp - $cdn_k_incep ) / 86400;
+		}
+	}
+	my $cdn_zsk = $keys->{$cdn_name}->{zsk};
+	foreach my $cdn_zrecord (@$cdn_zsk) {
+		my $cdn_zstatus = $cdn_zrecord->{status};
+		if ( $cdn_zstatus eq 'new' )
+		{    #ignore anything other than the 'new' record
+			my $cdn_z_exp   = $cdn_zrecord->{expirationDate};
+			my $cdn_z_incep = $cdn_zrecord->{inceptionDate};
+			$default_z_exp_days = ( $cdn_z_exp - $cdn_z_incep ) / 86400;
+		}
+	}
+	#create the ds domain name for dnssec keys
+	my $domain_name = $self->get_cdn_domain( $ds_id );
+	my $deliveryservice_regexes	= $self->get_regexp_set( $ds_id );
+	my $rs_ds = $self->db->resultset('Deliveryservice')->search(
+		{ 'me.xml_id' => $xml_id },
+		{   prefetch =>
+			[ { 'type' => undef }, { 'profile' => undef } ]
+		}
+	);
+	my $data = $rs_ds->single;
+	my @example_urls = UI::DeliveryService::get_example_urls( $self, $ds_id, $deliveryservice_regexes, $data, $domain_name, $data->protocol );
+	#first one is the one we want.  period at end for dnssec, substring off stuff we dont want
+	my $ds_name = $example_urls[0] . ".";
+	my $length = length($ds_name) - index( $ds_name, "." );
+	$ds_name = substr( $ds_name, index( $ds_name, "." ) + 1, $length );
+
+	my $inception = time();
+	my $z_expiration
+				= $inception + ( 86400 * $default_z_exp_days );
+			my $k_expiration
+				= $inception + ( 86400 * $default_k_exp_days );
+
+			my $zsk
+				= $self->get_dnssec_keys( "zsk", $ds_name, $dnskey_ttl,
+				$inception, $z_expiration, "new", $inception );
+			my $ksk
+				= $self->get_dnssec_keys( "ksk", $ds_name, $dnskey_ttl,
+				$inception, $k_expiration, "new", $inception );
+
+			#add to keys hash
+			$keys->{$xml_id} = { zsk => [$zsk], ksk => [$ksk] };
+
+	#put keys back in Riak
+	my $json_data = encode_json($keys);
+	$response_container	= $self->riak_put( "dnssec", $cdn_name, $json_data );
+}
+
 
 # for the add delivery service view
 sub add {

--- a/traffic_ops/app/lib/UI/DnssecKeys.pm
+++ b/traffic_ops/app/lib/UI/DnssecKeys.pm
@@ -99,9 +99,11 @@ sub add {
 	my $z_expiry = "30";
 	my $effective_date = strftime( "%Y-%m-%d %H:%M:%S\n", gmtime(time) );
 	my $keys;
+	my $existing = 0;
 	my $response_container = $self->riak_get( "dnssec", $cdn_name );
 	my $get_keys = $response_container->{'response'};
 	if ( $get_keys->is_success() ) {
+		$existing = 1; ##change the generate keys dialog based on whether or not keys exist.
 		$keys = decode_json( $get_keys->content );
 		my $cdn_ksk = $keys->{$cdn_name}->{ksk};
 		foreach my $cdn_krecord (@$cdn_ksk) {
@@ -129,7 +131,8 @@ sub add {
 			cdn_name => $cdn_name,
 			k_expiry => $k_expiry,
 			z_expiry => $z_expiry,
-			effective_date => $effective_date
+			effective_date => $effective_date,
+			existing => $existing
 		},
 		fbox_layout => 1
 	);
@@ -162,7 +165,7 @@ sub addksk {
 			cdn_name => $cdn_name,
 			k_expiry => $k_expiry,
 			z_expiry => "1", ##for is_valid purposes only. 
-			effective_date => $effective_date
+			effective_date => $effective_date,
 		},
 		fbox_layout => 1
 	);

--- a/traffic_ops/app/lib/UI/Utils.pm
+++ b/traffic_ops/app/lib/UI/Utils.pm
@@ -30,7 +30,7 @@ use Data::Dumper;
 # A release gets cut with just a $major.$minor
 # The presence of a $micro means this version (branch) has been patched and released with that patch.
 # Lowest $micro number, when present is 1.
-my $version = "1.1.5";
+my $version = "1.1.6-dev";
 
 require Exporter;
 our @ISA = qw(Exporter);

--- a/traffic_ops/app/templates/dnssec_keys/add.html.ep
+++ b/traffic_ops/app/templates/dnssec_keys/add.html.ep
@@ -34,7 +34,7 @@
 
 			  $( "#dialog-confirm" ).dialog({
 				resizable: false,
-				height:150,
+				maxHeight:500,
 				modal: true,
 				buttons: {
 				  "Generate Keys": function() {
@@ -107,7 +107,11 @@
         		</div><br>    
 			<div class="buttons-section">
 				<div id="dialog-confirm" title="Generate Keys?" style="display:none;">
-					<p><span class="ui-icon ui-icon-alert" style="float:left; margin:0 7px 20px 0;"></span>This will generate DNSSEC keys for the CDN selected and all associated Delivery Services. Are you sure?</p>
+					<% if ($dnssec->{existing} == 1) { %>
+						<p><span class="ui-icon ui-icon-alert" style="float:left; margin:0 7px 50px 0;"></span>This will regenerate DNSSEC keys for the CDN selected and all associated Delivery Services. A new DS Record will be created and needs to be added to the parent zone in order for DNSSEC to work properly.  Are you sure?</p>
+					<% } else { %>
+						<p><span class="ui-icon ui-icon-alert" style="float:left; margin:0 7px 20px 0;"></span>This will generate DNSSEC keys for the CDN selected and all associated Delivery Services. Are you sure?</p>
+					<% } %>
 				</div>
 			<div id="generate-section" style="margin-bottom: 20px;">
 				<div>

--- a/traffic_ops/app/templates/dnssec_keys/addksk.html.ep
+++ b/traffic_ops/app/templates/dnssec_keys/addksk.html.ep
@@ -34,7 +34,7 @@
 
 			  $( "#dialog-confirm" ).dialog({
 				resizable: false,
-				height:150,
+				maxHeight:500,
 				modal: true,
 				buttons: {
 				  "Generate Keys": function() {
@@ -100,7 +100,7 @@
         		</div><br>    
 			<div class="buttons-section">
 				<div id="dialog-confirm" title="Generate Keys?" style="display:none;">
-					<p><span class="ui-icon ui-icon-alert" style="float:left; margin:0 7px 20px 0;"></span>This will re-generate the KSK for the chosen CDN. Are you sure?</p>
+						<p><span class="ui-icon ui-icon-alert" style="float:left; margin:0 7px 50px 0;"></span>This will regenerate the KSK for the CDN Chosen. A new DS Record will be created and needs to be added to the parent zone in order for DNSSEC to work properly.  Are you sure?</p>
 				</div>
 			<div id="generate-section">
 				<div>

--- a/traffic_ops/app/templates/dnssec_keys/manage.html.ep
+++ b/traffic_ops/app/templates/dnssec_keys/manage.html.ep
@@ -80,12 +80,14 @@ function generate_ksk() {
 			        </div>
 					<div class="buttons-section" style="margin-bottom: 20px;">
 						<div style="margin-top: 25px; margin-left: 10px; position: relative; display: inline-block; float: left;">
-							<% if ($dnssec->{active} =~ /true/ ) { %>
-								%= field('dnssec.active_flag')->hidden(class => 'field', required => 'required', id => 'dnssec.active', name => 'dnssec.active', type => 'hidden', value => 'false');
-								<button class="button" id="submit_button">Deactivate DNSSEC</button>
-							<% } else { %>
-								%= field('dnssec.active_flag')->hidden(class => 'field', required => 'required', id => 'dnssec.active', name => 'dnssec.active', type => 'hidden', value => 'true');
-								<button class="button" id="submit_button">Activate DNSSEC</button>
+							<% if defined($dnssec->{ttl}) { %>
+								<% if ($dnssec->{active} =~ /true/ ) { %>
+									%= field('dnssec.active_flag')->hidden(class => 'field', required => 'required', id => 'dnssec.active', name => 'dnssec.active', type => 'hidden', value => 'false');
+									<button class="button" id="submit_button">Deactivate DNSSEC</button>
+								<% } else { %>
+									%= field('dnssec.active_flag')->hidden(class => 'field', required => 'required', id => 'dnssec.active', name => 'dnssec.active', type => 'hidden', value => 'true');
+									<button class="button" id="submit_button">Activate DNSSEC</button>
+								<% } %>
 							<% } %>
 						</form>
 				   			<button class="button" onclick="generate_keys()" id="generate_keys" style="margin-left: 10px">Generate Keys</button>

--- a/traffic_ops/app/templates/dnssec_keys/manage.html.ep
+++ b/traffic_ops/app/templates/dnssec_keys/manage.html.ep
@@ -80,7 +80,7 @@ function generate_ksk() {
 			        </div>
 					<div class="buttons-section" style="margin-bottom: 20px;">
 						<div style="margin-top: 25px; margin-left: 10px; position: relative; display: inline-block; float: left;">
-							<% if defined($dnssec->{ttl}) { %>
+							<% if (defined($dnssec->{ttl})) { %>
 								<% if ($dnssec->{active} =~ /true/ ) { %>
 									%= field('dnssec.active_flag')->hidden(class => 'field', required => 'required', id => 'dnssec.active', name => 'dnssec.active', type => 'hidden', value => 'false');
 									<button class="button" id="submit_button">Deactivate DNSSEC</button>
@@ -91,7 +91,9 @@ function generate_ksk() {
 							<% } %>
 						</form>
 				   			<button class="button" onclick="generate_keys()" id="generate_keys" style="margin-left: 10px">Generate Keys</button>
+				   			<% if (defined($dnssec->{k_expiry})) { %>
 				   			<button class="button" onclick="generate_ksk()" style="margin-left: 10px">Regenerate KSK</button>
+				   			<% } %>
 				 		</div>
 					 	<div style="margin-top: 25px; float:right; margin-right: 50px">
 							<button class="button" id="close_button">Close</button>


### PR DESCRIPTION
The Activate key is only visible if keys exist, this is to help prevent issues that could occur if a user activiates DNSSEC for a CDN before creating DNSSEC keys.

Updated language used on confirm keys for generating and regenerating keys. A user should now be more clear as to the implications of creating or recreating the keys.

Create DNSSEC keys for a new delivery service if DS is part of a CDN with DNSSEC enabled