### PR TITLE
Fix traffic_stats init script startup

### DIFF
--- a/traffic_stats/traffic_stats.init
+++ b/traffic_stats/traffic_stats.init
@@ -37,7 +37,7 @@ start() {
 
         # Start daemons.
         echo -n $"Starting $name: "
-        daemon nohup $prog $options
+        daemon nohup $prog $options < /dev/null > /dev/null &
         RETVAL=$?
         echo
         [ $RETVAL -eq 0 ] && touch $lockfile


### PR DESCRIPTION
Apparently we still need the &. Also redirect everything to /dev/null since we don't print anything important not to a log.