### PR TITLE
Traffic Stats Spec file and documentation

### DIFF
--- a/docs/source/admin/traffic_stats.rst
+++ b/docs/source/admin/traffic_stats.rst
@@ -105,7 +105,9 @@ Configuration
 
 	In order for Traffic Ops users to see Grafana graphs, Grafana will need to allow anonymous access.  Information on how to configure anonymous access can be found on the configuration page of the `Grafana Website  <http://docs.grafana.org/installation/configuration/#authanonymous>`_.
 
-	Traffic Ops uses custom dashboards to display information about individual delivery services or cache-groups.  In order for the custom graphs to display correctly, you will need to install the `traffic_ops_*.js <https://github.com/Comcast/traffic_control/blob/master/traffic_stats/grafana/>`_ file to the ``/usr/share/grafana/public/dashboards/`` directory on the grafana server.  More information on custom scripted graphs can be found in the `scripted dashboards <http://docs.grafana.org/reference/scripting/>`_ section of the Grafana documentation.
+	Traffic Ops uses custom dashboards to display information about individual delivery services or cache groups.  In order for the custom graphs to display correctly, the `traffic_ops_*.js <https://github.com/Comcast/traffic_control/blob/master/traffic_stats/grafana/>`_ files need to be in the ``/usr/share/grafana/public/dashboards/`` directory on the grafana server.  If your Grafana server is the same as your Traffic Stats server the RPM install process will take care of putting the files in place.  If your grafana server is different from your Traffic Stats server, you will need to manually copy the files to the correct directory.  
+
+	More information on custom scripted graphs can be found in the `scripted dashboards <http://docs.grafana.org/reference/scripting/>`_ section of the Grafana documentation.
 
 **Configuring httpd proxying for SSL**
 
@@ -128,6 +130,7 @@ Configuration
 				ProxyPass /public http://localhost:3000/public
 				ProxyPass /login http://localhost:3000/login
 				ProxyPass /logout http://localhost:3000/logout
+				
 				# The following ProxyPassReverse doesn't work for some.
 				ProxyPassReverse / http://localhost:3000/
 
@@ -137,8 +140,8 @@ Configuration
 				BalancerMember http://<influxDb3>:8086
 				</Proxy>
 				ProxyPass /query balancer://influxDb/query
-
-	      # This works better for some
+				
+				# This works better for some
 				ProxyPass / http://localhost:3000/
 
 	6. Restart httpd ``service httpd restart``

--- a/traffic_stats/traffic_stats.spec
+++ b/traffic_stats/traffic_stats.spec
@@ -95,7 +95,7 @@ fi
 %attr(600, traffic_stats, traffic_stats) /opt/traffic_stats/conf/*
 %attr(755, traffic_stats, traffic_stats) /opt/traffic_stats/bin/*
 %attr(755, traffic_stats, traffic_stats) /etc/init.d/traffic_stats
-%attr(755, traffic_stats, traffic_stats) /usr/share/grafana/public/dashboards
+%attr(644, traffic_stats, traffic_stats) /usr/share/grafana/public/dashboards/*
 
 %preun
 # args for hooks: http://www.ibm.com/developerworks/library/l-rpm2/

--- a/traffic_stats/traffic_stats.spec
+++ b/traffic_stats/traffic_stats.spec
@@ -90,10 +90,12 @@ fi
 %dir /opt/traffic_stats/var/log
 %dir /opt/traffic_stats/var/run
 %dir /opt/traffic_stats/var/log/traffic_stats
+%dir /usr/share/grafana/public/dashboards
 
 %attr(600, traffic_stats, traffic_stats) /opt/traffic_stats/conf/*
 %attr(755, traffic_stats, traffic_stats) /opt/traffic_stats/bin/*
 %attr(755, traffic_stats, traffic_stats) /etc/init.d/traffic_stats
+%attr(755, traffic_stats, traffic_stats) /usr/share/grafana/public/dashboards
 
 %preun
 # args for hooks: http://www.ibm.com/developerworks/library/l-rpm2/
@@ -115,3 +117,4 @@ if [ -e /etc/init.d/ts_daily_summary ]; then
 	/etc/init.d/ts_daily_summary stop
 	/sbin/chkconfig --del ts_daily_summary
 fi
+	

--- a/traffic_stats/traffic_stats.spec
+++ b/traffic_stats/traffic_stats.spec
@@ -11,8 +11,9 @@ URL:		https://github.com/comcast/traffic_control/
 Source:		~/rpmbuild/SOURCES/traffic_stats-@VERSION@.tar.gz
 
 %description
-Installs traffic_stats which is comprised of two seperate rpms:
-	- traffic_stats: gets data from traffic monitor and stores in InfluxDB and also calculates daily summary of the data from InfluxDB and stores in traffic_ops
+Installs traffic_stats which performs the follwing functions:
+	1. Gets data from Traffic Monitor via a RESTful API and stores the data in InfluxDb
+	2. Calculates Daily Summary stats from the raw data and stores it in Traffic Ops as well as InfluxDb
 
 %prep
 
@@ -29,12 +30,14 @@ mkdir -p ${RPM_BUILD_ROOT}/opt/traffic_stats/var/run
 mkdir -p ${RPM_BUILD_ROOT}/opt/traffic_stats/var/log/traffic_stats
 mkdir -p ${RPM_BUILD_ROOT}/etc/init.d
 mkdir -p ${RPM_BUILD_ROOT}/etc/logrotate.d
+mkdir -p ${RPM_BUILD_ROOT}/usr/share/grafana/public/dashboards/
 
 cp $GOPATH/src/github.com/comcast/traffic_control/traffic_stats/traffic_stats ${RPM_BUILD_ROOT}/opt/traffic_stats/bin/traffic_stats
 cp $GOPATH/src/github.com/comcast/traffic_control/traffic_stats/traffic_stats.cfg ${RPM_BUILD_ROOT}/opt/traffic_stats/conf/traffic_stats.cfg
 cp $GOPATH/src/github.com/comcast/traffic_control/traffic_stats/traffic_stats_seelog.xml ${RPM_BUILD_ROOT}/opt/traffic_stats/conf/traffic_stats_seelog.xml
 cp $GOPATH/src/github.com/comcast/traffic_control/traffic_stats/traffic_stats.init ${RPM_BUILD_ROOT}/etc/init.d/traffic_stats
 cp $GOPATH/src/github.com/comcast/traffic_control/traffic_stats/traffic_stats.logrotate ${RPM_BUILD_ROOT}/etc/logrotate.d/traffic_stats
+cp $GOPATH/src/github.com/comcast/traffic_control/traffic_stats/grafana/*.js ${RPM_BUILD_ROOT}/usr/share/grafana/public/dashboards/
 
 %pre
 /usr/bin/getent group traffic_stats >/dev/null


### PR DESCRIPTION
Updated the Spec file to copy the Grafana custom dashboard files into place as part of the RPM install process.
Updated the Traffic Stats admin docs to reflect the change.