### PR TITLE
Speed up display of the Servers Page

### DIFF
--- a/traffic_ops/app/lib/UI/Cdn.pm
+++ b/traffic_ops/app/lib/UI/Cdn.pm
@@ -320,6 +320,10 @@ sub aserver {
 	my $self          = shift;
 	my $server_select = shift;
 	my %data          = ( "aaData" => undef );
+	my $pparam =
+		$self->db->resultset('ProfileParameter')->search( { -and => [ 'parameter.name' => 'server_graph_url', 'profile.name' => 'GLOBAL' ] },
+		{ prefetch => [ 'parameter', 'profile' ] } )->single();
+	my $srvg_url = defined($pparam) ? $pparam->parameter->value : '';
 
 	my $rs = $self->db->resultset('Server')->search( undef, { prefetch => [ 'cdn', 'cachegroup', 'type', 'profile', 'status', 'phys_location' ] } );
 	while ( my $row = $rs->next ) {
@@ -333,10 +337,6 @@ sub aserver {
 			my $img     = "";
 
 			if ( $row->type->name eq "MID" || $row->type->name eq "EDGE" ) {
-				my $pparam =
-					$self->db->resultset('ProfileParameter')->search( { -and => [ 'parameter.name' => 'server_graph_url', 'profile.name' => 'GLOBAL' ] },
-					{ prefetch => [ 'parameter', 'profile' ] } )->single();
-				my $srvg_url = defined($pparam) ? $pparam->parameter->value : '';
 				$aux_url = $srvg_url . $row->host_name;
 				$img     = "graph.png";
 			}


### PR DESCRIPTION
The Servers Page was querying the DB for the URL of graphing server once for each server to display the link for the graph for that server. This change just makes it do the lookup once. 