### PR TITLE
#556 skip ip6_address if not defined

### DIFF
--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -485,7 +485,9 @@ sub ip_allow_data {
 				|| ( defined( $allow_locs{ $allow_row->cachegroup->id } ) && $allow_locs{ $allow_row->cachegroup->id } == 1 ) )
 			{
 				push( @allowed_netaddrips, NetAddr::IP->new( $allow_row->ip_address, $allow_row->ip_netmask ) );
-				push( @allowed_ipv6_netaddrips, NetAddr::IP->new( $allow_row->ip6_address ) );
+				if ( defined $allow_row->ip6_address ) {
+					push( @allowed_ipv6_netaddrips, NetAddr::IP->new( $allow_row->ip6_address ) );
+				}
 			}
 		}
 


### PR DESCRIPTION
#556 - when generating conf files for mid,  goes thru all rascal and edge servers to get ip addresses.  This error happened when one of those servers had no ip6 address defined.