### PR TITLE
MySQL does not use a standard time format

### DIFF
--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -434,7 +434,7 @@ func getToData(config StartupConfig, init bool, configChan chan RunningConfig) {
 	if err != nil {
 		errHndlr(err, ERROR)
 	} else {
-		lastSummaryTime, err := time.Parse(time.RFC3339, lastSummaryTimeStr)
+		lastSummaryTime, err := time.Parse("2006-01-02 15:04:05", lastSummaryTimeStr)
 		if err != nil {
 			errHndlr(err, ERROR)
 		} else {


### PR DESCRIPTION
Revert "Missed one time format change"

This reverts commit 9fba1ae1eb4a5c34e2715a32555d436f6b3dbd14.