### PR TITLE
Improve cache selection performance

### DIFF
--- a/traffic_router/core/pom.xml
+++ b/traffic_router/core/pom.xml
@@ -204,7 +204,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<argLine>-DminimumTPS=80 -DnnTPS=12000</argLine>
+					<argLine>-DminimumTPS=140 -DnnTPS=12000</argLine>
 					<systemPropertyVariables>
 						<log4j.configuration>file:src/test/resources/log4j.maven.properties</log4j.configuration>
 					</systemPropertyVariables>

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/cache/Cache.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/cache/Cache.java
@@ -21,7 +21,9 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -44,8 +46,8 @@ public class Cache implements Comparable<Cache> {
 	private String fqdn;
 	private List<InetRecord> ipAddresses;
 	private int port;
-	private Collection<DeliveryServiceReference> deliveryServices = new ArrayList<DeliveryServiceReference>();
-	final private List<Double> hashValues;
+	private final Map<String, DeliveryServiceReference> deliveryServices = new HashMap<String, DeliveryServiceReference>();
+	private final List<Double> hashValues;
 
 	final private int replicas;
 
@@ -89,7 +91,7 @@ public class Cache implements Comparable<Cache> {
 	}
 
 	public Collection<DeliveryServiceReference> getDeliveryServices() {
-		return deliveryServices;
+		return deliveryServices.values();
 	}
 
 	public String getFqdn() {
@@ -188,7 +190,13 @@ public class Cache implements Comparable<Cache> {
 	}
 
 	public void setDeliveryServices(final Collection<DeliveryServiceReference> deliveryServices) {
-		this.deliveryServices = deliveryServices;
+		for (DeliveryServiceReference deliveryServiceReference : deliveryServices) {
+			this.deliveryServices.put(deliveryServiceReference.getDeliveryServiceId(), deliveryServiceReference);
+		}
+	}
+
+	public boolean hasDeliveryService(final String deliveryServiceId) {
+		return deliveryServices.containsKey(deliveryServiceId);
 	}
 
 	public void setFqdn(final String fqdn) {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
@@ -45,7 +45,6 @@ import com.comcast.cdn.traffic_control.traffic_router.core.cache.Cache;
 import com.comcast.cdn.traffic_control.traffic_router.core.cache.CacheLocation;
 import com.comcast.cdn.traffic_control.traffic_router.core.cache.CacheRegister;
 import com.comcast.cdn.traffic_control.traffic_router.core.cache.InetRecord;
-import com.comcast.cdn.traffic_control.traffic_router.core.cache.Cache.DeliveryServiceReference;
 import com.comcast.cdn.traffic_control.traffic_router.core.dns.ZoneManager;
 import com.comcast.cdn.traffic_control.traffic_router.core.dns.DNSAccessRecord;
 import com.comcast.cdn.traffic_control.traffic_router.core.ds.DeliveryService;
@@ -115,23 +114,12 @@ public class TrafficRouter {
 			if(cache.hasAuthority()) {
 				isAvailable = cache.isAvailable();
 			}
-			if (!isAvailable || !cacheSupportsDeliveryService(cache, ds)) {
+			if (!isAvailable || !cache.hasDeliveryService(ds.getId())) {
 				caches.remove(i);
 				i--;
 			}
 		}
 		return caches;
-	}
-
-	private boolean cacheSupportsDeliveryService(final Cache cache, final DeliveryService ds) {
-		boolean result = false;
-		for (final DeliveryServiceReference dsRef : cache.getDeliveryServices()) {
-			if (dsRef.getDeliveryServiceId().equals(ds.getId())) {
-				result = true;
-				break;
-			}
-		}
-		return result;
 	}
 
 	public CacheRegister getCacheRegister() {


### PR DESCRIPTION
The improved TPS score will be even better with proper hostnames in the dns request from PR 730
https://github.com/Comcast/traffic_control/pull/730

The minimum TPS score should be adjusted as soon as both are merged.
