### PR TITLE
Traffic monitor scaling

### DIFF
--- a/traffic_monitor/.gitignore
+++ b/traffic_monitor/.gitignore
@@ -1,3 +1,4 @@
 /target/
 /.settings/
 /bin
+overlays

--- a/traffic_monitor/src/main/conf/log4j.properties
+++ b/traffic_monitor/src/main/conf/log4j.properties
@@ -29,7 +29,7 @@ log4j.appender.ACCESS.threshold=INFO
 # A1 is set to be a RollingFileAppender.
 log4j.appender.A1=org.apache.log4j.RollingFileAppender
 log4j.appender.A1.file=${deploy.dir}/var/log/traffic_monitor.log
-log4j.appender.A1.maxFileSize=2MB
+log4j.appender.A1.maxFileSize=75MB
 
 # A1 uses PatternLayout.
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout

--- a/traffic_monitor/src/main/java/com/comcast/cdn/traffic_control/traffic_monitor/health/CacheState.java
+++ b/traffic_monitor/src/main/java/com/comcast/cdn/traffic_control/traffic_monitor/health/CacheState.java
@@ -272,14 +272,7 @@ public class CacheState extends AbstractState {
 	}
 
 	public boolean completeFetch(final HealthDeterminer myHealthDeterminer, final CacheDataModel errorCount, final AtomicInteger cancelCount, final AtomicInteger failCount) {
-		if (future == null) {
-			return true;
-		}
-
-		// Does this logic change make performance better????
-		// if (future.isDone() || future.isCancelled()) {
-
-		if (future.isDone()) {
+		if (future == null || future.isDone() || future.isCancelled()) {
 			return true;
 		}
 

--- a/traffic_monitor/src/main/java/com/comcast/cdn/traffic_control/traffic_monitor/health/CacheWatcher.java
+++ b/traffic_monitor/src/main/java/com/comcast/cdn/traffic_control/traffic_monitor/health/CacheWatcher.java
@@ -167,7 +167,7 @@ public class CacheWatcher {
 					queryIntervalActual.set(completedTime - time);
 					queryIntervalDelta.set((completedTime - time) - config.getHealthPollingInterval());
 
-					LOGGER.info("Check time of " + states.size() + " caches elapsed: " + mytime + " msec, (Active time was " + (completedTime - time) + ") msec, " + cancelCount.get() + " checks were cancelled, " + failCount.get() + " failed");
+					LOGGER.warn("Check time of " + states.size() + " caches elapsed: " + mytime + " msec, (Active time was " + (completedTime - time) + ") msec, " + cancelCount.get() + " checks were cancelled, " + failCount.get() + " failed");
 				} catch (Exception e) {
 					LOGGER.warn(e, e);
 

--- a/traffic_monitor/src/main/java/com/comcast/cdn/traffic_control/traffic_monitor/health/CacheWatcher.java
+++ b/traffic_monitor/src/main/java/com/comcast/cdn/traffic_control/traffic_monitor/health/CacheWatcher.java
@@ -75,21 +75,29 @@ public class CacheWatcher {
 	class FetchService extends Thread {
 		public FetchService() {
 		}
+
 		final Runtime runtime = Runtime.getRuntime();
 
 		private List<CacheState> checkCaches(final RouterConfig crConfig) {
-			maxMemory.set(runtime.maxMemory()/(1024*1024));
-			totalMem.set(runtime.totalMemory()/(1024*1024));
-			freeMem.set(runtime.freeMemory()/(1024*1024));
+			maxMemory.set(runtime.maxMemory() / (1024 * 1024));
+			totalMem.set(runtime.totalMemory() / (1024 * 1024));
+			freeMem.set(runtime.freeMemory() / (1024 * 1024));
 
 			//					List<AtsServer> servers = new ArrayList<AtsServer>(config.getAtsServer());
 			final List<CacheState> retList = new ArrayList<CacheState>();
 //			DsState.startUpdateAll();
 
 			final List<Cache> myList = crConfig.getCacheList();
-			for(Cache cache : myList) {
-				if(!isActive) { return retList; }
-				if(!myHealthDeterminer.shouldMonitor(cache)) { continue; }
+			for (Cache cache : myList) {
+
+				if (!isActive) {
+					return retList;
+				}
+
+				if (!myHealthDeterminer.shouldMonitor(cache)) {
+					continue;
+				}
+
 				final CacheState state = CacheState.getOrCreate(cache);
 				state.fetchAndUpdate(myHealthDeterminer, fetchCount, errorCount);
 				retList.add(state);
@@ -100,7 +108,11 @@ public class CacheWatcher {
 
 		private void cacheTimePad() {
 			final int t = config.getCacheTimePad();
-			if(t == 0) { return; }
+
+			if (t == 0) {
+				return;
+			}
+
 			try {
 				Thread.sleep(t);
 			} catch (InterruptedException e) {
@@ -117,11 +129,12 @@ public class CacheWatcher {
 					if (crConfig == null) {
 						try {
 							Thread.sleep(config.getHealthPollingInterval());
-						} catch (InterruptedException e) { }
+						} catch (InterruptedException e) {
+						}
 
 						continue;
 					}
-	
+
 					final List<CacheState> states = checkCaches(crConfig);
 
 					boolean waitForFinish = true;
@@ -139,7 +152,8 @@ public class CacheWatcher {
 
 					try {
 						Thread.sleep(Math.max(config.getHealthPollingInterval() - (completedTime - time), 0));
-					} catch (InterruptedException e) { }
+					} catch (InterruptedException e) {
+					}
 
 					itercount.inc();
 
@@ -150,13 +164,14 @@ public class CacheWatcher {
 					queryIntervalActual.set(completedTime - time);
 					queryIntervalDelta.set((completedTime - time) - config.getHealthPollingInterval());
 
-					LOGGER.info("Pool time elapsed: "+mytime);
+					LOGGER.info("Pool time elapsed: " + mytime);
 				} catch (Exception e) {
-					LOGGER.warn(e,e);
+					LOGGER.warn(e, e);
 
 					try {
 						Thread.sleep(100);
-					} catch (InterruptedException ex) { }
+					} catch (InterruptedException ex) {
+					}
 				}
 
 				if (!isActive) {
@@ -171,25 +186,42 @@ public class CacheWatcher {
 		private static final long serialVersionUID = 1L;
 		private final String label;
 		long i = 0;
+
 		public CacheDataModel(final String label) {
 			this.label = label;
-			if(label == null) { super.setObject(null); }
-			else { super.setObject(label + ": "); }
+
+			if (label == null) {
+				super.setObject(null);
+			} else {
+				super.setObject(label + ": ");
+			}
 		}
-		public String getKey() {return label;}
-		public String getValue() { return String.valueOf(i); }
+
+		public String getKey() {
+			return label;
+		}
+
+		public String getValue() {
+			return String.valueOf(i);
+		}
+
 		public void inc() {
-			synchronized(this) {
+			synchronized (this) {
 				i++;
 				this.set(i);
 			}
 		}
+
 		public void setObject(final String o) {
-			if(label == null) { super.setObject(o); }
-			else { super.setObject(label + ": "+o); }
+			if (label == null) {
+				super.setObject(o);
+			} else {
+				super.setObject(label + ": " + o);
+			}
 		}
+
 		public void set(final long arg) {
-			synchronized(this) {
+			synchronized (this) {
 				i = arg;
 				this.setObject(String.valueOf(arg));
 			}
@@ -198,17 +230,20 @@ public class CacheWatcher {
 
 	public void destroy() {
 		LOGGER.warn("CacheWatcher: shutting down ");
-		isActive  = false;
+
+		isActive = false;
 		final long time = System.currentTimeMillis();
+
 		mainThread.interrupt();
 		CacheState.shutdown();
-		while(mainThread.isAlive()) {
+
+		while (mainThread.isAlive()) {
 			try {
 				Thread.sleep(10);
 			} catch (InterruptedException e) {
 			}
 		}
-		LOGGER.warn("Stopped: Termination time: "+(System.currentTimeMillis() - time));	
+		LOGGER.warn("Stopped: Termination time: " + (System.currentTimeMillis() - time));
 	}
 
 	public long getCycleCount() {
@@ -217,6 +252,3 @@ public class CacheWatcher {
 	}
 
 }
-
-
-

--- a/traffic_monitor/src/main/java/com/comcast/cdn/traffic_control/traffic_monitor/health/CacheWatcher.java
+++ b/traffic_monitor/src/main/java/com/comcast/cdn/traffic_control/traffic_monitor/health/CacheWatcher.java
@@ -133,6 +133,7 @@ public class CacheWatcher {
 						} catch (InterruptedException e) {
 						}
 
+						LOGGER.warn("No router config available, skipping health check");
 						continue;
 					}
 
@@ -178,6 +179,7 @@ public class CacheWatcher {
 				}
 
 				if (!isActive) {
+					LOGGER.warn("Not active");
 					return;
 				}
 			}


### PR DESCRIPTION
After lots of testing we found that we can set the health.timepad configuration to 0 and found an improvement by not cancelling already cancelled java future tasks