### PR TITLE
Exclude unnecessary transitive dependency wicket-atmosphere from Traffic Monitor

### DIFF
--- a/traffic_monitor/pom.xml
+++ b/traffic_monitor/pom.xml
@@ -86,6 +86,12 @@
 			<artifactId>wicket-examples-war</artifactId>
 			<version>0.2</version>
 			<classifier>test-sources</classifier>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.wicket</groupId>
+					<artifactId>wicket-atmosphere</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.wicket</groupId>


### PR DESCRIPTION
some of them are interfering with successful maven builds

(cherry picked from commit 883db3a61f67eed0ae150239026fb5f64a44c19c)