### PR TITLE
TO: fixes warnings

### DIFF
--- a/traffic_ops/app/lib/API/Cdn.pm
+++ b/traffic_ops/app/lib/API/Cdn.pm
@@ -27,17 +27,17 @@ use MIME::Base64;
 use UI::DeliveryService;
 use MojoPlugins::Response;
 use Common::ReturnCodes qw(SUCCESS ERROR);
+use strict;
 
 sub index {
 	my $self = shift;
 	my @data;
 	my $orderby = $self->param('orderby') || "name";
-	my $rs_data = $self->db->resultset("Cdn")
-		->search( undef, { order_by => $orderby } );
+	my $rs_data = $self->db->resultset("Cdn")->search( undef, { order_by => $orderby } );
 	while ( my $row = $rs_data->next ) {
 		push(
-			@data,
-			{   "id"   => $row->id,
+			@data, {
+				"id"   => $row->id,
 				"name" => $row->name,
 			}
 		);
@@ -53,8 +53,8 @@ sub name {
 	my @data = ();
 	while ( my $row = $rs_data->next ) {
 		push(
-			@data,
-			{   "name"        => $row->name,
+			@data, {
+				"name"        => $row->name,
 				"lastUpdated" => $row->last_updated,
 			}
 		);
@@ -80,12 +80,8 @@ sub get_traffic_monitor_config {
 	my $ccr_profile_id;
 	my $data_obj;
 
-	my @profile_ids
-		= $self->db->resultset('Server')
-		->search( { 'cdn.name' => $cdn_name }, { prefetch => ['cdn'] } )
-		->get_column('profile')->all();
-	my $rs_pp = $self->db->resultset('Profile')
-		->search( { id => { -in => \@profile_ids } } );
+	my @profile_ids = $self->db->resultset('Server')->search( { 'cdn.name' => $cdn_name }, { prefetch => ['cdn'] } )->get_column('profile')->all();
+	my $rs_pp = $self->db->resultset('Profile')->search( { id => { -in => \@profile_ids } } );
 	while ( my $row = $rs_pp->next ) {
 		if ( $row->name =~ m/^RASCAL/ ) {
 			$rascal_profile = $row->name;
@@ -105,19 +101,16 @@ sub get_traffic_monitor_config {
 		'parameter.config_file' => 'rascal-config.txt',
 		'profile.name'          => $rascal_profile
 	);
-	$rs_pp = $self->db->resultset('ProfileParameter')->search( \%condition,
-		{ prefetch => [ { 'parameter' => undef }, { 'profile' => undef } ] }
-	);
+	$rs_pp = $self->db->resultset('ProfileParameter')->search( \%condition, { prefetch => [ { 'parameter' => undef }, { 'profile' => undef } ] } );
 	while ( my $row = $rs_pp->next ) {
 		my $parameter;
 		if ( $row->parameter->name =~ m/location/ ) { next; }
 		if ( $row->parameter->value =~ m/^\d+$/ ) {
-			$data_obj->{'config'}->{ $row->parameter->name }
-				= int( $row->parameter->value );
+			$data_obj->{'config'}->{ $row->parameter->name } =
+				int( $row->parameter->value );
 		}
 		else {
-			$data_obj->{'config'}->{ $row->parameter->name }
-				= $row->parameter->value;
+			$data_obj->{'config'}->{ $row->parameter->name } = $row->parameter->value;
 		}
 	}
 
@@ -125,9 +118,7 @@ sub get_traffic_monitor_config {
 		'parameter.config_file' => 'rascal.properties',
 		'profile.name'          => { -in => \@cache_profiles }
 	);
-	$rs_pp = $self->db->resultset('ProfileParameter')->search( \%condition,
-		{ prefetch => [ { 'parameter' => undef }, { 'profile' => undef } ] }
-	);
+	$rs_pp = $self->db->resultset('ProfileParameter')->search( \%condition, { prefetch => [ { 'parameter' => undef }, { 'profile' => undef } ] } );
 
 	if ( !exists( $data_obj->{'profiles'} ) ) {
 		$data_obj->{'profiles'} = undef;
@@ -144,16 +135,13 @@ sub get_traffic_monitor_config {
 			$type = "MID";
 		}
 		$profile_tracker->{ $row->profile->name }->{'type'} = $type;
-		$profile_tracker->{ $row->profile->name }->{'name'}
-			= $row->profile->name;
+		$profile_tracker->{ $row->profile->name }->{'name'} = $row->profile->name;
 
 		if ( $row->parameter->value =~ m/^\d+$/ ) {
-			$profile_tracker->{ $row->profile->name }->{'parameters'}
-				->{ $row->parameter->name } = int( $row->parameter->value );
+			$profile_tracker->{ $row->profile->name }->{'parameters'}->{ $row->parameter->name } = int( $row->parameter->value );
 		}
 		else {
-			$profile_tracker->{ $row->profile->name }->{'parameters'}
-				->{ $row->parameter->name } = $row->parameter->value;
+			$profile_tracker->{ $row->profile->name }->{'parameters'}->{ $row->parameter->name } = $row->parameter->value;
 		}
 	}
 
@@ -169,37 +157,29 @@ sub get_traffic_monitor_config {
 		push( @{ $data_obj->{'profiles'} }, $profile );
 	}
 
-	my $rs_ds = $self->db->resultset('Deliveryservice')
-		->search( { 'me.profile' => $ccr_profile_id, 'active' => 1 }, {} );
+	my $rs_ds = $self->db->resultset('Deliveryservice')->search( { 'me.profile' => $ccr_profile_id, 'active' => 1 }, {} );
 	while ( my $row = $rs_ds->next ) {
 		my $delivery_service;
 
-# MAT: Do we move this to the DB? Rascal needs to know if it should monitor a DS or not, and the status=REPORTED is what we do for caches.
-		$delivery_service->{'xmlId'}  = $row->xml_id;
-		$delivery_service->{'status'} = "REPORTED";
-		$delivery_service->{'totalKbpsThreshold'}
-			= $row->global_max_mbps * 1000;
-		$delivery_service->{'totalTpsThreshold'}
-			= int( $row->global_max_tps || 0 );
+		# MAT: Do we move this to the DB? Rascal needs to know if it should monitor a DS or not, and the status=REPORTED is what we do for caches.
+		$delivery_service->{'xmlId'}              = $row->xml_id;
+		$delivery_service->{'status'}             = "REPORTED";
+		$delivery_service->{'totalKbpsThreshold'} = $row->global_max_mbps * 1000;
+		$delivery_service->{'totalTpsThreshold'}  = int( $row->global_max_tps || 0 );
 		push( @{ $data_obj->{'deliveryServices'} }, $delivery_service );
 	}
 	my $rs_caches = $self->db->resultset('Server')->search(
 		{ 'cdn.name' => $cdn_name },
-		{   prefetch => [ 'type', 'status', 'cachegroup', 'profile', 'cdn' ],
-			columns  => [
-				'host_name',  'domain_name',
-				'tcp_port',   'interface_name',
-				'ip_address', 'ip6_address',
-				'id',         'xmpp_id'
-			]
+		{
+			prefetch => [ 'type',      'status',      'cachegroup', 'profile',        'cdn' ],
+			columns  => [ 'host_name', 'domain_name', 'tcp_port',   'interface_name', 'ip_address', 'ip6_address', 'id', 'xmpp_id' ]
 		}
 	);
 	while ( my $row = $rs_caches->next ) {
 		if ( $row->type->name eq "RASCAL" ) {
 			my $traffic_monitor;
-			$traffic_monitor->{'hostName'} = $row->host_name;
-			$traffic_monitor->{'fqdn'}
-				= $row->host_name . "." . $row->domain_name;
+			$traffic_monitor->{'hostName'}   = $row->host_name;
+			$traffic_monitor->{'fqdn'}       = $row->host_name . "." . $row->domain_name;
 			$traffic_monitor->{'status'}     = $row->status->name;
 			$traffic_monitor->{'cachegroup'} = $row->cachegroup->name;
 			$traffic_monitor->{'port'}       = int( $row->tcp_port );
@@ -211,10 +191,9 @@ sub get_traffic_monitor_config {
 		}
 		elsif ( $row->type->name eq "EDGE" || $row->type->name eq "MID" ) {
 			my $traffic_server;
-			$traffic_server->{'cachegroup'} = $row->cachegroup->name;
-			$traffic_server->{'hostName'}   = $row->host_name;
-			$traffic_server->{'fqdn'}
-				= $row->host_name . "." . $row->domain_name;
+			$traffic_server->{'cachegroup'}    = $row->cachegroup->name;
+			$traffic_server->{'hostName'}      = $row->host_name;
+			$traffic_server->{'fqdn'}          = $row->host_name . "." . $row->domain_name;
 			$traffic_server->{'port'}          = int( $row->tcp_port );
 			$traffic_server->{'interfaceName'} = $row->interface_name;
 			$traffic_server->{'status'}        = $row->status->name;
@@ -230,11 +209,9 @@ sub get_traffic_monitor_config {
 
 	my $rs_loc = $self->db->resultset('Server')->search(
 		{ 'cdn.name' => $cdn_name },
-		{   join   => [ 'cdn', 'cachegroup' ],
-			select => [
-				'cachegroup.name', 'cachegroup.latitude',
-				'cachegroup.longitude'
-			],
+		{
+			join   => [ 'cdn',             'cachegroup' ],
+			select => [ 'cachegroup.name', 'cachegroup.latitude', 'cachegroup.longitude' ],
 			distinct => 1
 		}
 	);
@@ -280,16 +257,13 @@ sub routing {
 	};
 	for my $cdn_name ( keys( %{$ccr_map} ) ) {
 		for my $ccr ( keys( %{ $ccr_map->{$cdn_name} } ) ) {
-			my $ccr_host = $ccr_map->{$cdn_name}->{$ccr}->{host_name} . "."
-				. $ccr_map->{$cdn_name}->{$ccr}->{domain_name};
+			my $ccr_host = $ccr_map->{$cdn_name}->{$ccr}->{host_name} . "." . $ccr_map->{$cdn_name}->{$ccr}->{domain_name};
 
 			# TODO: what happens when the request to CCR times out? -jse
-			my $c = $self->get_traffic_router_connection(
-				{ hostname => $ccr_host } );
+			my $c = $self->get_traffic_router_connection( { hostname => $ccr_host } );
 			my $s = $c->get_crs_stats();
 			if ( !defined($s) ) {
-				return $self->internal_server_error(
-					{ "Internal Server" => "Error" } );
+				return $self->internal_server_error( { "Internal Server" => "Error" } );
 			}
 			else {
 
@@ -300,8 +274,7 @@ sub routing {
 							&& $args->{stat_key} ne $type );
 
 						if ( exists( $s->{stats}->{$type} ) ) {
-							for my $fqdn ( keys( %{ $s->{stats}->{$type} } ) )
-							{
+							for my $fqdn ( keys( %{ $s->{stats}->{$type} } ) ) {
 								my $count = 1;
 
 								if ( exists( $args->{patterns} )
@@ -309,8 +282,7 @@ sub routing {
 								{
 									$count = 0;
 
-									for my $pattern ( @{ $args->{patterns} } )
-									{
+									for my $pattern ( @{ $args->{patterns} } ) {
 										if ( $fqdn =~ /$pattern/ ) {
 											$count = 1;
 											last;
@@ -319,51 +291,23 @@ sub routing {
 								}
 
 								if ($count) {
-									for my $counter (
-										keys(
-											%{  $s->{stats}->{$type}->{$fqdn}
-											}
-										)
-										)
-									{
-										if (!exists(
-												$stats->{raw}->{$counter}
-											)
-											)
-										{
+									for my $counter ( keys( %{ $s->{stats}->{$type}->{$fqdn} } ) ) {
+										if ( !exists( $stats->{raw}->{$counter} ) ) {
 											$stats->{raw}->{$counter} = 0;
 										}
 
-										$stats->{raw}->{$counter}
-											+= $s->{stats}->{$type}->{$fqdn}
-											->{$counter};
-										$stats->{totalCount}
-											+= $s->{stats}->{$type}->{$fqdn}
-											->{$counter};
+										$stats->{raw}->{$counter} += $s->{stats}->{$type}->{$fqdn}->{$counter};
+										$stats->{totalCount} += $s->{stats}->{$type}->{$fqdn}->{$counter};
 									}
 								}
 								if ($count) {
-									for my $counter (
-										keys(
-											%{  $s->{stats}->{$type}->{$fqdn}
-											}
-										)
-										)
-									{
-										if (!exists(
-												$stats->{raw}->{$counter}
-											)
-											)
-										{
+									for my $counter ( keys( %{ $s->{stats}->{$type}->{$fqdn} } ) ) {
+										if ( !exists( $stats->{raw}->{$counter} ) ) {
 											$stats->{raw}->{$counter} = 0;
 										}
 
-										$stats->{raw}->{$counter}
-											+= $s->{stats}->{$type}->{$fqdn}
-											->{$counter};
-										$stats->{totalCount}
-											+= $s->{stats}->{$type}->{$fqdn}
-											->{$counter};
+										$stats->{raw}->{$counter} += $s->{stats}->{$type}->{$fqdn}->{$counter};
+										$stats->{totalCount} += $s->{stats}->{$type}->{$fqdn}->{$counter};
 									}
 								}
 							}
@@ -379,8 +323,8 @@ sub routing {
 		$p =~ s/Count//gi;
 
 		if ( $stats->{totalCount} > 0 ) {
-			$data->{$p}
-				= ( $stats->{raw}->{$counter} / $stats->{totalCount} ) * 100;
+			$data->{$p} =
+				( $stats->{raw}->{$counter} / $stats->{totalCount} ) * 100;
 		}
 		else {
 			$data->{$p} = 0;
@@ -414,45 +358,35 @@ sub gen_traffic_router_config {
 
 	$SIG{__WARN__} = sub {
 		warn $_[0]
-			unless $_[0]
-			=~ m/Prefetching multiple has_many rels deliveryservice_servers/;
+			unless $_[0] =~ m/Prefetching multiple has_many rels deliveryservice_servers/;
 	};
 
 	$data_obj->{'stats'}->{'cdnName'}           = $cdn_name;
 	$data_obj->{'stats'}->{'date'}              = time();
 	$data_obj->{'stats'}->{'trafficOpsVersion'} = &tm_version();
-	$data_obj->{'stats'}->{'trafficOpsPath'}
-		= $self->req->url->path->{'path'};
+	$data_obj->{'stats'}->{'trafficOpsPath'} =
+		$self->req->url->path->{'path'};
 	$data_obj->{'stats'}->{'trafficOpsHost'} = $self->req->headers->host;
-	$data_obj->{'stats'}->{'trafficOpsUser'}
-		= $self->current_user()->{username};
+	$data_obj->{'stats'}->{'trafficOpsUser'} =
+		$self->current_user()->{username};
 
-	my @cdn_profiles
-		= $self->db->resultset('Server')
-		->search( { 'cdn.name' => $cdn_name }, { prefetch => ['cdn'] } )
-		->get_column('profile')->all();
+	my @cdn_profiles = $self->db->resultset('Server')->search( { 'cdn.name' => $cdn_name }, { prefetch => ['cdn'] } )->get_column('profile')->all();
 	if ( scalar(@cdn_profiles) ) {
-		$ccr_profile_id
-			= $self->db->resultset('Profile')
-			->search(
-			{ id => { -in => \@cdn_profiles }, name => { -like => 'CCR%' } } )
-			->get_column('id')->single();
+		$ccr_profile_id =
+			$self->db->resultset('Profile')->search( { id => { -in => \@cdn_profiles }, name => { -like => 'CCR%' } } )->get_column('id')->single();
 		if ( !defined($ccr_profile_id) ) {
-			my $e = Mojo::Exception->throw(
-				"No CCR profile found in profile IDs: @cdn_profiles ");
+			my $e = Mojo::Exception->throw("No CCR profile found in profile IDs: @cdn_profiles ");
 		}
 	}
 	else {
-		my $e = Mojo::Exception->throw(
-			"No profiles found for CDN_name: " . $cdn_name );
+		my $e = Mojo::Exception->throw( "No profiles found for CDN_name: " . $cdn_name );
 	}
 
 	my %condition = (
 		'profile_parameters.profile' => $ccr_profile_id,
 		'config_file'                => 'CRConfig.json'
 	);
-	my $rs_config = $self->db->resultset('Parameter')
-		->search( \%condition, { join => 'profile_parameters' } );
+	my $rs_config = $self->db->resultset('Parameter')->search( \%condition, { join => 'profile_parameters' } );
 	while ( my $row = $rs_config->next ) {
 		if ( $row->name eq 'domain_name' ) {
 			$ccr_domain_name = $row->value;
@@ -490,11 +424,9 @@ sub gen_traffic_router_config {
 
 	my $rs_loc = $self->db->resultset('Server')->search(
 		{ 'cdn.name' => $cdn_name },
-		{   join   => [ 'cdn', 'cachegroup' ],
-			select => [
-				'cachegroup.name', 'cachegroup.latitude',
-				'cachegroup.longitude'
-			],
+		{
+			join   => [ 'cdn',             'cachegroup' ],
+			select => [ 'cachegroup.name', 'cachegroup.latitude', 'cachegroup.longitude' ],
 			distinct => 1
 		}
 	);
@@ -509,8 +441,7 @@ sub gen_traffic_router_config {
 	}
 
 	my $regex_tracker;
-	my $rs_regexes = $self->db->resultset('Regex')
-		->search( {}, { 'prefetch' => 'type' } );
+	my $rs_regexes = $self->db->resultset('Regex')->search( {}, { 'prefetch' => 'type' } );
 	while ( my $row = $rs_regexes->next ) {
 		$regex_tracker->{ $row->id }->{'type'}    = $row->type->name;
 		$regex_tracker->{ $row->id }->{'pattern'} = $row->pattern;
@@ -518,21 +449,16 @@ sub gen_traffic_router_config {
 	my %cache_tracker;
 	my $rs_caches = $self->db->resultset('Server')->search(
 		{ 'profile' => { -in => \@cdn_profiles } },
-		{   prefetch => [ 'type', 'status', 'cachegroup', 'profile' ],
-			columns  => [
-				'host_name',  'domain_name',
-				'tcp_port',   'interface_name',
-				'ip_address', 'ip6_address',
-				'id',         'xmpp_id'
-			]
+		{
+			prefetch => [ 'type',      'status',      'cachegroup', 'profile' ],
+			columns  => [ 'host_name', 'domain_name', 'tcp_port',   'interface_name', 'ip_address', 'ip6_address', 'id', 'xmpp_id' ]
 		}
 	);
 	while ( my $row = $rs_caches->next ) {
 		if ( $row->type->name eq "RASCAL" ) {
 			my $traffic_monitor;
 			$traffic_monitor->{'hostName'} = $row->host_name;
-			$traffic_monitor->{'fqdn'}
-				= $row->host_name . "." . $row->domain_name;
+			$traffic_monitor->{'fqdn'}     = $row->host_name . "." . $row->domain_name;
 			$traffic_monitor->{'status'}   = $row->status->name;
 			$traffic_monitor->{'location'} = $row->cachegroup->name;
 			$traffic_monitor->{'port'}     = int( $row->tcp_port );
@@ -544,20 +470,20 @@ sub gen_traffic_router_config {
 		}
 		elsif ( $row->type->name eq "CCR" ) {
 			my $rs_param = $self->db->resultset('Parameter')->search(
-				{   'profile_parameters.profile' => $row->profile->id,
+				{
+					'profile_parameters.profile' => $row->profile->id,
 					'name'                       => 'api.port'
 				},
 				{ join => 'profile_parameters' }
 			);
 			my $r = $rs_param->single;
-			my $api_port
-				= ( defined($r) && defined( $r->value ) ) ? $r->value : 3333;
+			my $api_port =
+				( defined($r) && defined( $r->value ) ) ? $r->value : 3333;
 
 			my $traffic_router;
 
 			$traffic_router->{'hostName'} = $row->host_name;
-			$traffic_router->{'fqdn'}
-				= $row->host_name . "." . $row->domain_name;
+			$traffic_router->{'fqdn'}     = $row->host_name . "." . $row->domain_name;
 			$traffic_router->{'status'}   = $row->status->name;
 			$traffic_router->{'location'} = $row->cachegroup->name;
 			$traffic_router->{'port'}     = int( $row->tcp_port );
@@ -573,10 +499,9 @@ sub gen_traffic_router_config {
 			}
 
 			my $traffic_server;
-			$traffic_server->{'cacheGroup'} = $row->cachegroup->name;
-			$traffic_server->{'hostName'}   = $row->host_name;
-			$traffic_server->{'fqdn'}
-				= $row->host_name . "." . $row->domain_name;
+			$traffic_server->{'cacheGroup'}    = $row->cachegroup->name;
+			$traffic_server->{'hostName'}      = $row->host_name;
+			$traffic_server->{'fqdn'}          = $row->host_name . "." . $row->domain_name;
 			$traffic_server->{'port'}          = int( $row->tcp_port );
 			$traffic_server->{'interfaceName'} = $row->interface_name;
 			$traffic_server->{'status'}        = $row->status->name;
@@ -592,14 +517,8 @@ sub gen_traffic_router_config {
 
 	my $ds_regex_tracker;
 	my $regexps;
-	my $rs_ds = $self->db->resultset('Deliveryservice')->search(
-		{ 'me.profile' => $ccr_profile_id, 'active' => 1 },
-		{   prefetch => [
-				'deliveryservice_servers', 'deliveryservice_regexes',
-				'type'
-			]
-		}
-	);
+	my $rs_ds = $self->db->resultset('Deliveryservice')
+		->search( { 'me.profile' => $ccr_profile_id, 'active' => 1 }, { prefetch => [ 'deliveryservice_servers', 'deliveryservice_regexes', 'type' ] } );
 	while ( my $row = $rs_ds->next ) {
 		my $delivery_service;
 		$delivery_service->{'xmlId'} = $row->xml_id;
@@ -616,24 +535,13 @@ sub gen_traffic_router_config {
 		my %ds_to_remap;
 		if ( scalar(@regex_subrows) ) {
 			foreach my $subrow (@regex_subrows) {
-				$delivery_service->{'matchSets'}->[ $subrow->set_number ]
-					->{'protocol'} = $protocol;
-				$regex_to_props->{ $subrow->{'_column_data'}->{'regex'} }
-					->{'pattern'}
-					= $regex_tracker->{ $subrow->{'_column_data'}->{'regex'} }
-					->{'pattern'};
-				$regex_to_props->{ $subrow->{'_column_data'}->{'regex'} }
-					->{'setNumber'} = $subrow->set_number;
-				$regex_to_props->{ $subrow->{'_column_data'}->{'regex'} }
-					->{'type'}
-					= $regex_tracker->{ $subrow->{'_column_data'}->{'regex'} }
-					->{'type'};
-				if ( $regex_to_props->{ $subrow->{'_column_data'}->{'regex'} }
-					->{'type'} eq 'HOST_REGEXP' )
-				{
-					$ds_to_remap{ $row->xml_id }->[ $subrow->set_number ]
-						= $regex_to_props->{ $subrow->{'_column_data'}
-							->{'regex'} }->{'pattern'};
+				$delivery_service->{'matchSets'}->[ $subrow->set_number ]->{'protocol'} = $protocol;
+				$regex_to_props->{ $subrow->{'_column_data'}->{'regex'} }->{'pattern'} =
+					$regex_tracker->{ $subrow->{'_column_data'}->{'regex'} }->{'pattern'};
+				$regex_to_props->{ $subrow->{'_column_data'}->{'regex'} }->{'setNumber'} = $subrow->set_number;
+				$regex_to_props->{ $subrow->{'_column_data'}->{'regex'} }->{'type'} = $regex_tracker->{ $subrow->{'_column_data'}->{'regex'} }->{'type'};
+				if ( $regex_to_props->{ $subrow->{'_column_data'}->{'regex'} }->{'type'} eq 'HOST_REGEXP' ) {
+					$ds_to_remap{ $row->xml_id }->[ $subrow->set_number ] = $regex_to_props->{ $subrow->{'_column_data'}->{'regex'} }->{'pattern'};
 				}
 			}
 		}
@@ -643,33 +551,18 @@ sub gen_traffic_router_config {
 			my $pattern    = $regex_to_props->{$regex}->{'pattern'};
 			my $type       = $regex_to_props->{$regex}->{'type'};
 			if ( $type eq 'HOST_REGEXP' ) {
-				push(
-					@{  $delivery_service->{'matchSets'}->[$set_number]
-							->{'matchList'}
-					},
-					{ 'matchType' => 'HOST', 'regex' => $pattern }
-				);
+				push( @{ $delivery_service->{'matchSets'}->[$set_number]->{'matchList'} }, { 'matchType' => 'HOST', 'regex' => $pattern } );
 				my $host = $pattern;
 				$host =~ s/\\//g;
 				$host =~ s/\.\*//g;
-				$host =~ s/\.//g;\
+				$host =~ s/\.//g;
 				push @$domains, "$host.$ccr_domain_name";
 			}
 			elsif ( $type eq 'PATH_REGEXP' ) {
-				push(
-					@{  $delivery_service->{'matchSets'}->[$set_number]
-							->{'matchList'}
-					},
-					{ 'matchType' => 'PATH', 'regex' => $pattern }
-				);
+				push( @{ $delivery_service->{'matchSets'}->[$set_number]->{'matchList'} }, { 'matchType' => 'PATH', 'regex' => $pattern } );
 			}
 			elsif ( $type eq 'HEADER_REGEXP' ) {
-				push(
-					@{  $delivery_service->{'matchSets'}->[$set_number]
-							->{'matchList'}
-					},
-					{ 'matchType' => 'HEADER', 'regex' => $pattern }
-				);
+				push( @{ $delivery_service->{'matchSets'}->[$set_number]->{'matchList'} }, { 'matchType' => 'HEADER', 'regex' => $pattern } );
 			}
 		}
 		$delivery_service->{'domains'} = $domains;
@@ -678,11 +571,11 @@ sub gen_traffic_router_config {
 			#my $host_regex = qr/(^(\.)+\*\\\.)(.*)(\\\.(\.)+\*$)/;
 			my $host_regex1 = qr/\\|\.\*/;
 
-#MAT: Have to do this dedup because @server_subrows contains duplicates (* the # of host regexes)
+			#MAT: Have to do this dedup because @server_subrows contains duplicates (* the # of host regexes)
 			my %server_subrow_dedup;
 			foreach my $subrow (@server_subrows) {
-				$server_subrow_dedup{ $subrow->{'_column_data'}->{'server'} }
-					= $subrow->{'_column_data'}->{'deliveryservice'};
+				$server_subrow_dedup{ $subrow->{'_column_data'}->{'server'} } =
+					$subrow->{'_column_data'}->{'deliveryservice'};
 			}
 			my $ds_regex->{'xmlId'} = $row->xml_id;
 			foreach my $server ( keys %server_subrow_dedup ) {
@@ -696,14 +589,10 @@ sub gen_traffic_router_config {
 							$remap = 'edge' . $host_copy . $ccr_domain_name;
 						}
 						else {
-							my $cache_tracker_server
-								= $cache_tracker{$server} || "";
-							my $host_copy       = $host_copy       || "";
-							my $ccr_domain_name = $ccr_domain_name || "";
-							$remap
-								= $cache_tracker_server
-								. $host_copy
-								. $ccr_domain_name;
+							my $cache_tracker_server = $cache_tracker{$server} || "";
+							my $host_copy            = $host_copy              || "";
+							my $ccr_domain_name      = $ccr_domain_name        || "";
+							$remap = $cache_tracker_server . $host_copy . $ccr_domain_name;
 						}
 					}
 					else {
@@ -712,12 +601,7 @@ sub gen_traffic_router_config {
 					push( @remaps, $remap );
 				}
 				my $cache_tracker_server = $cache_tracker{$server} || "";
-				push(
-					@{  $ds_regex_tracker->{$cache_tracker_server}
-							->{ $row->xml_id }->{'remaps'}
-					},
-					@remaps
-				);
+				push( @{ $ds_regex_tracker->{$cache_tracker_server}->{ $row->xml_id }->{'remaps'} }, @remaps );
 			}
 		}
 
@@ -749,8 +633,7 @@ sub gen_traffic_router_config {
 		my $bypass_destination;
 		if ( $protocol =~ m/DNS/ ) {
 			$bypass_destination->{'type'} = 'DNS';
-			if ( defined( $row->dns_bypass_ip ) && $row->dns_bypass_ip ne "" )
-			{
+			if ( defined( $row->dns_bypass_ip ) && $row->dns_bypass_ip ne "" ) {
 				$bypass_destination->{'ip'} = $row->dns_bypass_ip;
 			}
 			if ( defined( $row->dns_bypass_ip6 )
@@ -771,8 +654,7 @@ sub gen_traffic_router_config {
 			if ( defined( $row->max_dns_answers )
 				&& $row->max_dns_answers ne "" )
 			{
-				$bypass_destination->{'maxDnsIpsForLocation'}
-					= int( $row->max_dns_answers );
+				$bypass_destination->{'maxDnsIpsForLocation'} = int( $row->max_dns_answers );
 			}
 		}
 		elsif ( $protocol =~ m/HTTP/ ) {
@@ -797,12 +679,10 @@ sub gen_traffic_router_config {
 		$delivery_service->{'bypassDestination'} = $bypass_destination;
 
 		if ( defined( $row->miss_lat ) && $row->miss_lat ne "" ) {
-			$delivery_service->{'missCoordinates'}->{'latitude'}
-				= $row->miss_lat + 0;
+			$delivery_service->{'missCoordinates'}->{'latitude'} = $row->miss_lat + 0;
 		}
 		if ( defined( $row->miss_long ) && $row->miss_long ne "" ) {
-			$delivery_service->{'missCoordinates'}->{'longitude'}
-				= $row->miss_long + 0;
+			$delivery_service->{'missCoordinates'}->{'longitude'} = $row->miss_long + 0;
 		}
 		$delivery_service->{'ttls'} = {
 			'A'    => int( $row->ccr_dns_ttl ),
@@ -817,10 +697,11 @@ sub gen_traffic_router_config {
 		$delivery_service->{'soa'}->{'admin'}   = $cdn_soa_admin;
 
 		my $rs_dns = $self->db->resultset('Staticdnsentry')->search(
-			{   'deliveryservice.active'  => 1,
+			{
+				'deliveryservice.active'  => 1,
 				'deliveryservice.profile' => $ccr_profile_id
-			},
-			{   prefetch => [ 'deliveryservice', 'type' ],
+			}, {
+				prefetch => [ 'deliveryservice', 'type' ],
 				columns  => [ 'host',            'type', 'ttl', 'address' ]
 			}
 		);
@@ -850,13 +731,11 @@ sub gen_traffic_router_config {
 			$server_ref = $data_obj->{'trafficServers'}->[ $i - 1 ];
 		}
 
-		foreach
-			my $xml_id ( sort keys %{ $ds_regex_tracker->{$cache_hostname} } )
-		{
+		foreach my $xml_id ( sort keys %{ $ds_regex_tracker->{$cache_hostname} } ) {
 			my $ds;
 			$ds->{'xmlId'} = $xml_id;
-			$ds->{'remaps'}
-				= $ds_regex_tracker->{$cache_hostname}->{$xml_id}->{'remaps'};
+			$ds->{'remaps'} =
+				$ds_regex_tracker->{$cache_hostname}->{$xml_id}->{'remaps'};
 			push( @{ $server_ref->{'deliveryServices'} }, $ds );
 			$data_obj->{'trafficServers'}->[$i] = $server_ref;
 		}
@@ -875,11 +754,11 @@ sub gen_traffic_router_config {
 sub get_cdns {
 	my $self = shift;
 
-	my $rs_data
-		= $self->db->resultset("Cdn")->search( {}, { order_by => "name" } );
+	my $rs_data =
+		$self->db->resultset("Cdn")->search( {}, { order_by => "name" } );
 	my $json_response = $self->build_cdns_json( $rs_data, "id,name" );
 
-#push( @{$json_response}, { "links" => [ { "rel" => "configs", "href" => "child" } ] } );
+	#push( @{$json_response}, { "links" => [ { "rel" => "configs", "href" => "child" } ] } );
 	$self->success($json_response);
 }
 
@@ -919,10 +798,10 @@ sub domains {
 	my $self = shift;
 	my @data;
 
-	my @ccrprofs = $self->db->resultset('Profile')
-		->search( { name => { -like => 'CCR%' } } )->get_column('id')->all();
+	my @ccrprofs = $self->db->resultset('Profile')->search( { name => { -like => 'CCR%' } } )->get_column('id')->all();
 	my $rs_pp = $self->db->resultset('ProfileParameter')->search(
-		{   profile                 => { -in => \@ccrprofs },
+		{
+			profile                 => { -in => \@ccrprofs },
 			'parameter.name'        => 'domain_name',
 			'parameter.config_file' => 'CRConfig.json'
 		},
@@ -930,8 +809,8 @@ sub domains {
 	);
 	while ( my $row = $rs_pp->next ) {
 		push(
-			@data,
-			{   "domainName"         => $row->parameter->value,
+			@data, {
+				"domainName"         => $row->parameter->value,
 				"parameterId"        => $row->parameter->id,
 				"profileId"          => $row->profile->id,
 				"profileName"        => $row->profile->name,
@@ -947,9 +826,7 @@ sub dnssec_keys {
 	my $self       = shift;
 	my $is_updated = 0;
 	if ( !&is_admin($self) ) {
-		$self->alert(
-			{ Error => " - You must be an ADMIN to perform this operation!" }
-		);
+		$self->alert( { Error => " - You must be an ADMIN to perform this operation!" } );
 	}
 	else {
 		my $cdn_name = $self->param('name');
@@ -960,15 +837,10 @@ sub dnssec_keys {
 			$keys = decode_json( $get_keys->content );
 		}
 		else {
-			return $self->alert(
-				{   Error =>
-						" - Dnssec keys for $cdn_name do not exist!  Response was: "
-						. $get_keys->content
-				}
-			);
+			return $self->alert( { Error => " - Dnssec keys for $cdn_name do not exist!  Response was: " . $get_keys->content } );
 		}
 
-   #get DNSKEY ttl, generation multiplier, and effective mutiplier for CDN TLD
+		#get DNSKEY ttl, generation multiplier, and effective mutiplier for CDN TLD
 		my $profile_id = $self->get_profile_id_by_cdn($cdn_name);
 		my $dnskey_gen_multiplier;
 		my $dnskey_ttl;
@@ -977,46 +849,31 @@ sub dnssec_keys {
 			'parameter.name' => 'tld.ttls.DNSKEY',
 			'profile.name'   => $profile_id
 		);
-		my $rs_pp = $self->db->resultset('ProfileParameter')->search(
-			\%condition,
-			{   prefetch =>
-					[ { 'parameter' => undef }, { 'profile' => undef } ]
-			}
-		)->single;
+		my $rs_pp =
+			$self->db->resultset('ProfileParameter')->search( \%condition, { prefetch => [ { 'parameter' => undef }, { 'profile' => undef } ] } )->single;
 		$rs_pp ? $dnskey_ttl = $rs_pp->parameter->value : $dnskey_ttl = '60';
 
 		%condition = (
 			'parameter.name' => 'DNSKEY.generation.multiplier',
 			'profile.name'   => $profile_id
 		);
-		$rs_pp = $self->db->resultset('ProfileParameter')->search(
-			\%condition,
-			{   prefetch =>
-					[ { 'parameter' => undef }, { 'profile' => undef } ]
-			}
-		)->single;
+		$rs_pp =
+			$self->db->resultset('ProfileParameter')->search( \%condition, { prefetch => [ { 'parameter' => undef }, { 'profile' => undef } ] } )->single;
 		$rs_pp
-			? $dnskey_gen_multiplier
-			= $rs_pp->parameter->value
+			? $dnskey_gen_multiplier = $rs_pp->parameter->value
 			: $dnskey_gen_multiplier = '10';
 
 		%condition = (
 			'parameter.name' => 'DNSKEY.effective.multiplier',
 			'profile.name'   => $profile_id
 		);
-		$rs_pp = $self->db->resultset('ProfileParameter')->search(
-			\%condition,
-			{   prefetch =>
-					[ { 'parameter' => undef }, { 'profile' => undef } ]
-			}
-		)->single;
+		$rs_pp =
+			$self->db->resultset('ProfileParameter')->search( \%condition, { prefetch => [ { 'parameter' => undef }, { 'profile' => undef } ] } )->single;
 		$rs_pp
-			? $dnskey_effective_multiplier
-			= $rs_pp->parameter->value
+			? $dnskey_effective_multiplier = $rs_pp->parameter->value
 			: $dnskey_effective_multiplier = '10';
 
-		my $key_expiration
-			= time() - ( $dnskey_ttl * $dnskey_gen_multiplier );
+		my $key_expiration = time() - ( $dnskey_ttl * $dnskey_gen_multiplier );
 
 		#get default expiration days and ttl for DSs from CDN record
 		my $default_k_exp_days = "365";
@@ -1024,8 +881,7 @@ sub dnssec_keys {
 		my $cdn_ksk            = $keys->{$cdn_name}->{ksk};
 		foreach my $cdn_krecord (@$cdn_ksk) {
 			my $cdn_kstatus = $cdn_krecord->{status};
-			if ( $cdn_kstatus eq 'new' )
-			{    #ignore anything other than the 'new' record
+			if ( $cdn_kstatus eq 'new' ) {    #ignore anything other than the 'new' record
 				my $cdn_k_exp   = $cdn_krecord->{expirationDate};
 				my $cdn_k_incep = $cdn_krecord->{inceptionDate};
 				$default_k_exp_days = ( $cdn_k_exp - $cdn_k_incep ) / 86400;
@@ -1034,8 +890,7 @@ sub dnssec_keys {
 		my $cdn_zsk = $keys->{$cdn_name}->{zsk};
 		foreach my $cdn_zrecord (@$cdn_zsk) {
 			my $cdn_zstatus = $cdn_zrecord->{status};
-			if ( $cdn_zstatus eq 'new' )
-			{    #ignore anything other than the 'new' record
+			if ( $cdn_zstatus eq 'new' ) {    #ignore anything other than the 'new' record
 				my $cdn_z_exp   = $cdn_zrecord->{expirationDate};
 				my $cdn_z_incep = $cdn_zrecord->{inceptionDate};
 				$default_z_exp_days = ( $cdn_z_exp - $cdn_z_incep ) / 86400;
@@ -1044,13 +899,9 @@ sub dnssec_keys {
 				if ( ($cdn_z_exp) < $key_expiration ) {
 
 					#if expired create new keys
-					$self->app->log->info(
-						"The ZSK keys for $cdn_name are expired!");
-					my $effective_date = $cdn_z_exp
-						- ( $dnskey_ttl * $dnskey_effective_multiplier );
-					my $new_dnssec_keys
-						= $self->regen_expired_keys( "zsk", $cdn_name, $keys,
-						$effective_date );
+					$self->app->log->info("The ZSK keys for $cdn_name are expired!");
+					my $effective_date = $cdn_z_exp - ( $dnskey_ttl * $dnskey_effective_multiplier );
+					my $new_dnssec_keys = $self->regen_expired_keys( "zsk", $cdn_name, $keys, $effective_date );
 					$keys->{$cdn_name} = $new_dnssec_keys;
 				}
 			}
@@ -1058,8 +909,7 @@ sub dnssec_keys {
 
 		#get DeliveryServices for CDN
 		my %search = ( profile => $profile_id );
-		my @ds_rs
-			= $self->db->resultset('Deliveryservice')->search( \%search );
+		my @ds_rs = $self->db->resultset('Deliveryservice')->search( \%search );
 		foreach my $ds (@ds_rs) {
 
 			#check if keys exist for ds
@@ -1072,40 +922,24 @@ sub dnssec_keys {
 				my $ds_id = $ds->id;
 
 				#create the ds domain name for dnssec keys
-				my $domain_name
-					= UI::DeliveryService::get_cdn_domain( $self, $ds_id );
-				my $deliveryservice_regexes
-					= UI::DeliveryService::get_regexp_set( $self, $ds_id );
-				my $rs_ds = $self->db->resultset('Deliveryservice')->search(
-					{ 'me.xml_id' => $xml_id },
-					{   prefetch =>
-							[ { 'type' => undef }, { 'profile' => undef } ]
-					}
-				);
+				my $domain_name = UI::DeliveryService::get_cdn_domain( $self, $ds_id );
+				my $deliveryservice_regexes = UI::DeliveryService::get_regexp_set( $self, $ds_id );
+				my $rs_ds = $self->db->resultset('Deliveryservice')
+					->search( { 'me.xml_id' => $xml_id }, { prefetch => [ { 'type' => undef }, { 'profile' => undef } ] } );
 				my $data = $rs_ds->single;
-				my @example_urls
-					= UI::DeliveryService::get_example_urls( $self, $ds_id,
-					$deliveryservice_regexes, $data, $domain_name,
-					$data->protocol );
+				my @example_urls = UI::DeliveryService::get_example_urls( $self, $ds_id, $deliveryservice_regexes, $data, $domain_name, $data->protocol );
 
-#first one is the one we want.  period at end for dnssec, substring off stuff we dont want
+				#first one is the one we want.  period at end for dnssec, substring off stuff we dont want
 				my $ds_name = $example_urls[0] . ".";
-				my $length = length($ds_name) - index( $ds_name, "." );
-				$ds_name
-					= substr( $ds_name, index( $ds_name, "." ) + 1, $length );
+				my $length = length($ds_name) - CORE::index( $ds_name, "." );
+				$ds_name = substr( $ds_name, CORE::index( $ds_name, "." ) + 1, $length );
 
-				my $inception = time();
-				my $z_expiration
-					= $inception + ( 86400 * $default_z_exp_days );
-				my $k_expiration
-					= $inception + ( 86400 * $default_k_exp_days );
+				my $inception    = time();
+				my $z_expiration = $inception + ( 86400 * $default_z_exp_days );
+				my $k_expiration = $inception + ( 86400 * $default_k_exp_days );
 
-				my $zsk
-					= $self->get_dnssec_keys( "zsk", $ds_name, $dnskey_ttl,
-					$inception, $z_expiration, "new", $inception );
-				my $ksk
-					= $self->get_dnssec_keys( "ksk", $ds_name, $dnskey_ttl,
-					$inception, $k_expiration, "new", $inception );
+				my $zsk = $self->get_dnssec_keys( "zsk", $ds_name, $dnskey_ttl, $inception, $z_expiration, "new", $inception );
+				my $ksk = $self->get_dnssec_keys( "ksk", $ds_name, $dnskey_ttl, $inception, $k_expiration, "new", $inception );
 
 				#add to keys hash
 				$keys->{$xml_id} = { zsk => [$zsk], ksk => [$ksk] };
@@ -1119,21 +953,14 @@ sub dnssec_keys {
 				my $ksk = $ds_keys->{ksk};
 				foreach my $krecord (@$ksk) {
 					my $kstatus = $krecord->{status};
-					if ( $kstatus eq 'new' )
-					{    #ignore anything other than the 'new' record
-						    #check if expired
+					if ( $kstatus eq 'new' ) {    #ignore anything other than the 'new' record
+						                          #check if expired
 						if ( $krecord->{expirationDate} < $key_expiration ) {
 
 							#if expired create new keys
-							$self->app->log->info(
-								"The KSK keys for $xml_id are expired!");
-							my $effective_date
-								= $krecord->{expirationDate}
-								- (
-								$dnskey_ttl * $dnskey_effective_multiplier );
-							my $new_dnssec_keys
-								= $self->regen_expired_keys( "ksk", $xml_id,
-								$keys, $effective_date );
+							$self->app->log->info("The KSK keys for $xml_id are expired!");
+							my $effective_date = $krecord->{expirationDate} - ( $dnskey_ttl * $dnskey_effective_multiplier );
+							my $new_dnssec_keys = $self->regen_expired_keys( "ksk", $xml_id, $keys, $effective_date );
 							$keys->{$xml_id} = $new_dnssec_keys;
 
 							#update is_updated param
@@ -1148,15 +975,9 @@ sub dnssec_keys {
 						if ( $zrecord->{expirationDate} < $key_expiration ) {
 
 							#if expired create new keys
-							$self->app->log->info(
-								"The ZSK keys for $xml_id are expired!");
-							my $effective_date
-								= $zrecord->{expirationDate}
-								- (
-								$dnskey_ttl * $dnskey_effective_multiplier );
-							my $new_dnssec_keys
-								= $self->regen_expired_keys( "zsk", $xml_id,
-								$keys, $effective_date );
+							$self->app->log->info("The ZSK keys for $xml_id are expired!");
+							my $effective_date = $zrecord->{expirationDate} - ( $dnskey_ttl * $dnskey_effective_multiplier );
+							my $new_dnssec_keys = $self->regen_expired_keys( "zsk", $xml_id, $keys, $effective_date );
 							$keys->{$xml_id} = $new_dnssec_keys;
 
 							#update is_updated param
@@ -1170,19 +991,13 @@ sub dnssec_keys {
 
 			# #convert hash to json and store in Riak
 			my $json_data = encode_json($keys);
-			$response_container
-				= $self->riak_put( "dnssec", $cdn_name, $json_data );
+			$response_container = $self->riak_put( "dnssec", $cdn_name, $json_data );
 		}
 
 		my $response = $response_container->{"response"};
 		$response->is_success()
 			? $self->success($keys)
-			: $self->alert(
-			{   Error =>
-					" - A record for dnssec key $cdn_name could not be found.  Response was: "
-					. $response->content
-			}
-			);
+			: $self->alert( { Error => " - A record for dnssec key $cdn_name could not be found.  Response was: " . $response->content } );
 	}
 }
 
@@ -1214,8 +1029,7 @@ sub regen_expired_keys {
 	my $new_expiration = $new_inception + ( 86400 * $expiration_days );
 
 	#generate new keys
-	my $new_key = $self->get_dnssec_keys( $type, $name, $ttl, $new_inception,
-		$new_expiration, "new", $effective_date, $tld );
+	my $new_key = $self->get_dnssec_keys( $type, $name, $ttl, $new_inception, $new_expiration, "new", $effective_date, $tld );
 
 	if ( $type eq "ksk" ) {
 
@@ -1248,9 +1062,7 @@ sub dnssec_keys_generate {
 	my $self = shift;
 
 	if ( !&is_admin($self) ) {
-		$self->alert(
-			{ Error => " - You must be an ADMIN to perform this operation!" }
-		);
+		$self->alert( { Error => " - You must be an ADMIN to perform this operation!" } );
 	}
 	else {
 		my $key_type      = "dnssec";
@@ -1263,8 +1075,7 @@ sub dnssec_keys_generate {
 		if ( !defined($effectiveDate) ) {
 			$effectiveDate = time();
 		}
-		my $res = $self->generate_store_dnssec_keys( $key, $name, $ttl,
-			$k_exp_days, $z_exp_days, $effectiveDate );
+		my $res      = $self->generate_store_dnssec_keys( $key, $name, $ttl, $k_exp_days, $z_exp_days, $effectiveDate );
 		my $response = $res->{response};
 		my $rc       = $response->{_rc};
 		if ( $rc eq "204" ) {
@@ -1272,12 +1083,7 @@ sub dnssec_keys_generate {
 			$self->success("Successfully created $key_type keys for $key");
 		}
 		else {
-			$self->alert(
-				{   Error =>
-						" - DNSSEC keys for $key could not be created.  Response was"
-						. $response->content
-				}
-			);
+			$self->alert( { Error => " - DNSSEC keys for $key could not be created.  Response was" . $response->content } );
 		}
 	}
 }
@@ -1288,9 +1094,7 @@ sub delete_dnssec_keys {
 	my $key_type = "dnssec";
 	my $response;
 	if ( !&is_admin($self) ) {
-		$self->alert(
-			{ Error => " - You must be an ADMIN to perform this operation!" }
-		);
+		$self->alert( { Error => " - You must be an ADMIN to perform this operation!" } );
 	}
 	else {
 		$self->app->log->info("deleting key_type = $key_type, key = $key");
@@ -1301,12 +1105,7 @@ sub delete_dnssec_keys {
 			$self->success("Successfully deleted $key_type keys for $key");
 		}
 		else {
-			$self->alert(
-				{   Error =>
-						" - SSL keys for key type $key_type and key $key could not be deleted.  Response was"
-						. $response->content
-				}
-			);
+			$self->alert( { Error => " - SSL keys for key type $key_type and key $key could not be deleted.  Response was" . $response->content } );
 		}
 	}
 }

--- a/traffic_ops/app/lib/UI/Cdn.pm
+++ b/traffic_ops/app/lib/UI/Cdn.pm
@@ -334,7 +334,7 @@ sub aserver {
 				my $pparam =
 					$self->db->resultset('ProfileParameter')->search( { -and => [ 'parameter.name' => 'server_graph_url', 'profile.name' => 'GLOBAL' ] },
 					{ prefetch => [ 'parameter', 'profile' ] } )->single();
-				my $srvg_url = defined($pparam) ? $pparam->parameter->value : undef;
+				my $srvg_url = defined($pparam) ? $pparam->parameter->value : '';
 				$aux_url = $srvg_url . $row->host_name;
 				$img     = "graph.png";
 			}


### PR DESCRIPTION
I noticed several warnings during test in traffic_ops (prove -qrp t).   Use of uninitialized vars, useless use of scalar ref,   "assuming CORE::index..."...   Changes were minor -- these are fixed and prove (and dev console msgs) is less noisy.