### PR TITLE
cdn.conf validation checks for secrets instead of shared_secret

### DIFF
--- a/traffic_ops/app/lib/TrafficOps.pm
+++ b/traffic_ops/app/lib/TrafficOps.pm
@@ -463,8 +463,8 @@ sub validate_cdn_conf {
 
 	my $cdn_info = $self->load_conf( $ENV{MOJO_CONFIG} );
 	my $user;
-	if ( !exists( $cdn_info->{shared_secret} ) ) {
-		print("WARNING: no shared_secret found in in $ENV{MOJO_CONFIG}.\n");
+	if ( !exists( $cdn_info->{secrets} ) ) {
+		print("WARNING: no secrets found in $ENV{MOJO_CONFIG}.\n");
 	}
 
 	if ( exists( $cdn_info->{hypnotoad}{user} ) ) {


### PR DESCRIPTION
Fixes #625 
cdn.conf validation checks for secrets instead of shared_secret
(cherry picked from commit 00c4e618c09ac5d52db32ba924c625a501fc756f)