### PR TITLE
change out multi-byte "smart quotes" in docs for simple ascii version

### DIFF
--- a/docs/source/admin/quick_howto/multi_site.rst
+++ b/docs/source/admin/quick_howto/multi_site.rst
@@ -20,7 +20,7 @@
 Configure Multi Site Origin
 ***************************
 
-1) Create “cachegroups” for the origin locations, and assign the appropriate parent-child relationship between the mid cg's and org cgs (click the image to see full size):
+1) Create "cachegroups" for the origin locations, and assign the appropriate parent-child relationship between the mid cg's and org cgs (click the image to see full size):
 
 .. image:: C5C4CD22-949A-48FD-8976-C673083E2177.png
 	:scale: 100%

--- a/docs/source/admin/traffic_ops_install.rst
+++ b/docs/source/admin/traffic_ops_install.rst
@@ -257,11 +257,11 @@ To begin the install:
     Connecting to geolite.maxmind.com|141.101.115.190|:80... connected.
     HTTP request sent, awaiting response... 200 OK
     Length: 17633433 (17M) [application/octet-stream]
-    Saving to: “GeoLite2-City.mmdb.gz”
+    Saving to: "GeoLite2-City.mmdb.gz"
 
     100%[==================================================================================================================================================================>] 17,633,433  7.03M/s   in 2.4s
 
-    2015-04-14 02:14:35 (7.03 MB/s) - “GeoLite2-City.mmdb.gz” saved [17633433/17633433]
+    2015-04-14 02:14:35 (7.03 MB/s) - "GeoLite2-City.mmdb.gz" saved [17633433/17633433]
 
     Copying coverage zone file to public dir.
 

--- a/docs/source/admin/traffic_stats.rst
+++ b/docs/source/admin/traffic_stats.rst
@@ -44,7 +44,7 @@ Configuration
 
 **Configuring Traffic Stats:**
 
-	Traffic Stats’ configuration file can be found in /opt/traffic_stats/conf/traffic_stats.cfg.
+	Traffic Stats' configuration file can be found in /opt/traffic_stats/conf/traffic_stats.cfg.
 	The following values need to be configured: 
 
 	     - *toUser:* The user used to connect to Traffic Ops

--- a/docs/source/development/traffic_ops.rst
+++ b/docs/source/development/traffic_ops.rst
@@ -54,7 +54,7 @@ Traffic Ops Project Tree Overview
   * /API - Mojo Controllers for the /API area of the application.
   * /Common - Common Code between both the API and UI areas.
   * /Extensions      
-  * Fixtures/ - Test Case fixture data for the ‘to_test’ database.
+  * Fixtures/ - Test Case fixture data for the 'to_test' database.
     * /Integration - Integration Tests.
   * /MojoPlugins - Mojolicious Plugins for Common Controller Code.
   * Schema/ - Database Schema area.
@@ -182,7 +182,7 @@ To install the Traffic Ops Developer environment:
 
     Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 
-    mysql> create user ‘to_user’@’localhost’;
+    mysql> create user 'to_user'@'localhost';
     mysql> grant all on to_development.* to 'to_user'@'localhost' identified by 'twelve';
     mysql> grant all on to_test.* to 'to_user'@'localhost' identified by 'twelve';
     mysql> grant all on to_integration.* to 'to_user'@'localhost' identified by 'twelve';

--- a/docs/source/development/traffic_ops_api/v11/to_extension.rst
+++ b/docs/source/development/traffic_ops_api/v11/to_extension.rst
@@ -62,7 +62,7 @@ Response Content Type: application/json
 
 
   {
-         “response”: [
+         "response": [
                 {
                         script_file: "ping",
                         version: "1.0.0",

--- a/docs/source/development/traffic_ops_api/v11/user.rst
+++ b/docs/source/development/traffic_ops_api/v11/user.rst
@@ -149,24 +149,24 @@ Users
   **Response Example** ::
 
     {
-           “response”: {
-                            “email”: "email@email.com",
-                            “city”: "",
-                            “id”: "50",
-                            “phoneNumber”: "",
-                            “company”: "",
-                            “country”: "",
-                            “fullName”: "Tom Callahan",
-                            “localUser”: true,
-                            “uid”: "0",
-                            “stateOrProvince”: "",
-                            “username”: "tommyboy",
-                            “newUser”: false,
-                            “addressLine2”: "",
-                            “role”: "6",
-                            “addressLine1”: "",
-                            “gid”: "0",
-                            “postalCode”: ""
+           "response": {
+                            "email": "email@email.com",
+                            "city": "",
+                            "id": "50",
+                            "phoneNumber": "",
+                            "company": "",
+                            "country": "",
+                            "fullName": "Tom Callahan",
+                            "localUser": true,
+                            "uid": "0",
+                            "stateOrProvince": "",
+                            "username": "tommyboy",
+                            "newUser": false,
+                            "addressLine2": "",
+                            "role": "6",
+                            "addressLine1": "",
+                            "gid": "0",
+                            "postalCode": ""
            },
     }
 
@@ -405,11 +405,11 @@ Authentication Required: Yes
   **Response Example** ::
 
     {
-          “alerts”:
+          "alerts":
                   [
                       { 
-                            “level”: "success",
-                            “text”: "Successfully created purge job for: ."
+                            "level": "success",
+                            "text": "Successfully created purge job for: ."
                       }
                   ],
     }

--- a/docs/source/development/traffic_ops_api/v12/to_extension.rst
+++ b/docs/source/development/traffic_ops_api/v12/to_extension.rst
@@ -62,7 +62,7 @@ Response Content Type: application/json
 
 
   {
-         “response”: [
+         "response": [
                 {
                         script_file: "ping",
                         version: "1.0.0",

--- a/docs/source/development/traffic_ops_api/v12/user.rst
+++ b/docs/source/development/traffic_ops_api/v12/user.rst
@@ -149,24 +149,24 @@ Users
   **Response Example** ::
 
     {
-           “response”: {
-                            “email”: "email@email.com",
-                            “city”: "",
-                            “id”: "50",
-                            “phoneNumber”: "",
-                            “company”: "",
-                            “country”: "",
-                            “fullName”: "Tom Callahan",
-                            “localUser”: true,
-                            “uid”: "0",
-                            “stateOrProvince”: "",
-                            “username”: "tommyboy",
-                            “newUser”: false,
-                            “addressLine2”: "",
-                            “role”: "6",
-                            “addressLine1”: "",
-                            “gid”: "0",
-                            “postalCode”: ""
+           "response": {
+                            "email": "email@email.com",
+                            "city": "",
+                            "id": "50",
+                            "phoneNumber": "",
+                            "company": "",
+                            "country": "",
+                            "fullName": "Tom Callahan",
+                            "localUser": true,
+                            "uid": "0",
+                            "stateOrProvince": "",
+                            "username": "tommyboy",
+                            "newUser": false,
+                            "addressLine2": "",
+                            "role": "6",
+                            "addressLine1": "",
+                            "gid": "0",
+                            "postalCode": ""
            },
     }
 
@@ -405,11 +405,11 @@ Authentication Required: Yes
   **Response Example** ::
 
     {
-          “alerts”:
+          "alerts":
                   [
                       { 
-                            “level”: "success",
-                            “text”: "Successfully created purge job for: ."
+                            "level": "success",
+                            "text": "Successfully created purge job for: ."
                       }
                   ],
     }


### PR DESCRIPTION
many .rst docs had multi-byte smart quotes instead of normal ascii versions.   That causes problems when copying an example command from a web browser to a command line, e.g.

```
mysql> create user ‘to_user’@’localhost’;
```

I don't know exactly how to generate the docs html from .rst,  but this ought to fix that issue..