### PR TITLE
Remove Wire Parse Exception logging entries from Traffic Router

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/protocol/AbstractProtocol.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/protocol/AbstractProtocol.java
@@ -107,7 +107,7 @@ public abstract class AbstractProtocol implements Protocol {
      *            the DNS request in wire format
      * @return the DNS response in wire format
      */
-    protected byte[] query(final InetAddress client, final byte[] request) {
+    protected byte[] query(final InetAddress client, final byte[] request) throws WireParseException {
         Message query = null;
         Message response = null;
         final long queryTimeMillis = System.currentTimeMillis();
@@ -123,7 +123,7 @@ public abstract class AbstractProtocol implements Protocol {
             ACCESS.info(DNSAccessEventBuilder.create(dnsAccessRecord));
         } catch (final WireParseException e) {
             ACCESS.info(DNSAccessEventBuilder.create(dnsAccessRecord, e));
-            throw new IllegalArgumentException(e);
+            throw e;
         } catch (final Exception e) {
             ACCESS.info(DNSAccessEventBuilder.create(dnsAccessRecord, e));
             response = createServerFail(query);

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/protocol/TCP.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/protocol/TCP.java
@@ -25,6 +25,7 @@ import java.net.Socket;
 
 import org.apache.log4j.Logger;
 import org.xbill.DNS.Message;
+import org.xbill.DNS.WireParseException;
 
 public class TCP extends AbstractProtocol {
     private static final Logger LOGGER = Logger.getLogger(TCP.class);
@@ -84,6 +85,7 @@ public class TCP extends AbstractProtocol {
         }
 
         @Override
+        @SuppressWarnings("PMD.EmptyCatchBlock")
         public void run() {
             try {
                 final InetAddress client = socket.getInetAddress();
@@ -98,6 +100,8 @@ public class TCP extends AbstractProtocol {
                 final byte[] response = query(client, request);
                 os.writeShort(response.length);
                 os.write(response);
+            } catch (final WireParseException e) {
+                // This is already recorded in the access log
             } catch (final Exception e) {
                 LOGGER.error(e.getMessage(), e);
             } finally {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/protocol/UDP.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/protocol/UDP.java
@@ -24,6 +24,7 @@ import java.net.InetAddress;
 import org.apache.log4j.Logger;
 import org.xbill.DNS.Message;
 import org.xbill.DNS.OPTRecord;
+import org.xbill.DNS.WireParseException;
 
 public class UDP extends AbstractProtocol {
     private static final Logger LOGGER = Logger.getLogger(UDP.class);
@@ -96,6 +97,7 @@ public class UDP extends AbstractProtocol {
         }
 
         @Override
+        @SuppressWarnings("PMD.EmptyCatchBlock")
         public void run() {
             try {
                 final InetAddress client = packet.getAddress();
@@ -106,6 +108,8 @@ public class UDP extends AbstractProtocol {
                 final DatagramPacket outPacket = new DatagramPacket(response, response.length,
                         packet.getSocketAddress());
                 getDatagramSocket().send(outPacket);
+            } catch (final WireParseException e) {
+                // This is already recorded in the access log
             } catch (final Exception e) {
                 LOGGER.error(e.getMessage(), e);
             }

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/protocol/AbstractProtocolTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/protocol/AbstractProtocolTest.java
@@ -114,12 +114,8 @@ public class AbstractProtocolTest {
     public void itLogsBadClientRequests() throws Exception {
         FakeAbstractProtocol abstractProtocol = new FakeAbstractProtocol(client, new byte[] {1,2,3,4,5,6,7});
         abstractProtocol.setNameServer(nameServer);
-        try {
-            abstractProtocol.run();
-            fail("Should have caught illegal arguement exception");
-        } catch (IllegalArgumentException e) {
-            verify(accessLogger).info("144140678.000 qtype=DNS chi=192.168.23.45 ttms=345 xn=- fqdn=- type=- class=- ttl=- rcode=- rtype=- rloc=\"-\" rdtl=- rerr=\"Bad Request:WireParseException:end of input\" ans=\"-\"");
-        }
+        abstractProtocol.run();
+        verify(accessLogger).info("144140678.000 qtype=DNS chi=192.168.23.45 ttms=345 xn=- fqdn=- type=- class=- ttl=- rcode=- rtype=- rloc=\"-\" rdtl=- rerr=\"Bad Request:WireParseException:end of input\" ans=\"-\"");
     }
 
     @Test
@@ -163,7 +159,11 @@ public class AbstractProtocolTest {
 
         @Override
         public void run() {
-            query(inetAddress, request);
+            try {
+                query(inetAddress, request);
+            } catch (WireParseException e) {
+                // Ignore it
+            }
         }
 
     }


### PR DESCRIPTION
 application log, It's already recorded in the access log