### PR TITLE
add missing ANY_MAP entry to Type fixture

### DIFF
--- a/traffic_ops/app/lib/Fixtures/Type.pm
+++ b/traffic_ops/app/lib/Fixtures/Type.pm
@@ -254,6 +254,15 @@ my %definition_for = (
 			use_in_table => 'server',
 		}
 	},
+	ANY_MAP => {
+		new   => 'Type',
+		using => {
+			id           => 33,
+			name         => 'ANY_MAP',
+			description  => 'any_map type',
+			use_in_table => 'deliveryservice',
+		}
+	},
 
 );
 


### PR DESCRIPTION
this entry was missing in the Type fixture -- caused several unit tests to fail.