### PR TITLE
Traffic Stats documentation updated related to scripted dashboards

### DIFF
--- a/docs/source/admin/traffic_stats.rst
+++ b/docs/source/admin/traffic_stats.rst
@@ -1,24 +1,24 @@
-.. 
+..
 .. Copyright 2015 Comcast Cable Communications Management, LLC
-.. 
+..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.
 .. You may obtain a copy of the License at
-.. 
+..
 ..     http://www.apache.org/licenses/LICENSE-2.0
-.. 
+..
 .. Unless required by applicable law or agreed to in writing, software
 .. distributed under the License is distributed on an "AS IS" BASIS,
 .. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 .. See the License for the specific language governing permissions and
 .. limitations under the License.
-.. 
+..
 
 ****************************
 Traffic Stats Administration
 ****************************
 
-Traffic Stats actually consists of three sperate components:  Traffic Stats, InfluxDB, and Grafana.  See below for information on installing and configuring each component as well as configuring the integration between the three and Traffic Ops.
+Traffic Stats actually consists of three seperate components:  Traffic Stats, InfluxDB, and Grafana.  See below for information on installing and configuring each component as well as configuring the integration between the three and Traffic Ops.
 
 Installation
 ========================
@@ -35,9 +35,7 @@ Installation
 
 **Installing Grafana:**
 
-	Grafana is used to display Traffic Stats/InfluxDB data in Traffic Ops.  Grafana is typically run on the same server as Traffic Stats but this is not a requirement.  Grafana can be installed on any server that can access InfluxDB and be accessed by Traffic Ops.  Documentation on installing Grafana can be found `here <http://docs.grafana.org/installation/>`_. 
-
-	**Traffic Stats currently only supports the 2.0.2 version of Grafana!!!**
+	Grafana is used to display Traffic Stats/InfluxDB data in Traffic Ops.  Grafana is typically run on the same server as Traffic Stats but this is not a requirement.  Grafana can be installed on any server that can access InfluxDB and be accessed by Traffic Ops.  Documentation on installing Grafana can be found `here <http://docs.grafana.org/installation/>`_.
 
 Configuration
 =========================
@@ -45,7 +43,7 @@ Configuration
 **Configuring Traffic Stats:**
 
 	Traffic Stats' configuration file can be found in /opt/traffic_stats/conf/traffic_stats.cfg.
-	The following values need to be configured: 
+	The following values need to be configured:
 
 	     - *toUser:* The user used to connect to Traffic Ops
 	     - *toPasswd:*  The password to use when connecting to Traffic Ops
@@ -62,11 +60,11 @@ Configuration
 
 **Configuring InfluxDB:**
 
-	It is HIGHLY recommended that InfluxDB be configured for clutstering.  Documentation on clustering configuration can be found on the clustering page of the `InfluxDB Website <https://influxdb.com/docs/v0.9/concepts/clustering.html>`_.
-	
+	It is HIGHLY recommended that InfluxDB be configured for clustering.  Documentation on clustering configuration can be found on the clustering page of the `InfluxDB Website <https://influxdb.com/docs/v0.9/concepts/clustering.html>`_.
+
 	Once InfluxDB is installed and clustering is configured, Databases and Retention Policies need to be created.  Traffic Stats writes to three different databases: cache_stats, deliveryservice_stats, and daily_stats.  More information about the databases and what data is stored in each can be found on the `overview <../overview/traffic_stats.html>`_ page.
 
-	By default the cache_stats and deliveryservice_stats databases are set to store raw data for 26 hours with a retention policy called "daily"; the daily_stats datatbase is set to store data infintely with a retention policy called "daily_stats".The following commands can be completed via the influxdb `client <https://influxdb.com/download/index.html>`_ or via the admin user interface (http://influxdb_url:8083).  
+	By default the cache_stats and deliveryservice_stats databases are set to store raw data for 26 hours with a retention policy called "daily"; the daily_stats database is set to store data infinitely with a retention policy called "daily_stats".The following commands can be completed via the InfluxDB `client <https://influxdb.com/download/index.html>`_ or via the admin user interface (http://influxdb_url:8083).
 
 	*Creating Databases:*
 		``create database cache_stats``
@@ -82,12 +80,10 @@ Configuration
 
 		``create retention policy daily_stats on daily_stats duration INF replication 3 DEFAULT``
 
-	
+
 **Configuring Grafana:**
 
-	**NOTE: Traffic Control currently only supports Grafana version 2.0.2**
-
-	In Traffic Ops the Health -> Graph View tab can be configured to display grafana graphs using influxDb data.  In order for this to work correctly, you will need two things 1) a parameter added to traffic ops with the graph URL (we will discuss later) and 2) the graphs created in grafana.  See below for how to create some simple graphs in grafana.  These instructions assume that InfluxDB has been installed and conifugred and that data has been written to it.  If this is not true, you will not see any graphs.
+		In Traffic Ops the Health -> Graph View tab can be configured to display grafana graphs using influxDb data.  In order for this to work correctly, you will need two things 1) a parameter added to traffic ops with the graph URL (we will discuss later) and 2) the graphs created in grafana.  See below for how to create some simple graphs in grafana.  These instructions assume that InfluxDB has been installed and conifugred and that data has been written to it.  If this is not true, you will not see any graphs.
 
 		- Login to grafana as an admin user http://grafana_url:3000/login
 		- Choose Data Sources and then Add New
@@ -100,48 +96,51 @@ Configuration
 		- Click on the 'Home' dropdown at the top of the screen and choose New at the bottom
 		- Click on the green menu bar (with 3 lines) at the top and choose Add Panel -> Graph
 		- Where it says 'No Title (click here)' click and choose edit
-		- Choose your data source at the bottom 
+		- Choose your data source at the bottom
 		- You can have grafana help you create a query, or you can create your own.  Here is a sample query:
 
 			``SELECT sum(value)*1000/6 FROM "bandwidth" WHERE $timeFilter and time < now() - 60s GROUP BY time(60s), cdn``
 		- Once you have the graph the way you want it, click the 'Save Dashboard' button at the top
-		- You should now have a new saved graph 
+		- You should now have a new saved graph
 
-	In order for Traffic Ops users to see Grafana graphs, Grafana will need to allow anonymous access.  Information on how to configure anonymous access can be found on the configuration page of the `Grafana Website  <http://docs.grafana.org/installation/configuration/#authanonymous>`_. 
+	In order for Traffic Ops users to see Grafana graphs, Grafana will need to allow anonymous access.  Information on how to configure anonymous access can be found on the configuration page of the `Grafana Website  <http://docs.grafana.org/installation/configuration/#authanonymous>`_.
 
-	Traffic Ops uses custom dashboards to display information about individual delivery services or cachegroups.  In order for the custom graphs to display correctly, you will need to install the `traffic_ops_scripted.js <https://github.com/Comcast/traffic_control/blob/master/traffic_stats/grafana/traffic_ops_scripted.js>`_ file to the ``/usr/share/grafana/public/dashboards/`` directory on the grafana server.  More information on custom scripted graphs can be found in the `scripted dashboards <http://docs.grafana.org/reference/scripting/>`_ section of the Grafana documentation.
+	Traffic Ops uses custom dashboards to display information about individual delivery services or cache-groups.  In order for the custom graphs to display correctly, you will need to install the `traffic_ops_*.js <https://github.com/Comcast/traffic_control/blob/master/traffic_stats/grafana/>`_ file to the ``/usr/share/grafana/public/dashboards/`` directory on the grafana server.  More information on custom scripted graphs can be found in the `scripted dashboards <http://docs.grafana.org/reference/scripting/>`_ section of the Grafana documentation.
 
 **Configuring httpd proxying for SSL**
-	
-	Currently InfluxDB does not support HTTPS for queries (should be implemented very soon).  Since Traffic Ops is HTTPS, we need to be able to make HTTPS requests to grafana and influxdb.  We can accomplish the need to use HTTPS by installing httpd with the mod_ssl plugin and then configuring proxying of grafana and influxdb HTTPS calls to HTTP. Below are the steps for setting up the HTTPS to HTTP proxy.  This should be performed on the same server that is running grafana.
+
+	Currently InfluxDB does not support HTTPS for queries (should be implemented very soon).  Since Traffic Ops is HTTPS, we need to be able to make HTTPS requests to grafana and influxdb.  We can accomplish the need to use HTTPS by installing httpd with the mod_ssl plugin and then configuring proxying of grafana and influxdb HTTPS calls to HTTP. Below are the steps for setting up the HTTPS to HTTP proxy.  This should be performed on the same server that is running grafana. This is also useful if you are running InfluxDB with Private IP addresses.
 
 	1. Download and install httpd  `from here <http://httpd.apache.org/download.cgi>`_
 	2. Create SSL certs
-	3. Install and configure mod_ssl per `this link <http://dev.antoinesolutions.com/apache-server/mod_ssl>`_ 
+	3. Install and configure mod_ssl per `this link <http://dev.antoinesolutions.com/apache-server/mod_ssl>`_
 	4. Create a file called grafana_proxy.conf in the /etc/httpd/conf.d directory
 	5. Add the following information to grafana_proxy.conf:
-			
+
 	::
-		
-				ProxyPass /dashboard http://ipcdn-dev-grafana-01.cdnlab.comcast.net:3000/dashboard
-				ProxyPass /css http://ipcdn-dev-grafana-01.cdnlab.comcast.net:3000/css
-				ProxyPass /app http://ipcdn-dev-grafana-01.cdnlab.comcast.net:3000/app
-				ProxyPass /api http://ipcdn-dev-grafana-01.cdnlab.comcast.net:3000/api
-				ProxyPass /img http://ipcdn-dev-grafana-01.cdnlab.comcast.net:3000/img
-				ProxyPass /fonts http://ipcdn-dev-grafana-01.cdnlab.comcast.net:3000/fonts
-				ProxyPass /public http://ipcdn-dev-grafana-01.cdnlab.comcast.net:3000/public
-				ProxyPass /login http://ipcdn-dev-grafana-01.cdnlab.comcast.net:3000/login
-				ProxyPass /logout http://ipcdn-dev-grafana-01.cdnlab.comcast.net:3000/logout
-				ProxyPassReverse / http://ipcdn-dev-grafana-01.cdnlab.comcast.net:3000/
-				   
+
+				ProxyPass /dashboard http://localhost:3000/dashboard
+				ProxyPass /css http://localhost:3000/css
+				ProxyPass /app http://localhost:3000/app
+				ProxyPass /api http://localhost:3000/api
+				ProxyPass /img http://localhost:3000/img
+				ProxyPass /fonts http://localhost:3000/fonts
+				ProxyPass /public http://localhost:3000/public
+				ProxyPass /login http://localhost:3000/login
+				ProxyPass /logout http://localhost:3000/logout
+				# The following ProxyPassReverse doesn't work for some.
+				ProxyPassReverse / http://localhost:3000/
+
 				<Proxy balancer://influxDb>
 				BalancerMember http://<influxDb1>:8086
 				BalancerMember http://<influxDb2>:8086
 				BalancerMember http://<influxDb3>:8086
 				</Proxy>
 				ProxyPass /query balancer://influxDb/query
-	
-		
+
+	      # This works better for some
+				ProxyPass / http://localhost:3000/
+
 	6. Restart httpd ``service httpd restart``
 	7. Test grafana works by connect to grafana via https ``https://grafanaUrl``
 
@@ -161,20 +160,13 @@ Configuration
 	+===========================+================================================================================================+
 	| all_graph_url             | https://<grafana_url>/dashboard/db/deliveryservice-stats                                       |
 	+---------------------------+------------------------------------------------------------------------------------------------+
-	| cachegroup_graph_url      | https://<grafanaHost>/dashboard/script/traffic_ops_scripted.js?type=cachegroup&which=          |
+	| cachegroup_graph_url      | https://<grafanaHost>/dashboard/script/traffic_ops_cachegroup.js?which=                        |
 	+---------------------------+------------------------------------------------------------------------------------------------+
-	| deliveryservice_graph_url | https://<grafanaHost>/dashboard/script/traffic_ops_scripted.js?type=deliveryservice&which=     |
+	| deliveryservice_graph_url | https://<grafanaHost>/dashboard/script/traffic_ops_devliveryservice.js?which=                  |
 	+---------------------------+------------------------------------------------------------------------------------------------+
-	| server_graph_url          | https://<grafanaHost>/dashboard/script/traffic_ops_scripted.js?type=server&which=              |
+	| server_graph_url          | https://<grafanaHost>/dashboard/script/traffic_ops_server.js?which=                            |
 	+---------------------------+------------------------------------------------------------------------------------------------+
 	| visual_status_panel_1     | https://<grafanaHost>/dashboard/solo/db/cdn-stats?panelId=2&fullscreen&from=now-24h&to=now-60s |
 	+---------------------------+------------------------------------------------------------------------------------------------+
 	| visual_status_panel_2     | https://<grafanaHost>/dashboard/solo/db/cdn-stats?panelId=1&fullscreen&from=now-24h&to=now-60s |
 	+---------------------------+------------------------------------------------------------------------------------------------+
-
-
-         
-       
-         		
-           
-        	


### PR DESCRIPTION
Please review. 
- I removed some mention of Grafana 2.0.2
- added the new scripts in the table at the bottom
- added notes for httpd configuration