### PR TITLE
use correct var names in CacheGroup view template

### DIFF
--- a/traffic_ops/app/templates/cachegroup/view.html.ep
+++ b/traffic_ops/app/templates/cachegroup/view.html.ep
@@ -33,19 +33,19 @@ $(function () {
 						<table width=100%>
 							<tr>
 								<td>Name</td>
-								<td class="editable" id="name"><%= $loc_data->name %></td>
+								<td class="editable" id="name"><%= $cg_data->name %></td>
 							</tr>
 							<tr>
 								<td>Short Name</td>
-								<td class="editable" id="short_name"><%= $loc_data->short_name %></td>
+								<td class="editable" id="short_name"><%= $cg_data->short_name %></td>
 							</tr>
 							<tr>
 								<td>Latitude</td>
-								<td class="editable" id="latitude"><%= $loc_data->latitude %></td>
+								<td class="editable" id="latitude"><%= $cg_data->latitude %></td>
 							</tr>
 							<tr>
 								<td>Longitude</td>
-								<td class="editable" id="longitude"><%= $loc_data->longitude %></td>
+								<td class="editable" id="longitude"><%= $cg_data->longitude %></td>
 							</tr>
 							<tr>
 								<td>Parent Location</td>
@@ -53,7 +53,7 @@ $(function () {
 							</tr>
 							<tr>
 								<td>Type</td>
-								<td class="editable" id="type"><%= $loc_data->type->name %></td>
+								<td class="editable" id="type"><%= $cg_data->type->name %></td>
 							</tr>
 % if (stash 'extra_vars') {
 							<tr>
@@ -64,7 +64,7 @@ $(function () {
 								<td>(only parameters unique to this cache group can be edited here,<br />and parameters can only be added/removed to a cache group by the system administrator):</td>
 							</tr>
 % }
-% foreach my $var ( @{ $location_vars } ) {
+% foreach my $var ( @{ $cachegroup_vars } ) {
 							<tr>
 								<td><%= $var->{name} %> </td>
 								<td><%= $var->{value} %></td>


### PR DESCRIPTION
fixes #934 .   view template was referencing old variable names.   Will only happen when user has only read-only