### PR TITLE
Initialize federation resolvers as empty ComparableTreeSets to avoid NPEs

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMapping.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMapping.java
@@ -8,14 +8,18 @@ import java.util.Set;
 public class FederationMapping implements Comparable<FederationMapping> {
     private final String cname;
     private final int ttl;
-    private final ComparableTreeSet<CidrAddress> resolve4;
-    private final ComparableTreeSet<CidrAddress> resolve6;
+    private ComparableTreeSet<CidrAddress> resolve4 = new ComparableTreeSet<CidrAddress>();
+    private ComparableTreeSet<CidrAddress> resolve6 = new ComparableTreeSet<CidrAddress>();
 
     public FederationMapping(final String cname, final int ttl, final ComparableTreeSet<CidrAddress> resolve4, final ComparableTreeSet<CidrAddress> resolve6) {
         this.cname = cname;
         this.ttl = ttl;
-        this.resolve4 = resolve4;
-        this.resolve6 = resolve6;
+        if (resolve4 != null) {
+            this.resolve4 = resolve4;
+        }
+        if (resolve6 != null) {
+            this.resolve6 = resolve6;
+        }
     }
 
     public String getCname() {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMapping.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMapping.java
@@ -8,18 +8,14 @@ import java.util.Set;
 public class FederationMapping implements Comparable<FederationMapping> {
     private final String cname;
     private final int ttl;
-    private ComparableTreeSet<CidrAddress> resolve4 = new ComparableTreeSet<CidrAddress>();
-    private ComparableTreeSet<CidrAddress> resolve6 = new ComparableTreeSet<CidrAddress>();
+    private final ComparableTreeSet<CidrAddress> resolve4 = new ComparableTreeSet<CidrAddress>();
+    private final ComparableTreeSet<CidrAddress> resolve6 = new ComparableTreeSet<CidrAddress>();
 
     public FederationMapping(final String cname, final int ttl, final ComparableTreeSet<CidrAddress> resolve4, final ComparableTreeSet<CidrAddress> resolve6) {
         this.cname = cname;
         this.ttl = ttl;
-        if (resolve4 != null) {
-            this.resolve4 = resolve4;
-        }
-        if (resolve6 != null) {
-            this.resolve6 = resolve6;
-        }
+        this.resolve4.addAll(resolve4);
+        this.resolve6.addAll(resolve6);
     }
 
     public String getCname() {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMappingBuilder.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMappingBuilder.java
@@ -20,12 +20,12 @@ public class FederationMappingBuilder {
         final String cname = jsonObject.getString("cname");
         final int ttl = jsonObject.getInt("ttl");
 
-        ComparableTreeSet<CidrAddress> network = null;
+        final ComparableTreeSet<CidrAddress> network = new ComparableTreeSet<CidrAddress>();
         if (jsonObject.has("resolve4")) {
             final JSONArray networkArray = jsonObject.getJSONArray("resolve4");
 
             try {
-                network = buildAddresses(networkArray);
+                network.addAll(buildAddresses(networkArray));
             }
             catch (JSONException e) {
                 LOGGER.warn("Failed getting ipv4 address array likely due to bad json data: " + e.getMessage());
@@ -33,11 +33,11 @@ public class FederationMappingBuilder {
         }
 
 
-        ComparableTreeSet<CidrAddress> network6 = null;
+        final ComparableTreeSet<CidrAddress> network6 = new ComparableTreeSet<CidrAddress>();
         if (jsonObject.has("resolve6")) {
             final JSONArray network6Array = jsonObject.getJSONArray("resolve6");
             try {
-                network6 = buildAddresses(network6Array);
+                network6.addAll(buildAddresses(network6Array));
             }
             catch (JSONException e) {
                 LOGGER.warn("Failed getting ipv6 address array likely due to bad json data: " + e.getMessage());

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMappingBuilderTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationMappingBuilderTest.java
@@ -32,4 +32,24 @@ public class FederationMappingBuilderTest {
         assertThat(federationMapping.getResolve6(),
                 containsInAnyOrder(CidrAddress.fromString("fd12:3456:789a:1::/64"), CidrAddress.fromString("fdfe:dcba:9876:5::/64")));
     }
+
+    @Test
+    public void itConsumesJSONWithoutResolvers() throws Exception {
+        FederationMappingBuilder federationMappingBuilder = new FederationMappingBuilder();
+
+        String json = "{ " +
+                "'cname' : 'cname1', " +
+                "'ttl' : '86400' " +
+                "}";
+
+        FederationMapping federationMapping = federationMappingBuilder.fromJSON(json);
+
+        assertThat(federationMapping, not(nullValue()));
+        assertThat(federationMapping.getCname(), equalTo("cname1"));
+        assertThat(federationMapping.getTtl(), equalTo(86400));
+
+        assertThat(federationMapping.getResolve4(), not(nullValue()));
+        assertThat(federationMapping.getResolve6(), not(nullValue()));
+    }
+
 }


### PR DESCRIPTION
This closes #789 