### PR TITLE
use ref for hash value

### DIFF
--- a/traffic_ops/app/lib/UI/Topology.pm
+++ b/traffic_ops/app/lib/UI/Topology.pm
@@ -280,7 +280,7 @@ sub gen_crconfig_json {
 	my $regexps;
 	my $rs_ds = $self->db->resultset('Deliveryservice')->search(
 		{
-			'me.profile' => { -in => @{ $profile_cache->{'CCR'} } },
+			'me.profile' => { -in => \@{ $profile_cache->{'CCR'} } },
 			'active'     => 1
 		},
 		{ prefetch => [ 'deliveryservice_servers', 'deliveryservice_regexes', 'type' ] }


### PR DESCRIPTION
Fixes #944.   An even number of matching profiles caused "Odd number of elements..." warning which led to  incorrect DBIX query.

This should be pulled into a new 1.3.0-RC?