### PR TITLE
Add current bandwidth, connections, and percentage of capacity to graphs in TO.

### DIFF
--- a/traffic_ops/app/lib/Extensions/TrafficStats/API/CacheStats.pm
+++ b/traffic_ops/app/lib/Extensions/TrafficStats/API/CacheStats.pm
@@ -103,7 +103,6 @@ sub current_bandwidth {
 	if ($cdn) {
 		$query = "SELECT sum(value)/6 FROM \"bandwidth\" WHERE time < now() - 60s and time > now() - 120s and cdn = \'$cdn\'";
 	}
-	$self->app->log->debug("query = $query");
 	my $response_container = $self->influxdb_query("cache_stats", $query);
 	my $response           = $response_container->{'response'};
 	my $content            = $response->{_content};
@@ -120,11 +119,10 @@ sub current_bandwidth {
 sub current_connections {
 	my $self = shift;
 	my $cdn  = $self->param('cdnName');
-	my $query = "select sum(value) from \"ats.proxy.process.http.current_client_connections\" where time > now() - 120s and time < now() - 60s";
+	my $query = "select sum(value)/6 from \"ats.proxy.process.http.current_client_connections\" where time > now() - 120s and time < now() - 60s";
 	if ($cdn) {
-		$query = "select sum(value) from \"ats.proxy.process.http.current_client_connections\" where time > now() - 120s and time < now() - 60s and cdn = \'$cdn\'";
+		$query = "select sum(value)/6 from \"ats.proxy.process.http.current_client_connections\" where time > now() - 120s and time < now() - 60s and cdn = \'$cdn\'";
 	}
-	$self->app->log->debug("query = $query");
 	my $response_container = $self->influxdb_query("cache_stats", $query);
 	my $response           = $response_container->{'response'};
 	my $content            = $response->{_content};
@@ -135,6 +133,27 @@ sub current_connections {
 		$connections           = $summary_content->{results}[0]{series}[0]{values}[0][1];
 	}
 	return $self->success({"connections" => $connections});
+}
+
+sub current_capacity {
+	my $self = shift;
+	my $cdn  = $self->param('cdnName');
+	my $query = "select sum(value)/6 from \"maxKbps\" where time > now() - 120s and time < now() - 60s";
+	if ($cdn) {
+		$query = "select sum(value)/6 from \"maxKbps\" where time > now() - 120s and time < now() - 60s and cdn = \'$cdn\'";
+	}
+	my $response_container = $self->influxdb_query("cache_stats", $query);
+	my $response           = $response_container->{'response'};
+	my $content            = $response->{_content};
+	my $summary_content;
+	my $capacity = "err";
+	if ( $response->is_success() ) {
+		$summary_content   = decode_json($content);
+		$capacity           = $summary_content->{results}[0]{series}[0]{values}[0][1];
+		$capacity = $capacity/1000000; #convert to Gbps
+		$capacity = $capacity * 0.85;    # need a better way to figure out percentage of max besides hard-coding
+	}
+	return $self->success({"capacity" => $capacity});
 }
 
 1;

--- a/traffic_ops/app/lib/MojoPlugins/Stats.pm
+++ b/traffic_ops/app/lib/MojoPlugins/Stats.pm
@@ -290,7 +290,6 @@ sub register {
 			}
 			else {
 				my $mkbps_match = $cdn_name . ":" . $ds_name . ":" . $cg_name . ":" . $host_name . ":maxKbps";
-				$self->app->log->debug("mkbps_match = $mkbps_match");
 				$capacity = ( $redis->zrange( $mkbps_match, -1, -1 ) )[0];
 			}
 

--- a/traffic_ops/app/lib/MojoPlugins/Stats.pm
+++ b/traffic_ops/app/lib/MojoPlugins/Stats.pm
@@ -290,6 +290,7 @@ sub register {
 			}
 			else {
 				my $mkbps_match = $cdn_name . ":" . $ds_name . ":" . $cg_name . ":" . $host_name . ":maxKbps";
+				$self->app->log->debug("mkbps_match = $mkbps_match");
 				$capacity = ( $redis->zrange( $mkbps_match, -1, -1 ) )[0];
 			}
 

--- a/traffic_ops/app/lib/TrafficOpsRoutes.pm
+++ b/traffic_ops/app/lib/TrafficOpsRoutes.pm
@@ -771,6 +771,7 @@ sub traffic_stats_routes {
 	$r->get( "/api/$version/cache_stats" => [ format => [qw(json)] ] )->over( authenticated => 1 )->to( 'CacheStats#index', namespace => $namespace );
 	$r->get( "internal/api/$version/current_bandwidth" => [ format => [qw(json)] ] )->to( 'CacheStats#current_bandwidth', namespace => $namespace );
 	$r->get( "internal/api/$version/current_connections" => [ format => [qw(json)] ] )->to( 'CacheStats#current_connections', namespace => $namespace );
+	$r->get( "internal/api/$version/current_capacity" => [ format => [qw(json)] ] )->to( 'CacheStats#current_capacity', namespace => $namespace );
 }
 
 sub catch_all {

--- a/traffic_ops/app/lib/TrafficOpsRoutes.pm
+++ b/traffic_ops/app/lib/TrafficOpsRoutes.pm
@@ -769,6 +769,8 @@ sub traffic_stats_routes {
 	$r->get( "/api/$version/deliveryservice_stats" => [ format => [qw(json)] ] )->over( authenticated => 1 )
 		->to( 'DeliveryServiceStats#index', namespace => $namespace );
 	$r->get( "/api/$version/cache_stats" => [ format => [qw(json)] ] )->over( authenticated => 1 )->to( 'CacheStats#index', namespace => $namespace );
+	$r->get( "internal/api/$version/current_bandwidth" => [ format => [qw(json)] ] )->to( 'CacheStats#current_bandwidth', namespace => $namespace );
+	$r->get( "internal/api/$version/current_connections" => [ format => [qw(json)] ] )->to( 'CacheStats#current_connections', namespace => $namespace );
 }
 
 sub catch_all {

--- a/traffic_ops/app/lib/UI/VisualStatus.pm
+++ b/traffic_ops/app/lib/UI/VisualStatus.pm
@@ -53,31 +53,11 @@ sub graphs {
 		->search( { -and => [ 'parameter.name' => 'visual_status_panel_2', 'profile.name' => 'GLOBAL' ] }, { prefetch => [ 'parameter', 'profile' ] } )->single();
 	my $p2_url = defined($pparam) ? $pparam->parameter->value : undef;
 	
-	my $bw_total = 0;
-	my $bandwidth = "err";
-	my %cdn_bandwidth;
-	foreach my $cdn (@cdn_names) {
-		my $query = "SELECT sum(value)/6 FROM \"bandwidth\" WHERE time < now() - 60s and time > now() - 120s and cdn = \'$cdn\'";
-		my $response_container = $self->influxdb_query("cache_stats", $query);
-		my $response           = $response_container->{'response'};
-		my $content            = $response->{_content};
-		my $summary_content;
-		if ( $response->is_success() ) {
-			$summary_content   = decode_json($content);
-			$bandwidth           = $summary_content->{results}[0]{series}[0]{values}[0][1];
-			$bandwidth = $bandwidth/1000000;
-			$bw_total += $bandwidth;	
-			$cdn_bandwidth{$cdn} = sprintf("%.2f", $bandwidth);
-		}
-	}
-	$cdn_bandwidth{"all"} = sprintf("%.2f", $bw_total);
-	
 	$self->stash(
 		cdn_names   => \@cdn_names,	
 		ds_capacity => $ds_capacity,
 		panel_1_url => $p1_url,
-		panel_2_url => $p2_url,
-		cdn_bandwidth => \%cdn_bandwidth
+		panel_2_url => $p2_url
 	);
 
 	&navbarpage($self);

--- a/traffic_ops/app/lib/UI/VisualStatus.pm
+++ b/traffic_ops/app/lib/UI/VisualStatus.pm
@@ -22,7 +22,6 @@ use UI::Utils;
 use Mojo::Base 'Mojolicious::Controller';
 use Data::Dumper;
 use JSON;
-use Extensions::TrafficStats::Builder::CacheStatsBuilder;
 
 sub graphs {
 	my $self = shift;

--- a/traffic_ops/app/lib/UI/VisualStatus.pm
+++ b/traffic_ops/app/lib/UI/VisualStatus.pm
@@ -28,7 +28,6 @@ sub graphs {
 	my $match_string = $self->param('matchstring');
 	
 	my @cdn_names;
-	my $ds_capacity = 0;
 	my ( $ds_name, $loc_name, $host_name ) = split( /:/, $match_string );
 	if ( $host_name ne 'all' ) {    # we want a specific host, it has to be in only one CDN
 		my $server = $self->db->resultset('Server')->search( { host_name => $host_name }, { prefetch => 'cdn' } )->single();
@@ -37,7 +36,6 @@ sub graphs {
 	elsif ( $ds_name ne 'all' ) {    # we want a specific DS, it has to be in only one CDN
 		my $ds = $self->db->resultset('Deliveryservice')->search( { xml_id => $ds_name }, { prefetch => 'cdn' } )->single();
 		push( @cdn_names, $ds->cdn->name );
-		$ds_capacity = $ds->global_max_mbps / 1000;    # everything is in kbps in the stats
 	}
 	else {                                             # we want all the CDNs with edges
 		@cdn_names = $self->db->resultset('Server')->search({ 'type.name' => 'EDGE' }, { prefetch => [ 'cdn', 'type' ], group_by => 'cdn.name' } )->get_column('cdn.name')->all();
@@ -51,10 +49,8 @@ sub graphs {
 		$self->db->resultset('ProfileParameter')
 		->search( { -and => [ 'parameter.name' => 'visual_status_panel_2', 'profile.name' => 'GLOBAL' ] }, { prefetch => [ 'parameter', 'profile' ] } )->single();
 	my $p2_url = defined($pparam) ? $pparam->parameter->value : undef;
-	
 	$self->stash(
-		cdn_names   => \@cdn_names,	
-		ds_capacity => $ds_capacity,
+		cdn_names   => \@cdn_names,
 		panel_1_url => $p1_url,
 		panel_2_url => $p2_url
 	);
@@ -84,7 +80,7 @@ sub graphs_redis {
 		@cdn_names = $self->db->resultset('Server')->search({ 'type.name' => 'EDGE' }, { prefetch => [ 'cdn', 'type' ], group_by => 'cdn.name' } )->get_column('cdn.name')->all();
 	}
 	$self->stash(
-		cdn_names   => \@cdn_names,	
+		cdn_names   => \@cdn_names,
 		graph_page  => 1,
 		matchstring => $match_string,
 		ds_capacity => $ds_capacity,

--- a/traffic_ops/app/templates/visual_status/graphs.html.ep
+++ b/traffic_ops/app/templates/visual_status/graphs.html.ep
@@ -26,13 +26,116 @@ $(function () {
 })
 
 </script>
+<script>
+
+function refreshStats()
+{
+     % foreach my $cdn_name (sort @{ $cdn_names } ) {
+        getCurrentBandwidth("<%= $cdn_name %>");
+        getCurrentConnections("<%= $cdn_name %>");
+    % } 
+    getCurrentBandwidth();
+    getCurrentConnections();
+
+}
+
+function getCurrentBandwidth(cdn_name) {
+    var url = "/internal/api/1.2/current_bandwidth.json";
+    if (cdn_name != null) {
+        $.getJSON( url + "?cdnName=" + cdn_name, function() {})
+         .done(function(data) {
+            $('#' + cdn_name + '_gbps_val').text(data.response.bandwidth.toFixed(2));
+        });
+    }
+    else {
+        $.getJSON( url, function() {})
+         .done(function(data) {
+            $('#total_gbps_val').text(data.response.bandwidth.toFixed(2));
+        });   
+    }
+}
+
+function getCurrentConnections(cdn_name) {
+    var url = "/internal/api/1.2/current_connections.json";
+    if (cdn_name != null) {
+        $.getJSON( url + "?cdnName=" + cdn_name, function() {})
+         .done(function(data) {
+            $('#' + cdn_name + '_conn_val').text(data.response.connections.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")); //toLocaleString doesnt work across browsers, this regex does.
+        });
+    }
+    else {
+        $.getJSON( url, function() {})
+         .done(function(data) {
+            $('#total_conn_val').text(data.response.connections.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")); //toLocaleString doesnt work across browsers, this regex does.
+        });   
+    }
+}
+//refresh every 30 seconds
+setInterval('refreshStats()', 30000);
+
+</script>
+<style>
+.statistics_section { float:left; width:315px; height:240; color:white; font-size:150%; width:305px; background-color:#898989; margin-right:5px; padding:5px; border:1px solid #121212; }
+.ui-progressbar {
+  position: relative;
+}
+.progress-label {
+  /*position: absolute;*/
+  left: 50%;
+  top: 4px;
+  text-shadow: 1px 1px 0 #fff;
+}
+.percent_label {
+  clear:both;
+  float:left;
+  margin-left:10px;
+}
+.progress_bar {
+  float:right;
+  height: 10px;
+  width: 115px;
+  float:right;
+}
+#stat_value, #total_gbps_val, #total_conn_val { font-size: 225%; text-align: right;}
+
+</style>
 
 <body id="edge_health">
   %= include 'navbar'
-  <div id=accordion>
+  <div id="accordion">
 	% if ( defined($panel_1_url) && defined($panel_2_url) ) {
-        <iframe src="<%= $panel_1_url %>" width=100% height="450" frameborder="0"></iframe>
-        <iframe src="<%= $panel_2_url %>" width=100% height="450" frameborder="0"></iframe>
+        <div class="statistics_section">
+            <script>refreshStats()</script>
+            <div>total Gbps:</div>
+            <div id="total_gbps_val"></div>
+            % foreach my $cdn ( @{ $cdn_names }) {
+                <div><%= $cdn %> Gbps: </div>
+                <!-- <div><script>percentLabel('<%= $cdn %>_percent_indicator',0);</script></div> -->
+                <!-- <div><script>progressBar('<%= $cdn %>_percent_indicator',0);</script></div> -->
+                <div id="stat_value">
+                    <div id="<%= $cdn %>_gbps_val"></div>
+                </div>
+            % } 
+        </div>
+        <div style="width: 65%; float: left;">
+            <iframe src="<%= $panel_1_url %>" width=100% height="400" frameborder="0"></iframe>
+        </div>
+        <div class="statistics_section" style = "clear:left;">
+            <div>total Connections:</div>
+            <div id="total_conn_val"></div>
+            % foreach my $cdn ( @{ $cdn_names }) {
+                <div><%= $cdn %> Connections: </div>
+                <!-- <div><script>percentLabel('<%= $cdn %>_percent_indicator',0);</script></div> -->
+                <!-- <div><script>progressBar('<%= $cdn %>_percent_indicator',0);</script></div> -->
+                <div id="stat_value">
+                    <div id="<%= $cdn %>_conn_val"></div>
+                </div>
+            % } 
+        </div>
+        <div style="width: 65%; float: left;">
+            <iframe src="<%= $panel_2_url %>" width=100% height="400" frameborder="0"></iframe>
+        </div>
+    </div>
     % } else {
 		<h3><a href="#">Configuration Incomplete!</a></h3>
 		<div>

--- a/traffic_ops/app/templates/visual_status/graphs.html.ep
+++ b/traffic_ops/app/templates/visual_status/graphs.html.ep
@@ -40,15 +40,31 @@ function refreshStats()
 }
 
 function getCurrentBandwidth(cdn_name) {
-    var url = "/internal/api/1.2/current_bandwidth.json";
+    var bwUrl = "/internal/api/1.2/current_bandwidth.json";
     if (cdn_name != null) {
-        $.getJSON( url + "?cdnName=" + cdn_name, function() {})
+        var bandwidth = 0;
+        // get bandwidth
+        $.getJSON( bwUrl + "?cdnName=" + cdn_name, function() {})
          .done(function(data) {
-            $('#' + cdn_name + '_gbps_val').text(data.response.bandwidth.toFixed(2));
+            bandwidth = data.response.bandwidth.toFixed(2);
+            console.log("cdn_name = " + cdn_name + " bandwidth = " + bandwidth);
+            $('#' + cdn_name + '_gbps_val').text(bandwidth);
+            // get capacity
+            var capacityUrl = "/internal/api/1.2/current_capacity.json";
+            $.getJSON( capacityUrl + "?cdnName=" + cdn_name, function() {})
+            .done(function(data) {
+            var capacity = Math.round(data.response.capacity);
+            var percentage = Math.round(bandwidth/capacity * 100);
+            console.log("cdn = " + cdn_name + " bandwidth = " + bandwidth + " capacity = " + capacity + " percentage = " + percentage);
+            setProgress(cdn_name + "_percent_indicator", percentage);
+            setText(cdn_name + "_percent_indicator", "avail: " + capacity + ", used: " + percentage);
+            $('#' + cdn_name + '_gbps_val').text(bandwidth);
+            });
         });
+        
     }
     else {
-        $.getJSON( url, function() {})
+        $.getJSON( bwUrl, function() {})
          .done(function(data) {
             $('#total_gbps_val').text(data.response.bandwidth.toFixed(2));
         });   
@@ -60,22 +76,27 @@ function getCurrentConnections(cdn_name) {
     if (cdn_name != null) {
         $.getJSON( url + "?cdnName=" + cdn_name, function() {})
          .done(function(data) {
-            $('#' + cdn_name + '_conn_val').text(data.response.connections.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")); //toLocaleString doesnt work across browsers, this regex does.
+            var connections = Math.round(data.response.connections).toString();
+            $('#' + cdn_name + '_conn_val').text(connections.replace(/\B(?=(\d{3})+(?!\d))/g, ",")); //toLocaleString doesnt work across browsers, this regex does.
         });
     }
     else {
         $.getJSON( url, function() {})
          .done(function(data) {
-            $('#total_conn_val').text(data.response.connections.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")); //toLocaleString doesnt work across browsers, this regex does.
+            var connections = Math.round(data.response.connections).toString();
+            $('#total_conn_val').text(connections.replace(/\B(?=(\d{3})+(?!\d))/g, ",")); //toLocaleString doesnt work across browsers, this regex does.
         });   
     }
 }
+
 //refresh every 30 seconds
 setInterval('refreshStats()', 30000);
 
 </script>
+<script type="text/javascript" src="/js/percentagebar.js"></script>
+
 <style>
-.statistics_section { float:left; width:315px; height:240; color:white; font-size:150%; width:305px; background-color:#898989; margin-right:5px; padding:5px; border:1px solid #121212; }
+.statistics_section { float:left; width:35%; color:white; font-size:150%; width:305px; background-color:#898989; margin-right:5px; padding:5px; border:1px solid #121212; }
 .ui-progressbar {
   position: relative;
 }
@@ -93,9 +114,10 @@ setInterval('refreshStats()', 30000);
 .progress_bar {
   float:right;
   height: 10px;
-  width: 115px;
+  width: 100px;
   float:right;
 }
+#graph_panel {width: 65%; float: left;}
 #stat_value, #total_gbps_val, #total_conn_val { font-size: 225%; text-align: right;}
 
 </style>
@@ -110,14 +132,14 @@ setInterval('refreshStats()', 30000);
             <div id="total_gbps_val"></div>
             % foreach my $cdn ( @{ $cdn_names }) {
                 <div><%= $cdn %> Gbps: </div>
-                <!-- <div><script>percentLabel('<%= $cdn %>_percent_indicator',0);</script></div> -->
-                <!-- <div><script>progressBar('<%= $cdn %>_percent_indicator',0);</script></div> -->
+                <div><script>percentLabel('<%= $cdn %>_percent_indicator',0);</script></div>
+                <div><script>progressBar('<%= $cdn %>_percent_indicator',0);</script></div>
                 <div id="stat_value">
                     <div id="<%= $cdn %>_gbps_val"></div>
                 </div>
             % } 
         </div>
-        <div style="width: 65%; float: left;">
+        <div id = "graph_panel">
             <iframe src="<%= $panel_1_url %>" width=100% height="400" frameborder="0"></iframe>
         </div>
         <div class="statistics_section" style = "clear:left;">
@@ -132,7 +154,7 @@ setInterval('refreshStats()', 30000);
                 </div>
             % } 
         </div>
-        <div style="width: 65%; float: left;">
+        <div id="graph_panel">
             <iframe src="<%= $panel_2_url %>" width=100% height="400" frameborder="0"></iframe>
         </div>
     </div>


### PR DESCRIPTION
Current Bandwidth, Current Connections, and percentage of capacity used per CDN is now visible on the visual status page (Health -> graph view).  This replicates the functionality that was available in the redis graphs page using influxdb.