### PR TITLE
Remove scriptlet that causes rpm to remove /opt/traffic_monitor after…

### DIFF
--- a/traffic_monitor/pom.xml
+++ b/traffic_monitor/pom.xml
@@ -435,9 +435,6 @@
 							<preremoveScriptlet>
 								<scriptFile>src/main/scripts/preremove.sh</scriptFile>
 							</preremoveScriptlet>
-							<postremoveScriptlet>
-								<script>echo "Removing ${deploy.dir}";rm -rf ${deploy.dir}</script>
-							</postremoveScriptlet>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
… an upgrade.

(cherry picked from commit f1d5269ba0fcfcd11b7cd73016db059c24277108)