### PR TITLE
Fixes two bugs, both due to the same null variable, when a federation…

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationRegistry.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationRegistry.java
@@ -37,9 +37,12 @@ public class FederationRegistry {
             ComparableTreeSet<CidrAddress> cidrAddresses;
             if (cidrAddress.isIpV6()) {
                 cidrAddresses = federationMapping.getResolve6();
-            }
-            else {
+            } else {
                 cidrAddresses = federationMapping.getResolve4();
+            }
+
+            if (cidrAddresses == null) {
+                return null;
             }
 
             for (CidrAddress resolverAddress : cidrAddresses) {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/FederationExporter.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/FederationExporter.java
@@ -52,12 +52,12 @@ public class FederationExporter {
 	private Map<String, Object> addAddressProperties(final String propertyName, final ComparableTreeSet<CidrAddress> cidrAddresses, final Map<String, Object> properties) {
 		final List<String> addressStrings = new ArrayList<String>();
 
-		if (cidrAddresses.isEmpty()) {
+		if (cidrAddresses == null || cidrAddresses.isEmpty()) {
 			return properties;
 		}
 
-		for (CidrAddress cidrAddress4 : cidrAddresses) {
-			addressStrings.add(cidrAddress4.getAddressString());
+		for (CidrAddress cidrAddress : cidrAddresses) {
+			addressStrings.add(cidrAddress.getAddressString());
 		}
 
 		properties.put(propertyName, addressStrings);


### PR DESCRIPTION
… exists for a delivery service but no resolver mappings have been configured.