### PR TITLE
Traffic Router support for ingesting and parsing a secondary CZF file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ traffic_ops/app/public/js/jquery-ui.min.js
 traffic_ops/app/public/js/jquery.dataTables.min.js
 traffic_stats/write_traffic_stats
 misc/traffic-control-cdn/downloads/*.rpm
+traffic_router/*/*.log
+traffic_router/*.log
+traffic_router/*/*.iml
+traffic_router/*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ traffic_ops/app/public/js/jquery-1.11.2.min.js
 traffic_ops/app/public/js/jquery-ui.min.js
 traffic_ops/app/public/js/jquery.dataTables.min.js
 traffic_stats/write_traffic_stats
+misc/traffic-control-cdn/downloads/*.rpm

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/config/ConfigHandler.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/config/ConfigHandler.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.comcast.cdn.traffic_control.traffic_router.core.loc.*;
 import org.apache.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -37,10 +38,6 @@ import com.comcast.cdn.traffic_control.traffic_router.core.cache.Cache.DeliveryS
 import com.comcast.cdn.traffic_control.traffic_router.core.ds.DeliveryService;
 import com.comcast.cdn.traffic_control.traffic_router.core.ds.DeliveryServiceMatcher;
 import com.comcast.cdn.traffic_control.traffic_router.core.ds.DeliveryServiceMatcher.Type;
-import com.comcast.cdn.traffic_control.traffic_router.core.loc.Geolocation;
-import com.comcast.cdn.traffic_control.traffic_router.core.loc.GeolocationDatabaseUpdater;
-import com.comcast.cdn.traffic_control.traffic_router.core.loc.NetworkNode;
-import com.comcast.cdn.traffic_control.traffic_router.core.loc.NetworkUpdater;
 import com.comcast.cdn.traffic_control.traffic_router.core.monitor.TrafficMonitorWatcher;
 import com.comcast.cdn.traffic_control.traffic_router.core.router.TrafficRouterManager;
 import com.comcast.cdn.traffic_control.traffic_router.core.router.StatTracker;
@@ -58,6 +55,7 @@ public class ConfigHandler {
 	private String trafficRouterId;
 
 	private NetworkUpdater networkUpdater;
+	private FederationsWatcher federationsWatcher;
 
 	public String getConfigDir() {
 		return configDir;
@@ -107,6 +105,8 @@ public class ConfigHandler {
 				parseCacheConfig(jo.getJSONObject("contentServers"), cacheRegister);
 				parseMonitorConfig(jo.getJSONObject("monitors"));
 				NetworkNode.getInstance().clearCacheCache();
+				federationsWatcher.configure(config);
+
 				trafficRouterManager.setCacheRegister(cacheRegister);
 				setLastSnapshotTimestamp(sts);
 			} catch (ParseException e) {
@@ -394,4 +394,7 @@ public class ConfigHandler {
 		ConfigHandler.lastSnapshotTimestamp = lastSnapshotTimestamp;
 	}
 
+	public void setFederationsWatcher(final FederationsWatcher federationsWatcher) {
+		this.federationsWatcher = federationsWatcher;
+	}
 }

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
@@ -76,7 +76,7 @@ public abstract class AbstractServiceUpdater {
 
 	public void init() {
 		final long pi = getPollingInterval();
-		LOGGER.info("Starting schedule with interval: "+pi + " : "+TimeUnit.MILLISECONDS);
+		LOGGER.warn(getClass().getSimpleName() + " Starting schedule with interval: " + pi + " : " + TimeUnit.MILLISECONDS);
 		scheduledService = executorService.scheduleWithFixedDelay(updater, pi, pi, TimeUnit.MILLISECONDS);
 	}
 

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/Federation.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/Federation.java
@@ -1,0 +1,22 @@
+package com.comcast.cdn.traffic_control.traffic_router.core.loc;
+
+import java.util.List;
+
+public class Federation {
+
+    private final String deliveryService;
+    private final List<FederationMapping> federationMappings;
+
+    public Federation(final String deliveryService, final List<FederationMapping> federationMappings) {
+        this.deliveryService = deliveryService;
+        this.federationMappings = federationMappings;
+    }
+
+    public String getDeliveryService() {
+        return deliveryService;
+    }
+
+    public List<FederationMapping> getFederationMappings() {
+        return federationMappings;
+    }
+}

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMapping.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMapping.java
@@ -1,0 +1,69 @@
+package com.comcast.cdn.traffic_control.traffic_router.core.loc;
+
+import com.comcast.cdn.traffic_control.traffic_router.core.util.CidrAddress;
+
+import java.util.List;
+
+public class FederationMapping {
+    private final String cname;
+    private final int ttl;
+    private final List<CidrAddress> resolve4;
+    private final List<CidrAddress> resolve6;
+
+    public FederationMapping(final String cname, final int ttl, final List<CidrAddress> resolve4, final List<CidrAddress> resolve6) {
+        this.cname = cname;
+        this.ttl = ttl;
+        this.resolve4 = resolve4;
+        this.resolve6 = resolve6;
+    }
+
+    public String getCname() {
+        return cname;
+    }
+
+    public int getTtl() {
+        return ttl;
+    }
+
+    public List<CidrAddress> getResolve4() {
+        return resolve4;
+    }
+
+    public List<CidrAddress> getResolve6() {
+        return resolve6;
+    }
+
+    @Override
+    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity", "PMD.IfStmtsMustUseBraces"})
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final FederationMapping that = (FederationMapping) o;
+
+        if (ttl != that.ttl) return false;
+        if (cname != null ? !cname.equals(that.cname) : that.cname != null) return false;
+        if (resolve4 != null ? !resolve4.equals(that.resolve4) : that.resolve4 != null) return false;
+        return !(resolve6 != null ? !resolve6.equals(that.resolve6) : that.resolve6 != null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = cname != null ? cname.hashCode() : 0;
+        result = 31 * result + ttl;
+        result = 31 * result + (resolve4 != null ? resolve4.hashCode() : 0);
+        result = 31 * result + (resolve6 != null ? resolve6.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "FederationMapping{" +
+                "cname='" + cname + '\'' +
+                ", ttl=" + ttl +
+                ", resolve4=" + resolve4 +
+                ", resolve6=" + resolve6 +
+                '}';
+    }
+}

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMappingBuilder.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMappingBuilder.java
@@ -1,0 +1,66 @@
+package com.comcast.cdn.traffic_control.traffic_router.core.loc;
+
+import com.comcast.cdn.traffic_control.traffic_router.core.util.CidrAddress;
+import org.apache.wicket.ajax.json.JSONArray;
+import org.apache.wicket.ajax.json.JSONException;
+import org.apache.wicket.ajax.json.JSONObject;
+import org.apache.wicket.ajax.json.JSONTokener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FederationMappingBuilder {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FederationMappingBuilder.class);
+
+    public FederationMapping fromJSON(final String json) throws JSONException, UnknownHostException {
+        final JSONObject jsonObject = new JSONObject(new JSONTokener(json));
+
+        final String cname = jsonObject.getString("cname");
+        final int ttl = jsonObject.getInt("ttl");
+
+        List<CidrAddress> network = null;
+        if (jsonObject.has("resolve4")) {
+            final JSONArray networkArray = jsonObject.getJSONArray("resolve4");
+
+            try {
+                network = buildAddresses(networkArray);
+            }
+            catch (JSONException e) {
+                LOGGER.warn("Failed getting ipv4 address array");
+            }
+        }
+
+
+        List<CidrAddress> network6 = null;
+        if (jsonObject.has("resolve6")) {
+            final JSONArray network6Array = jsonObject.getJSONArray("resolve6");
+            try {
+                network6 = buildAddresses(network6Array);
+            }
+            catch (JSONException e) {
+                LOGGER.warn("Failed getting ipv6 address array");
+            }
+        }
+
+        return new FederationMapping(cname, ttl, network, network6);
+    }
+
+    private List<CidrAddress> buildAddresses(final JSONArray networkArray) throws JSONException {
+        final List<CidrAddress> network = new ArrayList<CidrAddress>();
+
+        for (int i = 0; i < networkArray.length(); i++) {
+            final String addressString = networkArray.getString(i);
+            try {
+                final CidrAddress cidrAddress = new CidrAddress(addressString);
+                network.add(cidrAddress);
+            } catch (NetworkNodeException e) {
+                LOGGER.warn(e.getMessage());
+            }
+        }
+
+        return network;
+    }
+}

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationsBuilder.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationsBuilder.java
@@ -1,0 +1,40 @@
+package com.comcast.cdn.traffic_control.traffic_router.core.loc;
+
+import org.apache.wicket.ajax.json.JSONArray;
+import org.apache.wicket.ajax.json.JSONException;
+import org.apache.wicket.ajax.json.JSONObject;
+import org.apache.wicket.ajax.json.JSONTokener;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FederationsBuilder {
+
+    public List<Federation> fromJSON(final String jsonString) throws JSONException, UnknownHostException {
+        final List<Federation> federations = new ArrayList<Federation>();
+
+        final JSONObject jsonObject = new JSONObject(new JSONTokener(jsonString));
+        final JSONArray federationsArray = jsonObject.getJSONArray("response");
+
+        for (int i = 0; i < federationsArray.length(); i++) {
+            final JSONObject jsonObject1 = federationsArray.getJSONObject(i);
+            final String deliveryService = jsonObject1.getString("deliveryService");
+
+            final List<FederationMapping> mappings = new ArrayList<FederationMapping>();
+
+            final JSONArray mappingsArray = jsonObject1.getJSONArray("mappings");
+            final FederationMappingBuilder federationMappingBuilder = new FederationMappingBuilder();
+
+            for (int j = 0; j < mappingsArray.length(); j++) {
+                mappings.add(federationMappingBuilder.fromJSON(mappingsArray.getJSONObject(j).toString()));
+            }
+
+            final Federation federation = new Federation(deliveryService, mappings);
+            federations.add(federation);
+        }
+
+        return federations;
+    }
+
+}

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationsWatcher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationsWatcher.java
@@ -1,0 +1,132 @@
+package com.comcast.cdn.traffic_control.traffic_router.core.loc;
+
+import com.comcast.cdn.traffic_control.traffic_router.core.util.ProtectedFetcher;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.net.URL;
+import java.util.List;
+
+public class FederationsWatcher extends AbstractServiceUpdater {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FederationsWatcher.class);
+
+    private URL authorizationURL;
+    private String postData;
+    private URL federationsURL;
+    private long pollingInterval;
+    private ProtectedFetcher fetcher;
+
+    private List<Federation> federations;
+
+    public void configure(final URL authorizationURL, final String postData, final URL federationsURL, final long pollingInterval) {
+
+        if (authorizationURL.equals(this.authorizationURL) && postData.equals(this.postData) &&
+            federationsURL.equals(this.federationsURL) && pollingInterval == this.pollingInterval) {
+            return;
+        }
+
+        this.federationsURL = federationsURL;
+        this.pollingInterval = pollingInterval;
+
+        // avoid recreating the fetcher if possible
+        if (!authorizationURL.equals(this.authorizationURL) || !postData.equals(this.postData)) {
+            this.authorizationURL = authorizationURL;
+            this.postData = postData;
+            fetcher = new ProtectedFetcher(authorizationURL.toString(), postData, 0);
+        }
+    }
+
+    public void configure(final JSONObject config) {
+        URL authUrl;
+        String jsonData;
+        URL fedsUrl;
+        long interval = -1L;
+
+        try {
+            authUrl = new URL(config.getString("keystore.auth.url"));
+            final String username = config.getString("dns.sec.keyserver.username");
+            final String password = config.getString("dns.sec.keyserver.password");
+            jsonData = "{u:\"" + username + "\",p:\"" + password + "\"}";
+        } catch (Exception e) {
+            LOGGER.warn("Failed Getting Configuration for ProtectedFetcher for FederationsWatcher: " + e.getMessage());
+            // All or nothing, don't allow the watcher to be halfway misconfigured
+            authUrl = this.authorizationURL;
+            jsonData = this.postData;
+        }
+
+        try {
+            fedsUrl = new URL(config.getString("federationmapping.polling.federationsURL"));
+        } catch (Exception e) {
+            LOGGER.warn("Failed Getting Configuration for FederationsWatcher URL: " + e.getMessage());
+            fedsUrl = this.federationsURL;
+        }
+
+        try {
+            interval = config.getLong("federationmapping.polling.interval");
+        } catch (JSONException e) {
+            LOGGER.warn("Failed getting configuration for FederationsWatcher Polling Interval " + e.getMessage());
+            interval = this.pollingInterval;
+        }
+
+        if (authUrl != null && jsonData != null && fedsUrl != null && interval != -1L) {
+            configure(authUrl, jsonData, fedsUrl, interval);
+        }
+    }
+
+    public List<Federation> getFederations() {
+        return federations;
+    }
+
+    @Override
+    public void verifyDatabase(final File dbFile) throws IOException {
+
+    }
+
+    @Override
+    public boolean loadDatabase() throws IOException, org.apache.wicket.ajax.json.JSONException {
+        final File existingDB = new File(databaseLocation);
+
+        if (!existingDB.exists() || !existingDB.canRead()) {
+            return false;
+        }
+
+        final char[] jsonData = new char[(int) existingDB.length()];
+        new FileReader(existingDB).read(jsonData);
+        final String json = new String(jsonData);
+
+        federations = new FederationsBuilder().fromJSON(json);
+
+        setLoaded(true);
+        return true;
+    }
+
+    @Override
+    protected File downloadDatabase(final String url, final File existingDb) {
+        final String jsonData = null;
+
+        try {
+            fetcher.fetchIfModifiedSince(url, existingDb.lastModified());
+        }
+        catch (IOException e) {
+            LOGGER.warn("Failed to fetch federations mapping from '" + url + "': ", e.getMessage());
+        }
+
+        if (jsonData == null) {
+            return existingDb;
+        }
+
+        File databaseFile = null;
+        try {
+            databaseFile = File.createTempFile(tmpPrefix, tmpSuffix);
+            new FileWriter(databaseFile).write(jsonData);
+        }
+        catch (IOException e) {
+            LOGGER.warn("Failed to create federations mapping file from data received from '" + url + "'");
+        }
+
+        return databaseFile;
+    }
+}

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/CidrAddress.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/CidrAddress.java
@@ -1,0 +1,112 @@
+package com.comcast.cdn.traffic_control.traffic_router.core.util;
+
+import com.comcast.cdn.traffic_control.traffic_router.core.loc.NetworkNodeException;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+
+public class CidrAddress implements Comparable<CidrAddress> {
+    private final byte[] hostBytes;
+    private final byte[] maskBytes;
+    private final int netmaskLength;
+    private final String ipString;
+
+    @SuppressWarnings("PMD.CyclomaticComplexity")
+    public CidrAddress(final String cidrString) throws NetworkNodeException {
+        this.ipString = cidrString;
+        final String[] hostNetworkArray = cidrString.split("/");
+		final InetAddress address;
+
+		try {
+			address = InetAddress.getByName(hostNetworkArray[0]);
+		} catch (UnknownHostException ex) {
+			throw new NetworkNodeException(ex);
+		}
+
+		final byte[] addressBytes = address.getAddress();
+
+		if (hostNetworkArray.length == 1) {
+			netmaskLength = addressBytes.length * 8;
+		} else {
+			netmaskLength = Integer.parseInt(hostNetworkArray[1]);
+		}
+
+		if (address instanceof Inet4Address && (netmaskLength > 32 || netmaskLength < 0)) {
+			throw new NetworkNodeException("Rejecting IPv4 subnet with invalid netmask: " + cidrString);
+		} else if (address instanceof Inet6Address && (netmaskLength > 128 || netmaskLength < 0)) {
+			throw new NetworkNodeException("Rejecting IPv6 subnet with invalid netmask: " + cidrString);
+		}
+
+		hostBytes = addressBytes;
+		maskBytes = new byte[addressBytes.length];
+
+		for (int i = 0; i < netmaskLength; i++) {
+			maskBytes[i/8] |= 1<<(7-(i%8));
+		}
+    }
+
+    public byte[] getHostBytes() {
+        return hostBytes;
+    }
+
+    public byte[] getMaskBytes() {
+        return maskBytes;
+    }
+
+    public int getNetmaskLength() {
+        return netmaskLength;
+    }
+
+    @Override
+	public int compareTo(final CidrAddress other) {
+		// returns zero if the other address is in the same network as this one.
+		byte[] mask = this.maskBytes;
+		int len = netmaskLength;
+
+		if (netmaskLength > other.netmaskLength) {
+			mask = other.maskBytes;
+			len = other.netmaskLength;
+		}
+
+		final int numNetmaskBytes = (int) Math.ceil((double) len / 8);
+
+		for(int i = 0; i < numNetmaskBytes; i++) {
+			final int diff = (hostBytes[i] & mask[i]) - (other.hostBytes[i] & mask[i]);
+			if(diff != 0) { return diff; }
+		}
+
+		return 0;
+    }
+
+    @Override
+    @SuppressWarnings({"PMD.NPathComplexity", "PMD.IfStmtsMustUseBraces"})
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final CidrAddress that = (CidrAddress) o;
+
+        if (netmaskLength != that.netmaskLength) return false;
+        if (!Arrays.equals(hostBytes, that.hostBytes)) return false;
+        if (!Arrays.equals(maskBytes, that.maskBytes)) return false;
+        return !(ipString != null ? !ipString.equals(that.ipString) : that.ipString != null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = hostBytes != null ? Arrays.hashCode(hostBytes) : 0;
+        result = 31 * result + (maskBytes != null ? Arrays.hashCode(maskBytes) : 0);
+        result = 31 * result + netmaskLength;
+        result = 31 * result + (ipString != null ? ipString.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "CidrAddress{" + ipString + "}";
+    }
+}

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/Fetcher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/Fetcher.java
@@ -18,7 +18,6 @@ package com.comcast.cdn.traffic_control.traffic_router.core.util;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/Fetcher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/Fetcher.java
@@ -45,7 +45,7 @@ public class Fetcher {
 	protected static final String GET_STR = "GET";
 	protected static final String POST_STR = "POST";
 	protected static final String UTF8_STR = "UTF-8";
-	protected static final int DEFAULT_TIMEOUT = 10;
+	protected static final int DEFAULT_TIMEOUT = 10000;
 	protected int timeout = DEFAULT_TIMEOUT; // override if you want something different
 	protected final Map<String, String> requestProps = new HashMap<String, String>();
 

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/ProtectedFetcher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/ProtectedFetcher.java
@@ -24,28 +24,24 @@ import org.apache.log4j.Logger;
 
 public class ProtectedFetcher extends Fetcher {
 	private static final Logger LOGGER = Logger.getLogger(ProtectedFetcher.class);
-	private String endpoint;
+	private String authorizationEndpoint;
 	private String data;
 	private HttpCookie cookie;
 
-	public ProtectedFetcher(final String endpoint, final String data, final int timeout) {
+	public ProtectedFetcher(final String authorizationEndpoint, final String data, final int timeout) {
 		this.timeout = (timeout > 0) ? timeout : DEFAULT_TIMEOUT;
-		this.setEndpoint(endpoint);
+		this.setAuthorizationEndpoint(authorizationEndpoint);
 		this.setData(data);
 	}
 
-	public ProtectedFetcher(final String endpoint, final String data) {
-		this(endpoint, data, DEFAULT_TIMEOUT);
-	}
-
 	@Override
-	protected HttpURLConnection getConnection(final String url, final String data, final String method) throws IOException {
+	protected HttpURLConnection getConnection(final String url, final String data, final String method, final long lastFetchedTime) throws IOException {
 		if (!isCookieValid()) {
-			LOGGER.debug("Cookie is no longer valid; re-authenticating to " + getEndpoint() + " cookie = " + cookie);
-			extractCookie(super.getConnection(getEndpoint(), getData(), POST_STR));
+			LOGGER.debug("Cookie is no longer valid; re-authenticating to " + getAuthorizationEndpoint() + " cookie = " + cookie);
+			extractCookie(super.getConnection(getAuthorizationEndpoint(), getData(), POST_STR, 0L));
 		}
 
-		return extractCookie(super.getConnection(url, data, method));
+		return extractCookie(super.getConnection(url, data, method, lastFetchedTime));
 	}
 
 	private HttpURLConnection extractCookie(final HttpURLConnection http) throws IOException {
@@ -80,12 +76,12 @@ public class ProtectedFetcher extends Fetcher {
 		}
 	}
 
-	private String getEndpoint() {
-		return endpoint;
+	private String getAuthorizationEndpoint() {
+		return authorizationEndpoint;
 	}
 
-	private void setEndpoint(final String endpoint) {
-		this.endpoint = endpoint;
+	private void setAuthorizationEndpoint(final String authorizationEndpoint) {
+		this.authorizationEndpoint = authorizationEndpoint;
 	}
 
 	private String getData() {
@@ -94,5 +90,31 @@ public class ProtectedFetcher extends Fetcher {
 
 	private void setData(final String data) {
 		this.data = data;
+	}
+
+	@Override
+	@SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity", "PMD.IfStmtsMustUseBraces"})
+	public boolean equals(final Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
+
+		final ProtectedFetcher that = (ProtectedFetcher) o;
+
+		if (authorizationEndpoint != null ? !authorizationEndpoint.equals(that.authorizationEndpoint) : that.authorizationEndpoint != null)
+			return false;
+		if (data != null ? !data.equals(that.data) : that.data != null) return false;
+		return !(cookie != null ? !cookie.equals(that.cookie) : that.cookie != null);
+
+	}
+
+	@Override
+	@SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (authorizationEndpoint != null ? authorizationEndpoint.hashCode() : 0);
+		result = 31 * result + (data != null ? data.hashCode() : 0);
+		result = 31 * result + (cookie != null ? cookie.hashCode() : 0);
+		return result;
 	}
 }

--- a/traffic_router/core/src/main/resources/applicationContext.xml
+++ b/traffic_router/core/src/main/resources/applicationContext.xml
@@ -82,12 +82,17 @@
 		<property name="nameServer" ref="NameServer" />
 	</bean>
 
+	<bean id="federationsWatcher" class="com.comcast.cdn.traffic_control.traffic_router.core.loc.FederationsWatcher">
+		<property name="executorService" ref="ScheduledExecutorService" />
+	</bean>
+
 	<bean id="ConfigHandler" class="com.comcast.cdn.traffic_control.traffic_router.core.config.ConfigHandler">
 		<property name="trafficRouterManager" ref="trafficRouterManager" />
 		<property name="geolocationDatabaseUpdater" ref="geolocationDatabaseUpdater" />
 		<property name="networkUpdater" ref="networkUpdater" />
 		<property name="statTracker" ref="statTracker" />
 		<property name="configDir" value="/opt/traffic_router/conf" />
+		<property name="federationsWatcher" ref="federationsWatcher" />
 	</bean>
 
 	<!-- Geolocation Configuration -->

--- a/traffic_router/core/src/main/resources/applicationContext.xml
+++ b/traffic_router/core/src/main/resources/applicationContext.xml
@@ -82,8 +82,12 @@
 		<property name="nameServer" ref="NameServer" />
 	</bean>
 
-	<bean id="federationsWatcher" class="com.comcast.cdn.traffic_control.traffic_router.core.loc.FederationsWatcher">
+	<bean id="federationsWatcher" class="com.comcast.cdn.traffic_control.traffic_router.core.loc.FederationsWatcher" init-method="init">
 		<property name="executorService" ref="ScheduledExecutorService" />
+		<property name="databaseLocation" value="$[cache.federations.database]" />
+		<property name="pollingInterval" value="$[cache.federations.database.refresh.period]" />
+		<property name="username" value="$[dns.sec.keyserver.username]" />
+		<property name="password" value="$[dns.sec.keyserver.password]" />
 	</bean>
 
 	<bean id="ConfigHandler" class="com.comcast.cdn.traffic_control.traffic_router.core.config.ConfigHandler">

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMappingBuilderTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMappingBuilderTest.java
@@ -1,0 +1,35 @@
+package com.comcast.cdn.traffic_control.traffic_router.core.loc;
+
+import com.comcast.cdn.traffic_control.traffic_router.core.util.CidrAddress;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.IsNull.nullValue;
+
+public class FederationMappingBuilderTest {
+    @Test
+    public void itConsumesValidJSON() throws Exception {
+        FederationMappingBuilder federationMappingBuilder = new FederationMappingBuilder();
+
+        String json = "{ " +
+            "'cname' : 'cname1', " +
+            "'ttl' : '86400', " +
+            "'resolve4' : [ '192.168.56.78/24', '192.168.45.67/24' ], " +
+            "'resolve6' : [ 'fdfe:dcba:9876:5::/64', 'fd12:3456:789a:1::/64' ] " +
+        "}";
+
+        FederationMapping federationMapping = federationMappingBuilder.fromJSON(json);
+
+        assertThat(federationMapping, not(nullValue()));
+        assertThat(federationMapping.getCname(), equalTo("cname1"));
+        assertThat(federationMapping.getTtl(), equalTo(86400));
+
+        assertThat(federationMapping.getResolve4(),
+                containsInAnyOrder(new CidrAddress("192.168.45.67/24"), new CidrAddress("192.168.56.78/24")));
+        assertThat(federationMapping.getResolve6(),
+                containsInAnyOrder(new CidrAddress("fd12:3456:789a:1::/64"), new CidrAddress("fdfe:dcba:9876:5::/64")));
+    }
+}

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationsBuilderTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationsBuilderTest.java
@@ -1,0 +1,41 @@
+package com.comcast.cdn.traffic_control.traffic_router.core.loc;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.IsNull.nullValue;
+
+public class FederationsBuilderTest {
+    @Test
+    public void itConsumesValidJSON() throws Exception {
+        FederationsBuilder federationsBuilder = new FederationsBuilder();
+
+        String json = "{ response: [ " +
+            "{ " +
+                "'deliveryService' : 'ccp-omg-01', " +
+                "'mappings' : [ " +
+                    "{ 'cname' : 'cname1', " +
+                        "'ttl' : '86400', " +
+                        "'resolve4' : [ '192.168.56.78/24', '192.168.45.67/24' ], " +
+                        "'resolve6' : [ 'fdfe:dcba:9876:5::/64', 'fd12:3456:789a:1::/64' ] " +
+                    "}, " +
+                    "{ 'cname' : 'cname2', 'ttl' : '86400' } " +
+                "] " +
+            "}, " +
+            "{ " +
+                "'deliveryService' : 'ccp-omg-02', " +
+                "'mappings' : [ { 'cname' : 'cname4' , 'ttl' : '86400' } ]" +
+            "} " +
+        "] }";
+
+        List<Federation> federations = federationsBuilder.fromJSON(json);
+
+        assertThat(federations.size(), equalTo(2));
+        assertThat(federations.get(0).getDeliveryService(), equalTo("ccp-omg-01"));
+        assertThat(federations.get(0).getFederationMappings(), not(nullValue()));
+    }
+}

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/util/FetcherTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/util/FetcherTest.java
@@ -1,0 +1,47 @@
+package com.comcast.cdn.traffic_control.traffic_router.core.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({URL.class, InputStreamReader.class})
+@SuppressStaticInitializationFor("com.comcast.cdn.traffic_control.traffic_router.core.util.Fetcher")
+public class FetcherTest {
+
+    @Test
+    public void itChecksIfDataHasChangedSinceLastFetch() throws Exception {
+        InputStream inputStream = mock(InputStream.class);
+
+        InputStreamReader inputStreamReader = mock(InputStreamReader.class);
+        whenNew(InputStreamReader.class).withArguments(inputStream).thenReturn(inputStreamReader);
+
+        BufferedReader bufferedReader = mock(BufferedReader.class);
+        when(bufferedReader.readLine()).thenReturn(null);
+
+        whenNew(BufferedReader.class).withArguments(inputStreamReader).thenReturn(bufferedReader);
+
+        HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
+        when(httpURLConnection.getInputStream()).thenReturn(inputStream);
+
+        URL url = mock(URL.class);
+        when(url.openConnection()).thenReturn(httpURLConnection);
+        whenNew(URL.class).withArguments("http://www.example.com").thenReturn(url);
+
+        Fetcher fetcher = new Fetcher();
+        fetcher.fetchIfModifiedSince("http://www.example.com", 123456L);
+        verify(httpURLConnection).setIfModifiedSince(123456L);
+    }
+}

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/util/FetcherTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/util/FetcherTest.java
@@ -17,8 +17,7 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({URL.class, InputStreamReader.class})
-@SuppressStaticInitializationFor("com.comcast.cdn.traffic_control.traffic_router.core.util.Fetcher")
+@PrepareForTest({Fetcher.class, URL.class, InputStreamReader.class})
 public class FetcherTest {
 
     @Test

--- a/traffic_router/core/src/test/resources/cache.properties
+++ b/traffic_router/core/src/test/resources/cache.properties
@@ -36,3 +36,5 @@ cache.health.json.refresh.period=1000
 cache.config.json=src/test/db/cr-config.json
 cache.config.json.refresh.period=1000
 
+cache.federations.database=src/test/db/federations.json
+cache.federations.database.refresh.period=5000


### PR DESCRIPTION
Traffic Router now polls Traffic Ops for federated coverage zone data
