### PR TITLE
guarantee order of cachegroup fixture db insertion

### DIFF
--- a/traffic_ops/app/lib/Fixtures/Cachegroup.pm
+++ b/traffic_ops/app/lib/Fixtures/Cachegroup.pm
@@ -51,7 +51,9 @@ sub get_definition {
 }
 
 sub all_fixture_names {
-	return keys %definition_for;
+
+	# sort by db id to guarantee insertion order
+	return sort { $definition_for{$a}{using}{id} <=> $definition_for{$b}{using}{id} } keys %definition_for;
 }
 
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
avoids fk constraint violation if fixtures inserted in wrong order