### PR TITLE
use $traffic_control.version for traffic_router version

### DIFF
--- a/traffic_monitor/build/build_rpm.sh
+++ b/traffic_monitor/build/build_rpm.sh
@@ -36,9 +36,9 @@ function buildRpmTrafficMonitor () {
 	echo "Building the rpm."
 
 	cd "$TM_DIR" || { echo "Could not cd to $TM_DIR: $?"; exit 1; }
-	local version="-Dtraffic_control.version=$TC_VERSION"
+	export TRAFFIC_CONTROL_VERSION="$TC_VERSION"
 	export GIT_REV_COUNT=$(getRevCount)
-	mvn "$version" package || { echo "RPM BUILD FAILED: $?"; exit 1; }
+	mvn package || { echo "RPM BUILD FAILED: $?"; exit 1; }
 
 	local rpm=$(find -name \*.rpm)
 	if [[ -z $rpm ]]; then

--- a/traffic_monitor/pom.xml
+++ b/traffic_monitor/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.comcast.cdn.traffic_control</groupId>
 	<packaging>war</packaging>
-	<version>${traffic_control.version}</version>
+	<version>${env.TRAFFIC_CONTROL_VERSION}</version>
 	<name>traffic_monitor</name>
 	<description></description>
 
@@ -149,6 +149,21 @@
 				<artifactId>maven-pmd-plugin</artifactId>
 				<version>2.5</version>
 				<executions>
+					<execution>
+						<phase>validate</phase>
+						<id>enforce-environment-variable-is-set</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireEnvironmentVariable>
+									<variableName>TRAFFIC_CONTROL_VERSION</variableName>
+								</requireEnvironmentVariable>
+							</rules>
+							<fail>true</fail>
+						</configuration>
+					</execution>
 					<execution>
 						<id>PMD</id>
 						<phase>verify</phase>

--- a/traffic_monitor/pom.xml
+++ b/traffic_monitor/pom.xml
@@ -150,21 +150,6 @@
 				<version>2.5</version>
 				<executions>
 					<execution>
-						<phase>validate</phase>
-						<id>enforce-environment-variable-is-set</id>
-						<goals>
-							<goal>enforce</goal>
-						</goals>
-						<configuration>
-							<rules>
-								<requireEnvironmentVariable>
-									<variableName>TRAFFIC_CONTROL_VERSION</variableName>
-								</requireEnvironmentVariable>
-							</rules>
-							<fail>true</fail>
-						</configuration>
-					</execution>
-					<execution>
 						<id>PMD</id>
 						<phase>verify</phase>
 						<goals>
@@ -269,6 +254,21 @@
 				<artifactId>maven-enforcer-plugin</artifactId>
 				<version>1.4.1</version>
 				<executions>
+					<execution>
+						<phase>validate</phase>
+						<id>enforce-environment-variable-is-set0</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireEnvironmentVariable>
+									<variableName>TRAFFIC_CONTROL_VERSION</variableName>
+								</requireEnvironmentVariable>
+							</rules>
+							<fail>true</fail>
+						</configuration>
+					</execution>
 					<execution>
 						<phase>package</phase>
 						<id>enforce-environment-variable-is-set</id>

--- a/traffic_router/api/pom.xml
+++ b/traffic_router/api/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
 		<artifactId>traffic_router</artifactId>
-		<version>1.2.1</version>
+		<version>${traffic_control.version}</version>
 	</parent>
 
 	<artifactId>traffic_router_api</artifactId>

--- a/traffic_router/api/pom.xml
+++ b/traffic_router/api/pom.xml
@@ -70,6 +70,12 @@
 							<fail>true</fail>
 						</configuration>
 					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<artifactId>maven-pmd-plugin</artifactId>
+				<version>2.5</version>
+				<executions>
 					<execution>
 						<id>PMD</id>
 						<phase>verify</phase>

--- a/traffic_router/api/pom.xml
+++ b/traffic_router/api/pom.xml
@@ -51,8 +51,9 @@
 		<finalName>ROOT</finalName>
 		<plugins>
 			<plugin>
-				<artifactId>maven-pmd-plugin</artifactId>
-				<version>2.5</version>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>1.4.1</version>
 				<executions>
 					<execution>
 						<phase>validate</phase>

--- a/traffic_router/api/pom.xml
+++ b/traffic_router/api/pom.xml
@@ -55,6 +55,21 @@
 				<version>2.5</version>
 				<executions>
 					<execution>
+						<phase>validate</phase>
+						<id>enforce-environment-variable-is-set</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireEnvironmentVariable>
+									<variableName>TRAFFIC_CONTROL_VERSION</variableName>
+								</requireEnvironmentVariable>
+							</rules>
+							<fail>true</fail>
+						</configuration>
+					</execution>
+					<execution>
 						<id>PMD</id>
 						<phase>verify</phase>
 						<goals>

--- a/traffic_router/api/pom.xml
+++ b/traffic_router/api/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
 		<artifactId>traffic_router</artifactId>
-		<version>${traffic_control.version}</version>
+		<version>${env.TRAFFIC_CONTROL_VERSION}</version>
 	</parent>
 
 	<artifactId>traffic_router_api</artifactId>

--- a/traffic_router/build/build_rpm.sh
+++ b/traffic_router/build/build_rpm.sh
@@ -57,9 +57,9 @@ function buildRpmTrafficRouter () {
 	installDnsSec
 
 	cd "$TR_DIR" || { echo "Could not cd to $TR_DIR: $?"; exit 1; }
-	local version="-Dtraffic_control.version=$TC_VERSION"
+	export TRAFFIC_CONTROL_VERSION="$TC_VERSION"
 	export GIT_REV_COUNT=$(getRevCount)
-	mvn -Dmaven.test.skip=true -DminimumTPS=1 "$version" package ||  \
+	mvn -Dmaven.test.skip=true -DminimumTPS=1 package ||  \
 		{ echo "RPM BUILD FAILED: $?"; exit 1; }
 
 	local rpm=$(find -name \*.rpm)

--- a/traffic_router/build/pom.xml
+++ b/traffic_router/build/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
 		<artifactId>traffic_router</artifactId>
-		<version>1.2.1</version>
+		<version>${project.version}</version>
 	</parent>
 
 	<scm>

--- a/traffic_router/build/pom.xml
+++ b/traffic_router/build/pom.xml
@@ -131,7 +131,7 @@
 				<executions>
 					<execution>
 						<phase>validate</phase>
-						<id>enforce-environment-variable-is-set</id>
+						<id>enforce-environment-variable-is-set0</id>
 						<goals>
 							<goal>enforce</goal>
 						</goals>

--- a/traffic_router/build/pom.xml
+++ b/traffic_router/build/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
 		<artifactId>traffic_router</artifactId>
-		<version>${project.version}</version>
+		<version>${env.TRAFFIC_CONTROL_VERSION}</version>
 	</parent>
 
 	<scm>
@@ -129,6 +129,21 @@
 				<artifactId>maven-enforcer-plugin</artifactId>
 				<version>1.4.1</version>
 				<executions>
+					<execution>
+						<phase>validate</phase>
+						<id>enforce-environment-variable-is-set</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireEnvironmentVariable>
+									<variableName>TRAFFIC_CONTROL_VERSION</variableName>
+								</requireEnvironmentVariable>
+							</rules>
+							<fail>true</fail>
+						</configuration>
+					</execution>
 					<execution>
 						<phase>package</phase>
 						<id>enforce-environment-variable-is-set</id>

--- a/traffic_router/connector/pom.xml
+++ b/traffic_router/connector/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
 		<artifactId>traffic_router</artifactId>
-		<version>${traffic_control.version}</version>
+        <version>${env.TRAFFIC_CONTROL_VERSION}</version>
 	</parent>
 
 	<properties>

--- a/traffic_router/connector/pom.xml
+++ b/traffic_router/connector/pom.xml
@@ -55,6 +55,12 @@
 							<fail>true</fail>
 						</configuration>
 					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<artifactId>maven-pmd-plugin</artifactId>
+				<version>2.5</version>
+				<executions>
 					<execution>
 						<id>PMD</id>
 						<phase>verify</phase>

--- a/traffic_router/connector/pom.xml
+++ b/traffic_router/connector/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
 		<artifactId>traffic_router</artifactId>
-		<version>1.2.1</version>
+		<version>${traffic_control.version}</version>
 	</parent>
 
 	<properties>

--- a/traffic_router/connector/pom.xml
+++ b/traffic_router/connector/pom.xml
@@ -36,8 +36,9 @@
 	<build>
 		<plugins>
 			<plugin>
-				<artifactId>maven-pmd-plugin</artifactId>
-				<version>2.5</version>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>1.4.1</version>
 				<executions>
 					<execution>
 						<phase>validate</phase>

--- a/traffic_router/connector/pom.xml
+++ b/traffic_router/connector/pom.xml
@@ -40,6 +40,21 @@
 				<version>2.5</version>
 				<executions>
 					<execution>
+						<phase>validate</phase>
+						<id>enforce-environment-variable-is-set</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireEnvironmentVariable>
+									<variableName>TRAFFIC_CONTROL_VERSION</variableName>
+								</requireEnvironmentVariable>
+							</rules>
+							<fail>true</fail>
+						</configuration>
+					</execution>
+					<execution>
 						<id>PMD</id>
 						<phase>verify</phase>
 						<goals>

--- a/traffic_router/core/pom.xml
+++ b/traffic_router/core/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
 		<artifactId>traffic_router</artifactId>
-		<version>${traffic_control.version}</version>
+		<version>${env.TRAFFIC_CONTROL_VERSION}</version>
 	</parent>
 
 	<scm>
@@ -80,6 +80,28 @@
 			</testResource>
 		</testResources>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>1.4.1</version>
+				<executions>
+					<execution>
+						<phase>validate</phase>
+						<id>enforce-environment-variable-is-set</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireEnvironmentVariable>
+									<variableName>TRAFFIC_CONTROL_VERSION</variableName>
+								</requireEnvironmentVariable>
+							</rules>
+							<fail>true</fail>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<artifactId>maven-pmd-plugin</artifactId>
 				<version>2.5</version>

--- a/traffic_router/core/pom.xml
+++ b/traffic_router/core/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
 		<artifactId>traffic_router</artifactId>
-		<version>1.2.1</version>
+		<version>${traffic_control.version}</version>
 	</parent>
 
 	<scm>

--- a/traffic_router/pom.xml
+++ b/traffic_router/pom.xml
@@ -19,7 +19,7 @@
 
 	<artifactId>traffic_router</artifactId>
 	<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
-	<version>1.2.1</version>
+	<version>${traffic_control.version}</version>
 	<packaging>pom</packaging>
 	<name>traffic_router</name>
 

--- a/traffic_router/pom.xml
+++ b/traffic_router/pom.xml
@@ -19,7 +19,7 @@
 
 	<artifactId>traffic_router</artifactId>
 	<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
-	<version>${traffic_control.version}</version>
+	<version>${env.TRAFFIC_CONTROL_VERSION}</version>
 	<packaging>pom</packaging>
 	<name>traffic_router</name>
 
@@ -29,7 +29,6 @@
 		<module>api</module>
 		<module>build</module>
 	</modules>
-
 	<properties>
 		<deploy.dir>/opt/traffic_router</deploy.dir>
 		<wicket.version>6.0.0</wicket.version>

--- a/traffic_router/pom.xml
+++ b/traffic_router/pom.xml
@@ -51,6 +51,28 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>1.4.1</version>
+				<executions>
+					<execution>
+						<phase>validate</phase>
+						<id>enforce-environment-variable-is-set</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireEnvironmentVariable>
+									<variableName>TRAFFIC_CONTROL_VERSION</variableName>
+								</requireEnvironmentVariable>
+							</rules>
+							<fail>true</fail>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<inherited>true</inherited>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/traffic_router/testServer/pom.xml
+++ b/traffic_router/testServer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
         <artifactId>traffic_router</artifactId>
-	<version>${traffic_control.version}</version>
+	<version>${env.TRAFFIC_CONTROL_VERSION}</version>
     </parent>
 
     <artifactId>traffic_router_test_server</artifactId>

--- a/traffic_router/testServer/pom.xml
+++ b/traffic_router/testServer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
         <artifactId>traffic_router</artifactId>
-        <version>1.2.1</version>
+	<version>${traffic_control.version}</version>
     </parent>
 
     <artifactId>traffic_router_test_server</artifactId>


### PR DESCRIPTION
rpm will now be named from content of VERSION file.  This should be included in the 1.3.x release.

This fixes #803 