### PR TITLE
make startup more specific

### DIFF
--- a/traffic_ops/etc/init.d/traffic_ops
+++ b/traffic_ops/etc/init.d/traffic_ops
@@ -50,7 +50,7 @@ stopHypnotoad ()
 	echo -e "Shutting down Traffic Ops\n"
 	if [ -e $PIDFILE ]; then
 	_PID=`/bin/cat $PIDFILE`
-	PID=`/bin/ps -ef|awk '/traffic_ops/ {if ($3 == 1) {print $2}}'`
+	PID=`/bin/ps -ef|awk '/traffic_ops\/app\/script\/cdn/ {if ($3 == 1) {print $2}}'`
 		if [ ! -z $PID ] && [ $_PID = $PID ]; then
 		kill -term $PID
 		fi
@@ -77,7 +77,7 @@ restart ()
 status ()
 {
 	_PID=`/bin/cat $PIDFILE`
-	PID=`/bin/ps -ef|awk '/traffic_ops/ {if ($3 == 1) {print $2}}'`
+	PID=`/bin/ps -ef|awk '/traffic_ops\/app\/script\/cdn/ {if ($3 == 1) {print $2}}'`
 	if [ -z $PID ] && [ -z $_PID ]; then
 		echo -e "\nTraffic Ops is offline\n"
 	else

--- a/traffic_ops/etc/init.d/traffic_ops
+++ b/traffic_ops/etc/init.d/traffic_ops
@@ -50,7 +50,7 @@ stopHypnotoad ()
 	echo -e "Shutting down Traffic Ops\n"
 	if [ -e $PIDFILE ]; then
 	_PID=`/bin/cat $PIDFILE`
-	PID=`/bin/ps -ef|awk '/traffic_ops\/app\/script\/cdn/ {if ($3 == 1) {print $2}}'`
+	PID=`/bin/ps -ef|/bin/awk '/traffic_ops\/app\/script\/cdn/ {if ($3 == 1) {print $2}}'`
 		if [ ! -z $PID ] && [ $_PID = $PID ]; then
 		kill -term $PID
 		fi
@@ -77,7 +77,7 @@ restart ()
 status ()
 {
 	_PID=`/bin/cat $PIDFILE`
-	PID=`/bin/ps -ef|awk '/traffic_ops\/app\/script\/cdn/ {if ($3 == 1) {print $2}}'`
+	PID=`/bin/ps -ef|/bin/awk '/traffic_ops\/app\/script\/cdn/ {if ($3 == 1) {print $2}}'`
 	if [ -z $PID ] && [ -z $_PID ]; then
 		echo -e "\nTraffic Ops is offline\n"
 	else


### PR DESCRIPTION
Changes init to match on /traffic_ops\/app\/script\/cdn/  instead of just traffic_ops. This prevents too many results from being returned in the awk when there is a mount point containing the name traffic_ops. 
also changed awk to /bin/awk to be more consistent.  