### PR TITLE
Remove reference to code.google.com repo

### DIFF
--- a/traffic_ops/client/traffic_ops.go
+++ b/traffic_ops/client/traffic_ops.go
@@ -18,7 +18,7 @@ package client
 
 import (
 	"bytes"
-	"code.google.com/p/go.net/publicsuffix"
+	"golang.org/x/net/publicsuffix"
 	"crypto/tls"
 	"encoding/json"
 	"errors"


### PR DESCRIPTION
> $ go get github.com/Comcast/traffic_control/traffic_ops/client
> warning: code.google.com is shutting down; import path code.google.com/p/go.net/publicsuffix will stop working

https://godoc.org/golang.org/x/net/publicsuffix