### PR TITLE
Scripts for Creating and Syncing Traffic Stats Databases

### DIFF
--- a/docs/source/admin/traffic_stats.rst
+++ b/docs/source/admin/traffic_stats.rst
@@ -199,7 +199,7 @@ They are specific for traffic stats and are not meant to be generic to influxdb.
 			- example: ./create_ts_databases -influxUrl=localhost:8086 -replication=3
 
 **sync_ts_databases**
-	This script is used to sync one influxdb environment to another.  Possible use cases are syncing from Production to Development or Syncing a new cluster once brought online.
+	This script is used to sync one influxdb environment to another.  Only data from continuous queries is synced as it is downsampled data and much smaller in size than syncing raw data.  Possible use cases are syncing from Production to Development or Syncing a new cluster once brought online.
 
 	**How to use sync_ts_databases:**
 

--- a/traffic_stats/influxdb_tools/README.txt
+++ b/traffic_stats/influxdb_tools/README.txt
@@ -1,0 +1,48 @@
+InfluxDB_Tools: 
+
+These tools are meant to be used to help a user quickly get new databases and continuous queries setup in influxdb for traffic stats.  
+They are specific for traffic stats and are not meant to be generic to influxdb.
+For more information see: http://traffic-control-cdn.net/docs/latest/admin/traffic_stats.html#influxdb-tools
+
+Pre-Requisites: 
+1. Go 1.4 or later
+2. Influxdb 0.9.4 or later
+3. configured $GOPATH (e.g. export GOPATH=~/go)
+
+Using create_ts_databases.go
+1. Install InfluxDb Client (0.9.4 version)
+	- go get github.com/influxdata/influxdb
+	- cd $GOPATH/src/github.com/influxdata/influxdb
+	- git checkout 0.9.4
+	- go install
+
+2. Build it
+	- go build create_ts_databases.go
+
+3. Run it 
+	- ./create_ts_databases
+	- optional flags:
+		- influxUrl -  The influxdb url and port
+		- replication -  The number of nodes in the cluster
+	- example: ./create_ts_databases -influxUrl=localhost:8086 -replication=3
+
+
+Using sync_ts_databases.go
+1. Install InfluxDb Client (0.9.4 version)
+	- go get github.com/influxdata/influxdb
+	- cd $GOPATH/src/github.com/influxdata/influxdb
+	- git checkout 0.9.4
+	- go install
+
+2. Build it
+	- go build sync_ts_databases.go
+
+3. Run it 
+	- required flags:
+		- sourceUrl - The URL of the source database 
+		- targetUrl - The URL of the target database
+	-optional flags:
+		- database - The database to sync (default = sync all databases)
+		- days - Days in the past to sync (default = sync all data)
+	- example: ./sync_ts_databases -sourceUrl=http://influxdb-production-01.kabletown.net:8086 -targetUrl=http://influxdb-dev-01.kabletown.net:8086 -database=cache_stats -days=7
+

--- a/traffic_stats/influxdb_tools/create_ts_databases.go
+++ b/traffic_stats/influxdb_tools/create_ts_databases.go
@@ -1,0 +1,128 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	influx "github.com/influxdb/influxdb/client/v2"
+)
+
+func main() {
+
+	influxUrl := flag.String("url", "http://localhost:8086", "The influxdb url and port")
+	replication := flag.String("replication", "3", "The number of nodes in the cluster")
+	flag.Parse()
+	fmt.Printf("creating datbases for influxUrl: %v with a replication of %v\n", *influxUrl, *replication)
+
+	client, err := influx.NewHTTPClient(influx.HTTPConfig{
+		Addr: *influxUrl,
+	})
+	if err != nil {
+		fmt.Printf("Error creating influx client: %v", err)
+		panic("could not create influx client")
+	}
+
+	createCacheStats(client, replication)
+	createDailyStats(client, replication)
+	createDeliveryServiceStats(client, replication)
+
+}
+
+func queryDB(client influx.Client, cmd string) (res []influx.Result, err error) {
+	q := influx.Query{
+		Command:  cmd,
+		Database: "",
+	}
+	if response, err := client.Query(q); err == nil {
+		if response.Error() != nil {
+			return res, response.Error()
+		}
+		res = response.Results
+	}
+	return res, nil
+}
+
+func createCacheStats(client influx.Client, replication *string) {
+	db := "cache_stats"
+	createDatabase(client, db)
+	createRetentionPolicy(client, db, "daily", "26h", replication, true)
+	createRetentionPolicy(client, db, "monthly", "30d", replication, false)
+	createRetentionPolicy(client, db, "indefinite", "INF", replication, false)
+	createContinuousQuery(client, "bandwidth_hostname_1min", "CREATE CONTINUOUS QUERY bandwidth_hostname_1min ON cache_stats BEGIN SELECT mean(value) AS \"value\" INTO \"cache_stats\".\"monthly\".\"bandwidth.hostname.1min\" FROM \"cache_stats\".\"daily\".bandwidth GROUP BY time(1m), hostname, cdn END")
+	createContinuousQuery(client, "connections_hostname_1min", "CREATE CONTINUOUS QUERY connections_hostname_1min ON cache_stats BEGIN SELECT mean(value) AS \"value\" INTO \"cache_stats\".\"monthly\".\"connections.hostname.1min\" FROM \"cache_stats\".\"daily\".\"ats.proxy.process.http.current_client_connections\" GROUP BY time(1m), hostname, cdn END")
+	createContinuousQuery(client, "bandwidth_cdn_1min", "CREATE CONTINUOUS QUERY bandwidth_cdn_1min ON cache_stats BEGIN SELECT sum(value) AS \"value\" INTO \"cache_stats\".\"monthly\".\"bandwidth.cdn.1min\" FROM \"cache_stats\".\"monthly\".\"bandwidth.hostname.1min\" GROUP BY time(1m), cdn END")
+	createContinuousQuery(client, "connections_cdn_1min", "CREATE CONTINUOUS QUERY connections_cdn_1min ON cache_stats BEGIN SELECT sum(value) AS \"value\" INTO \"cache_stats\".\"monthly\".\"connections.cdn.1min\" FROM \"cache_stats\".\"monthly\".\"connections.hostname.1min\" GROUP BY time(1m), cdn END")
+}
+
+func createDeliveryServiceStats(client influx.Client, replication *string) {
+	db := "deliveryservice_stats"
+	createDatabase(client, db)
+	createRetentionPolicy(client, db, "daily", "26h", replication, true)
+	createRetentionPolicy(client, db, "monthly", "30d", replication, false)
+	createRetentionPolicy(client, db, "indefinite", "INF", replication, false)
+	createContinuousQuery(client, "tps_2xx_ds_1min", "CREATE CONTINUOUS QUERY tps_2xx_ds_1min ON deliveryservice_stats BEGIN SELECT mean(value) AS \"value\" INTO \"deliveryservice_stats\".\"monthly\".\"tps_2xx.ds.1min\" FROM \"deliveryservice_stats\".\"daily\".tps_2xx WHERE cachegroup = 'total' GROUP BY time(1m), * END")
+	createContinuousQuery(client, "tps_3xx_ds_1min", "CREATE CONTINUOUS QUERY tps_3xx_ds_1min ON deliveryservice_stats BEGIN SELECT mean(value) AS \"value\" INTO \"deliveryservice_stats\".\"monthly\".\"tps_3xx.ds.1min\" FROM \"deliveryservice_stats\".\"daily\".tps_3xx WHERE cachegroup = 'total' GROUP BY time(1m), * END")
+	createContinuousQuery(client, "tps_4xx_ds_1min", "CREATE CONTINUOUS QUERY tps_4xx_ds_1min ON deliveryservice_stats BEGIN SELECT mean(value) AS \"value\" INTO \"deliveryservice_stats\".\"monthly\".\"tps_4xx.ds.1min\" FROM \"deliveryservice_stats\".\"daily\".tps_4xx WHERE cachegroup = 'total' GROUP BY time(1m), * END")
+	createContinuousQuery(client, "tps_5xx_ds_1min", "CREATE CONTINUOUS QUERY tps_5xx_ds_1min ON deliveryservice_stats BEGIN SELECT mean(value) AS \"value\" INTO \"deliveryservice_stats\".\"monthly\".\"tps_5xx.ds.1min\" FROM \"deliveryservice_stats\".\"daily\".tps_5xx WHERE cachegroup = 'total' GROUP BY time(1m), * END")
+	createContinuousQuery(client, "tps_total_ds_1min", "CREATE CONTINUOUS QUERY tps_total_ds_1min ON deliveryservice_stats BEGIN SELECT mean(value) AS \"value\" INTO \"deliveryservice_stats\".\"monthly\".\"tps_total.ds.1min\" FROM \"deliveryservice_stats\".\"daily\".tps_total WHERE cachegroup = 'total' GROUP BY time(1m), * END")
+	createContinuousQuery(client, "kbps_ds_1min", "CREATE CONTINUOUS QUERY kbps_ds_1min ON deliveryservice_stats BEGIN SELECT mean(value) AS \"value\" INTO \"deliveryservice_stats\".\"monthly\".\"kbps.ds.1min\" FROM \"deliveryservice_stats\".\"daily\".kbps WHERE cachegroup = 'total' GROUP BY time(1m), * END")
+	createContinuousQuery(client, "kbps_cg_1min", "CREATE CONTINUOUS QUERY kbps_cg_1min ON deliveryservice_stats BEGIN SELECT mean(value) AS \"value\" INTO \"deliveryservice_stats\".\"monthly\".\"kbps.cg.1min\" FROM \"deliveryservice_stats\".\"daily\".kbps WHERE cachegroup != 'total' GROUP BY time(1m), * END")
+	createContinuousQuery(client, "max_kbps_ds_1day", "CREATE CONTINUOUS QUERY max_kbps_ds_1day ON deliveryservice_stats BEGIN SELECT max(value) AS \"value\" INTO \"deliveryservice_stats\".\"indefinite\".\"max.kbps.ds.1day\" FROM \"deliveryservice_stats\".\"monthly\".\"kbps.ds.1min\" GROUP BY time(1d), deliveryservice, cdn END")
+
+}
+
+func createDailyStats(client influx.Client, replication *string) {
+	db := "daily_stats"
+	createDatabase(client, db)
+	createRetentionPolicy(client, db, "indefinite", "INF", replication, true)
+
+}
+
+func createDatabase(client influx.Client, db string) {
+	_, err := queryDB(client, fmt.Sprintf("CREATE DATABASE %s", db))
+	if err != nil {
+		fmt.Printf("An error occured creating the %v database: %v\n", db, err)
+		return
+	}
+	fmt.Println("Successfully created database: ", db)
+}
+
+func createRetentionPolicy(client influx.Client, db string, name string, duration string, replication *string, isDefault bool) {
+	qString := fmt.Sprintf("CREATE RETENTION POLICY %s ON %s DURATION %s REPLICATION %s", name, db, duration, *replication)
+	if isDefault {
+		qString += " DEFAULT"
+	}
+	_, err := queryDB(client, qString)
+	if err != nil {
+		fmt.Printf("An error occured creating the retention policy %s on database: %s:  %v\n", name, db, err)
+		return
+	}
+	fmt.Printf("Successfully created retention policy %s for database: %s\n", name, db)
+}
+
+func createContinuousQuery(client influx.Client, name string, query string) {
+	_, err := queryDB(client, query)
+	if err != nil {
+		fmt.Printf("An error occured creating continuous query %s: %v\n", name, err)
+		return
+	}
+	fmt.Println("Successfully created continuous query ", name)
+}

--- a/traffic_stats/influxdb_tools/create_ts_databases.go
+++ b/traffic_stats/influxdb_tools/create_ts_databases.go
@@ -22,7 +22,8 @@ package main
 import (
 	"flag"
 	"fmt"
-	influx "github.com/influxdb/influxdb/client/v2"
+	influx "github.com/influxdb/influxdb/client"
+	"net/url"
 )
 
 func main() {
@@ -31,18 +32,18 @@ func main() {
 	replication := flag.String("replication", "3", "The number of nodes in the cluster")
 	flag.Parse()
 	fmt.Printf("creating datbases for influxUrl: %v with a replication of %v\n", *influxUrl, *replication)
-
-	client, err := influx.NewHTTPClient(influx.HTTPConfig{
-		Addr: *influxUrl,
+	iu, _ := url.Parse(*influxUrl)
+	client, err := influx.NewClient(influx.Config{
+		URL: *iu,
 	})
 	if err != nil {
 		fmt.Printf("Error creating influx client: %v", err)
 		panic("could not create influx client")
 	}
 
-	createCacheStats(client, replication)
-	createDailyStats(client, replication)
-	createDeliveryServiceStats(client, replication)
+	createCacheStats(*client, replication)
+	createDailyStats(*client, replication)
+	createDeliveryServiceStats(*client, replication)
 
 }
 

--- a/traffic_stats/influxdb_tools/sync_ts_databases.go
+++ b/traffic_stats/influxdb_tools/sync_ts_databases.go
@@ -1,0 +1,425 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	influx "github.com/influxdb/influxdb/client"
+	"net/url"
+	"os"
+	"time"
+)
+
+type cacheStats struct {
+	t        string //time
+	value    float64
+	cdn      string
+	hostname string
+}
+type deliveryServiceStats struct {
+	t               string //time
+	value           float64
+	cdn             string
+	deliveryService string
+	cacheGroup      string
+}
+type dailyStats struct {
+	t               string //time
+	cdn             string
+	deliveryService string
+	value           float64
+}
+
+func main() {
+
+	sourceUrl := flag.String("sourceUrl", "http://server1.kabletown.net:8086", "The influxdb url and port")
+	targetUrl := flag.String("targetUrl", "http://server2.kabletown.net:8086", "The influxdb url and port")
+	database := flag.String("database", "all", "Sync a specific database")
+	days := flag.Int("days", 0, "Number of days in the past to sync (today - x days), 0 is all")
+	flag.Parse()
+	fmt.Printf("syncing %v to %v for %v database(s) for the past %v day(s)\n", *sourceUrl, *targetUrl, *database, *days)
+	su, _ := url.Parse(*sourceUrl)
+	sourceClient, err := influx.NewClient(influx.Config{
+		URL: *su,
+	})
+	if err != nil {
+		fmt.Printf("Error creating influx sourceClient: %v\n", err)
+		os.Exit(1)
+	}
+	tu, _ := url.Parse(*targetUrl)
+	targetClient, err := influx.NewClient(influx.Config{
+		URL: *tu,
+	})
+	if err != nil {
+		fmt.Printf("Error creating influx targetClient: %v\n", err)
+		os.Exit(1)
+	}
+	chSize := 1
+	if *database == "all" {
+		chSize = 3
+	}
+
+	ch := make(chan string)
+
+	switch *database {
+	case "all":
+		go syncCsDb(ch, *sourceClient, *targetClient, *days)
+		go syncDsDb(ch, *sourceClient, *targetClient, *days)
+		go syncDailyDb(ch, *sourceClient, *targetClient, *days)
+	case "cache_stats":
+		go syncCsDb(ch, *sourceClient, *targetClient, *days)
+	case "deliveryservice_stats":
+		go syncDsDb(ch, *sourceClient, *targetClient, *days)
+	case "daily_stats":
+		go syncDailyDb(ch, *sourceClient, *targetClient, *days)
+	}
+
+	for i := 1; i <= chSize; i++ {
+		fmt.Println(<-ch)
+	}
+
+	fmt.Println("Traffic Stats has been synced!")
+}
+
+func syncCsDb(ch chan string, sourceClient influx.Client, targetClient influx.Client, days int) {
+	db := "cache_stats"
+	fmt.Printf("Syncing %s database...\n", db)
+	stats := [...]string{
+		"bandwidth.cdn.1min",
+		"connections.cdn.1min",
+	}
+	for _, statName := range stats {
+		fmt.Printf("Syncing %s database with %s \n", db, statName)
+		syncCacheStat(sourceClient, targetClient, statName, days)
+	}
+	ch <- fmt.Sprintf("Done syncing %s!\n", db)
+}
+
+func syncDsDb(ch chan string, sourceClient influx.Client, targetClient influx.Client, days int) {
+	db := "deliveryservice_stats"
+	fmt.Printf("Syncing %s database...\n", db)
+	stats := [...]string{
+		"kbps.ds.1min",
+		"max.kbps.ds.1day",
+		"tps.ds.1min",
+		"tps_2xx.ds.1min",
+		"tps_3xx.ds.1min",
+		"tps_4xx.ds.1min",
+		"tps_5xx.ds.1min",
+		"tps_total.ds.1min",
+	}
+	for _, statName := range stats {
+		fmt.Printf("Syncing %s database with %s\n", db, statName)
+		syncDeliveryServiceStat(sourceClient, targetClient, statName, days)
+	}
+	ch <- fmt.Sprintf("Done syncing %s!\n", db)
+}
+
+func syncDailyDb(ch chan string, sourceClient influx.Client, targetClient influx.Client, days int) {
+	db := "daily_stats"
+	fmt.Printf("Syncing %s database...\n", db)
+	stats := [...]string{
+		"daily_bytesserved",
+		"daily_maxgbps",
+	}
+
+	for _, statName := range stats {
+		fmt.Printf("Syncing %s database with %s\n", db, statName)
+		syncDailyStat(sourceClient, targetClient, statName, days)
+	}
+	ch <- fmt.Sprintf("Done syncing %s!\n", db)
+
+}
+
+func queryDB(client influx.Client, cmd string, db string) (res []influx.Result, err error) {
+	q := influx.Query{
+		Command:  cmd,
+		Database: db,
+	}
+	if response, err := client.Query(q); err == nil {
+		if response.Error() != nil {
+			return res, response.Error()
+		}
+		res = response.Results
+	}
+	return res, nil
+}
+
+func syncCacheStat(sourceClient influx.Client, targetClient influx.Client, statName string, days int) {
+	//get records from source DB
+	db := "cache_stats"
+	var pts []influx.Point
+
+	queryString := fmt.Sprintf("select time, cdn, hostname, value from \"monthly\".\"%s\"", statName)
+	if days > 0 {
+		queryString += fmt.Sprintf(" where time > now() - %dd", days)
+	}
+	fmt.Println("queryString ", queryString)
+	res, err := queryDB(sourceClient, queryString, db)
+	if err != nil {
+		fmt.Println("An error occured getting %s records from sourceDb", statName)
+		return
+	}
+	sourceStats := getCacheStats(res)
+
+	//get values from target DB
+	targetRes, err := queryDB(targetClient, queryString, db)
+	if err != nil {
+		fmt.Printf("An error occured getting %s record from target db: %v\n", statName, err)
+		return
+	}
+	targetStats := getCacheStats(targetRes)
+
+	for ssKey := range sourceStats {
+		ts := targetStats[ssKey]
+		ss := sourceStats[ssKey]
+		if ts.value > ss.value {
+			fmt.Printf("target value %v is at least equal to source value %v\n", ts.value, ss.value)
+			continue //target value is bigger so leave it
+		}
+		statTime, _ := time.Parse(time.RFC3339, ss.t)
+		tags := map[string]string{"cdn": ss.cdn}
+
+		pts = append(pts,
+			influx.Point{
+				Measurement: statName,
+				Tags:        tags,
+				Fields: map[string]interface{}{
+					"value": ss.value,
+				},
+				Time:      statTime,
+				Precision: "ms",
+			},
+		)
+
+	}
+	bps := influx.BatchPoints{
+		Points:          pts,
+		Database:        "cache_stats",
+		RetentionPolicy: "monthly",
+	}
+	_, err = targetClient.Write(bps)
+	if err != nil {
+		fmt.Printf("An error occured writing points: %v\n", err)
+	}
+}
+
+func syncDeliveryServiceStat(sourceClient influx.Client, targetClient influx.Client, statName string, days int) {
+
+	db := "deliveryservice_stats"
+	var pts []influx.Point
+
+	queryString := fmt.Sprintf("select time, cachegroup, cdn, deliveryservice, value from \"monthly\".\"%s\"", statName)
+	if days > 0 {
+		queryString += fmt.Sprintf(" where time > now() - %dd", days)
+	}
+	fmt.Println("queryString ", queryString)
+	res, err := queryDB(sourceClient, queryString, db)
+	if err != nil {
+		fmt.Printf("An error occured getting %s records from sourceDb: %v\n", statName, err)
+		return
+	}
+	sourceStats := getDeliveryServiceStats(res)
+	// get value from target DB
+	targetRes, err := queryDB(targetClient, queryString, db)
+	if err != nil {
+		fmt.Printf("An error occured getting %s record from target db: %v\n", statName, err)
+		return
+	}
+	targetStats := getDeliveryServiceStats(targetRes)
+
+	for ssKey := range sourceStats {
+		ts := targetStats[ssKey]
+		ss := sourceStats[ssKey]
+		if ts.value > ss.value {
+			fmt.Printf("target value %v is at least equal to source value %v\n", ts.value, ss.value)
+			continue //target value is bigger so leave it
+		}
+		statTime, _ := time.Parse(time.RFC3339, ss.t)
+		tags := map[string]string{
+			"cdn":             ss.cdn,
+			"cachegroup":      ss.cacheGroup,
+			"deliveryservice": ss.deliveryService,
+		}
+		pts = append(pts,
+			influx.Point{
+				Measurement: statName,
+				Tags:        tags,
+				Fields: map[string]interface{}{
+					"value": ss.value,
+				},
+				Time:      statTime,
+				Precision: "ms",
+			},
+		)
+
+	}
+	bps := influx.BatchPoints{
+		Points:          pts,
+		Database:        "deliveryservice_stats",
+		RetentionPolicy: "monthly",
+	}
+	_, err = targetClient.Write(bps)
+	if err != nil {
+		fmt.Printf("An error occured writing points: %v\n", err)
+	}
+}
+func syncDailyStat(sourceClient influx.Client, targetClient influx.Client, statName string, days int) {
+	//get records from source DB
+	db := "daily_stats"
+	var pts []influx.Point
+
+	queryString := fmt.Sprintf("select time, cdn, deliveryservice, value from \"%s\"", statName)
+	if days > 0 {
+		queryString += fmt.Sprintf(" where time > now() - %dd", days)
+	}
+	res, err := queryDB(sourceClient, queryString, db)
+	if err != nil {
+		fmt.Printf("An error occured getting %s records from sourceDb: %v\n", statName, err)
+		return
+	}
+	sourceStats := getDailyStats(res)
+	// get value from target DB
+	targetRes, err := queryDB(targetClient, queryString, db)
+	if err != nil {
+		fmt.Printf("An error occured getting %s record from target db: %v\n", statName, err)
+		return
+	}
+	targetStats := getDailyStats(targetRes)
+
+	for ssKey := range sourceStats {
+		ts := targetStats[ssKey]
+		ss := sourceStats[ssKey]
+		if ts.value >= ss.value {
+			fmt.Printf("target value %v is at least equal to source value %v\n", ts.value, ss.value)
+			continue //target value is bigger or equal so leave it
+		}
+		statTime, _ := time.Parse(time.RFC3339, ss.t)
+		tags := map[string]string{
+			"cdn":             ss.cdn,
+			"deliveryservice": ss.deliveryService,
+		}
+		pts = append(pts,
+			influx.Point{
+				Measurement: statName,
+				Tags:        tags,
+				Fields: map[string]interface{}{
+					"value": ss.value,
+				},
+				Time:      statTime,
+				Precision: "ms",
+			},
+		)
+	}
+	bps := influx.BatchPoints{
+		Points:   pts,
+		Database: "daily_stats",
+	}
+	_, err = targetClient.Write(bps)
+	if err != nil {
+		fmt.Printf("An error occured writing points: %v\n", err)
+	}
+}
+
+func getCacheStats(res []influx.Result) map[string]cacheStats {
+	response := make(map[string]cacheStats)
+	if res != nil && len(res[0].Series) > 0 {
+		for _, row := range res[0].Series {
+			for _, record := range row.Values {
+				data := new(cacheStats)
+				t := record[0].(string)
+				data.t = t
+				data.cdn = record[1].(string)
+				var err error
+				data.value, err = record[3].(json.Number).Float64()
+				if err != nil {
+					fmt.Println("Couldn't parse value from record %v\n", record)
+					continue
+				}
+				key := data.t + data.cdn + data.hostname
+				response[key] = *data
+			}
+		}
+	}
+	return response
+}
+
+func getDeliveryServiceStats(res []influx.Result) map[string]deliveryServiceStats {
+	response := make(map[string]deliveryServiceStats)
+	if len(res[0].Series) > 0 {
+		for _, row := range res[0].Series {
+			for _, record := range row.Values {
+				data := new(deliveryServiceStats)
+				data.t = record[0].(string)
+				if record[1] != nil {
+					data.cacheGroup = record[1].(string)
+				}
+				data.cdn = record[2].(string)
+				if record[3] != nil {
+					data.deliveryService = record[3].(string)
+				}
+				var err error
+				data.value, err = record[4].(json.Number).Float64()
+				if err != nil {
+					fmt.Println("Couldn't parse value from record %v\n", record)
+					continue
+				}
+				key := data.t + data.cacheGroup + data.cdn + data.deliveryService
+				response[key] = *data
+			}
+		}
+	}
+	return response
+}
+
+func getDailyStats(res []influx.Result) map[string]dailyStats {
+	response := make(map[string]dailyStats)
+	if len(res[0].Series) > 0 {
+		for _, row := range res[0].Series {
+			for _, record := range row.Values {
+				data := new(dailyStats)
+				data.t = record[0].(string)
+				data.cdn = record[1].(string)
+				data.deliveryService = record[2].(string)
+				var err error
+				data.value, err = record[3].(json.Number).Float64()
+				if err != nil {
+					fmt.Println("Couldn't parse value from record %v\n", record)
+					continue
+				}
+				key := data.t + data.cdn + data.deliveryService
+				response[key] = *data
+			}
+		}
+	}
+	return response
+}
+
+func writeStats(pts []influx.Point, client influx.Client, db string) error {
+	bps := influx.BatchPoints{
+		Points:   pts,
+		Database: db,
+	}
+	var err error
+	_, err = client.Write(bps)
+	return err
+}

--- a/traffic_stats/traffic_stats.cfg
+++ b/traffic_stats/traffic_stats.cfg
@@ -10,5 +10,5 @@
 	"dailySummaryPollingInterval": 300,
 	"cacheRetentionPolicy": "daily",
 	"dsRetentionPolicy": "daily",
-	"dailySummaryRetentionPolicy": "daily_stats"
+	"dailySummaryRetentionPolicy": "indefinite"
 }


### PR DESCRIPTION
Added influxdb_tools which contains go scripts: create_ts_databases.go and sync_ts_databases.go.

**create_ts_databases.go** creates all databases, retention_policies, and continuous queries used by traffic_stats.  The continuous queries help make the grafana graphs much faster and allow to easily keep more than a days worth of data. 

**sync_ts_databases.go** provides the ability to sync Traffic Stats continuous query data from one environment to another.  

