### PR TITLE
Redirect stdout and stderr to a log file

### DIFF
--- a/traffic_stats/traffic_stats.init
+++ b/traffic_stats/traffic_stats.init
@@ -54,7 +54,7 @@ start() {
 
         # Start daemons.
         echo -n $"Starting $name: "
-        daemon nohup $prog $options < /dev/null > /dev/null &
+        daemon nohup $prog $options < /dev/null > /opt/traffic_stats/var/log/traffic_stats/traffic_stats.out 2>&1 &
         RETVAL=$?
         echo
         [ $RETVAL -eq 0 ] && touch $lockfile


### PR DESCRIPTION
Thinking that when we crash we'll get more useful information this way.