### PR TITLE
Updated Traffic Stats to use v2 version of Influxdb Client

### DIFF
--- a/docs/source/admin/traffic_stats.rst
+++ b/docs/source/admin/traffic_stats.rst
@@ -31,7 +31,10 @@ Installation
 
 **Installing InfluxDB:**
 
+	**As of Traffic Stats 1.4.0, InfluxDb 0.9.6 or higher is required.  For InfluxDb versions less than 0.9.6 use Traffic Stats 1.3.0**
+
 	In order to store traffic stats data you will need to install InfluxDB.  It is recommended InfluxDB be installed in a 3 server cluster; VMs are acceptable. The documentation for installing InfluxDB can be found on the InfluxDB `website <https://influxdb.com/docs/v0.9/introduction/installation.html>`_.
+
 
 **Installing Grafana:**
 
@@ -60,7 +63,7 @@ Configuration
 
 **Configuring InfluxDB:**
 
-	It is HIGHLY recommended that InfluxDB be configured for clustering.  Documentation on clustering configuration can be found on the clustering page of the `InfluxDB Website <https://influxdb.com/docs/v0.9/concepts/clustering.html>`_.
+	It is HIGHLY recommended that InfluxDB be configured for clustering.  Documentation on clustering configuration can be found on the clustering page of the `InfluxDB Website <https://docs.influxdata.com/influxdb/v0.9/guides/clustering/>`_.
 
 	Once InfluxDB is installed and clustering is configured, Databases and Retention Policies need to be created.  Traffic Stats writes to three different databases: cache_stats, deliveryservice_stats, and daily_stats.  More information about the databases and what data is stored in each can be found on the `overview <../overview/traffic_stats.html>`_ page.
 

--- a/traffic_stats/influxdb_tools/create_ts_databases.go
+++ b/traffic_stats/influxdb_tools/create_ts_databases.go
@@ -17,22 +17,23 @@ specific language governing permissions and limitations
 under the License.
 */
 
-package main
+package create_ts_databases
 
 import (
 	"flag"
 	"fmt"
-	influx "github.com/influxdb/influxdb/client"
 	"net/url"
+
+	influx "github.com/influxdb/influxdb/client"
 )
 
 func main() {
 
-	influxUrl := flag.String("url", "http://localhost:8086", "The influxdb url and port")
+	influxURL := flag.String("url", "http://localhost:8086", "The influxdb url and port")
 	replication := flag.String("replication", "3", "The number of nodes in the cluster")
 	flag.Parse()
-	fmt.Printf("creating datbases for influxUrl: %v with a replication of %v\n", *influxUrl, *replication)
-	iu, _ := url.Parse(*influxUrl)
+	fmt.Printf("creating datbases for influxUrl: %v with a replication of %v\n", *influxURL, *replication)
+	iu, _ := url.Parse(*influxURL)
 	client, err := influx.NewClient(influx.Config{
 		URL: *iu,
 	})

--- a/traffic_stats/influxdb_tools/sync_ts_databases.go
+++ b/traffic_stats/influxdb_tools/sync_ts_databases.go
@@ -17,16 +17,17 @@ specific language governing permissions and limitations
 under the License.
 */
 
-package main
+package sync_ts_databases
 
 import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	influx "github.com/influxdb/influxdb/client"
 	"net/url"
 	"os"
 	"time"
+
+	influx "github.com/influxdb/influxdb/client"
 )
 
 type cacheStats struct {

--- a/traffic_stats/influxdb_tools/sync_ts_databases.go
+++ b/traffic_stats/influxdb_tools/sync_ts_databases.go
@@ -277,14 +277,13 @@ func syncDeliveryServiceStat(sourceClient influx.Client, targetClient influx.Cli
 	targetClient.Write(bps)
 }
 func syncDailyStat(sourceClient influx.Client, targetClient influx.Client, statName string, days int) {
-	//get records from source DB
+
 	db := "daily_stats"
 	bps, _ := influx.NewBatchPoints(influx.BatchPointsConfig{
-		Database:        db,
-		Precision:       "ms",
-		RetentionPolicy: "monthly",
+		Database:  db,
+		Precision: "s",
 	})
-
+	//get records from source DB
 	queryString := fmt.Sprintf("select time, cdn, deliveryservice, value from \"%s\"", statName)
 	if days > 0 {
 		queryString += fmt.Sprintf(" where time > now() - %dd", days)

--- a/traffic_stats/influxdb_tools/sync_ts_databases.go
+++ b/traffic_stats/influxdb_tools/sync_ts_databases.go
@@ -17,17 +17,16 @@ specific language governing permissions and limitations
 under the License.
 */
 
-package sync_ts_databases
+package main
 
 import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"net/url"
 	"os"
 	"time"
 
-	influx "github.com/influxdb/influxdb/client"
+	influx "github.com/influxdb/influxdb/client/v2"
 )
 
 type cacheStats struct {
@@ -52,23 +51,21 @@ type dailyStats struct {
 
 func main() {
 
-	sourceUrl := flag.String("sourceUrl", "http://server1.kabletown.net:8086", "The influxdb url and port")
-	targetUrl := flag.String("targetUrl", "http://server2.kabletown.net:8086", "The influxdb url and port")
+	sourceURL := flag.String("sourceUrl", "http://server1.kabletown.net:8086", "The influxdb url and port")
+	targetURL := flag.String("targetUrl", "http://server2.kabletown.net:8086", "The influxdb url and port")
 	database := flag.String("database", "all", "Sync a specific database")
 	days := flag.Int("days", 0, "Number of days in the past to sync (today - x days), 0 is all")
 	flag.Parse()
-	fmt.Printf("syncing %v to %v for %v database(s) for the past %v day(s)\n", *sourceUrl, *targetUrl, *database, *days)
-	su, _ := url.Parse(*sourceUrl)
-	sourceClient, err := influx.NewClient(influx.Config{
-		URL: *su,
+	fmt.Printf("syncing %v to %v for %v database(s) for the past %v day(s)\n", *sourceURL, *targetURL, *database, *days)
+	sourceClient, err := influx.NewHTTPClient(influx.HTTPConfig{
+		Addr: *sourceURL,
 	})
 	if err != nil {
 		fmt.Printf("Error creating influx sourceClient: %v\n", err)
 		os.Exit(1)
 	}
-	tu, _ := url.Parse(*targetUrl)
-	targetClient, err := influx.NewClient(influx.Config{
-		URL: *tu,
+	targetClient, err := influx.NewHTTPClient(influx.HTTPConfig{
+		Addr: *targetURL,
 	})
 	if err != nil {
 		fmt.Printf("Error creating influx targetClient: %v\n", err)
@@ -83,15 +80,15 @@ func main() {
 
 	switch *database {
 	case "all":
-		go syncCsDb(ch, *sourceClient, *targetClient, *days)
-		go syncDsDb(ch, *sourceClient, *targetClient, *days)
-		go syncDailyDb(ch, *sourceClient, *targetClient, *days)
+		go syncCsDb(ch, sourceClient, targetClient, *days)
+		go syncDsDb(ch, sourceClient, targetClient, *days)
+		go syncDailyDb(ch, sourceClient, targetClient, *days)
 	case "cache_stats":
-		go syncCsDb(ch, *sourceClient, *targetClient, *days)
+		go syncCsDb(ch, sourceClient, targetClient, *days)
 	case "deliveryservice_stats":
-		go syncDsDb(ch, *sourceClient, *targetClient, *days)
+		go syncDsDb(ch, sourceClient, targetClient, *days)
 	case "daily_stats":
-		go syncDailyDb(ch, *sourceClient, *targetClient, *days)
+		go syncDailyDb(ch, sourceClient, targetClient, *days)
 	}
 
 	for i := 1; i <= chSize; i++ {
@@ -168,7 +165,11 @@ func queryDB(client influx.Client, cmd string, db string) (res []influx.Result, 
 func syncCacheStat(sourceClient influx.Client, targetClient influx.Client, statName string, days int) {
 	//get records from source DB
 	db := "cache_stats"
-	var pts []influx.Point
+	bps, _ := influx.NewBatchPoints(influx.BatchPointsConfig{
+		Database:        db,
+		Precision:       "ms",
+		RetentionPolicy: "monthly",
+	})
 
 	queryString := fmt.Sprintf("select time, cdn, hostname, value from \"monthly\".\"%s\"", statName)
 	if days > 0 {
@@ -177,7 +178,7 @@ func syncCacheStat(sourceClient influx.Client, targetClient influx.Client, statN
 	fmt.Println("queryString ", queryString)
 	res, err := queryDB(sourceClient, queryString, db)
 	if err != nil {
-		fmt.Println("An error occured getting %s records from sourceDb", statName)
+		fmt.Printf("An error occured getting %s records from sourceDb\n", statName)
 		return
 	}
 	sourceStats := getCacheStats(res)
@@ -199,35 +200,32 @@ func syncCacheStat(sourceClient influx.Client, targetClient influx.Client, statN
 		}
 		statTime, _ := time.Parse(time.RFC3339, ss.t)
 		tags := map[string]string{"cdn": ss.cdn}
-
-		pts = append(pts,
-			influx.Point{
-				Measurement: statName,
-				Tags:        tags,
-				Fields: map[string]interface{}{
-					"value": ss.value,
-				},
-				Time:      statTime,
-				Precision: "ms",
-			},
+		fields := map[string]interface{}{
+			"value": ss.value,
+		}
+		pt, err := influx.NewPoint(
+			statName,
+			tags,
+			fields,
+			statTime,
 		)
-
+		if err != nil {
+			fmt.Printf("error adding creating point for %v...%v\n", statName, err)
+			continue
+		}
+		bps.AddPoint(pt)
 	}
-	bps := influx.BatchPoints{
-		Points:          pts,
-		Database:        "cache_stats",
-		RetentionPolicy: "monthly",
-	}
-	_, err = targetClient.Write(bps)
-	if err != nil {
-		fmt.Printf("An error occured writing points: %v\n", err)
-	}
+	targetClient.Write(bps)
 }
 
 func syncDeliveryServiceStat(sourceClient influx.Client, targetClient influx.Client, statName string, days int) {
 
 	db := "deliveryservice_stats"
-	var pts []influx.Point
+	bps, _ := influx.NewBatchPoints(influx.BatchPointsConfig{
+		Database:        db,
+		Precision:       "ms",
+		RetentionPolicy: "monthly",
+	})
 
 	queryString := fmt.Sprintf("select time, cachegroup, cdn, deliveryservice, value from \"monthly\".\"%s\"", statName)
 	if days > 0 {
@@ -261,33 +259,31 @@ func syncDeliveryServiceStat(sourceClient influx.Client, targetClient influx.Cli
 			"cachegroup":      ss.cacheGroup,
 			"deliveryservice": ss.deliveryService,
 		}
-		pts = append(pts,
-			influx.Point{
-				Measurement: statName,
-				Tags:        tags,
-				Fields: map[string]interface{}{
-					"value": ss.value,
-				},
-				Time:      statTime,
-				Precision: "ms",
-			},
+		fields := map[string]interface{}{
+			"value": ss.value,
+		}
+		pt, err := influx.NewPoint(
+			statName,
+			tags,
+			fields,
+			statTime,
 		)
-
+		if err != nil {
+			fmt.Printf("error adding creating point for %v...%v\n", statName, err)
+			continue
+		}
+		bps.AddPoint(pt)
 	}
-	bps := influx.BatchPoints{
-		Points:          pts,
-		Database:        "deliveryservice_stats",
-		RetentionPolicy: "monthly",
-	}
-	_, err = targetClient.Write(bps)
-	if err != nil {
-		fmt.Printf("An error occured writing points: %v\n", err)
-	}
+	targetClient.Write(bps)
 }
 func syncDailyStat(sourceClient influx.Client, targetClient influx.Client, statName string, days int) {
 	//get records from source DB
 	db := "daily_stats"
-	var pts []influx.Point
+	bps, _ := influx.NewBatchPoints(influx.BatchPointsConfig{
+		Database:        db,
+		Precision:       "ms",
+		RetentionPolicy: "monthly",
+	})
 
 	queryString := fmt.Sprintf("select time, cdn, deliveryservice, value from \"%s\"", statName)
 	if days > 0 {
@@ -319,26 +315,22 @@ func syncDailyStat(sourceClient influx.Client, targetClient influx.Client, statN
 			"cdn":             ss.cdn,
 			"deliveryservice": ss.deliveryService,
 		}
-		pts = append(pts,
-			influx.Point{
-				Measurement: statName,
-				Tags:        tags,
-				Fields: map[string]interface{}{
-					"value": ss.value,
-				},
-				Time:      statTime,
-				Precision: "ms",
-			},
+		fields := map[string]interface{}{
+			"value": ss.value,
+		}
+		pt, err := influx.NewPoint(
+			statName,
+			tags,
+			fields,
+			statTime,
 		)
+		if err != nil {
+			fmt.Printf("error adding creating point for %v...%v\n", statName, err)
+			continue
+		}
+		bps.AddPoint(pt)
 	}
-	bps := influx.BatchPoints{
-		Points:   pts,
-		Database: "daily_stats",
-	}
-	_, err = targetClient.Write(bps)
-	if err != nil {
-		fmt.Printf("An error occured writing points: %v\n", err)
-	}
+	targetClient.Write(bps)
 }
 
 func getCacheStats(res []influx.Result) map[string]cacheStats {
@@ -353,7 +345,7 @@ func getCacheStats(res []influx.Result) map[string]cacheStats {
 				var err error
 				data.value, err = record[3].(json.Number).Float64()
 				if err != nil {
-					fmt.Println("Couldn't parse value from record %v\n", record)
+					fmt.Printf("Couldn't parse value from record %v\n", record)
 					continue
 				}
 				key := data.t + data.cdn + data.hostname
@@ -381,7 +373,7 @@ func getDeliveryServiceStats(res []influx.Result) map[string]deliveryServiceStat
 				var err error
 				data.value, err = record[4].(json.Number).Float64()
 				if err != nil {
-					fmt.Println("Couldn't parse value from record %v\n", record)
+					fmt.Printf("Couldn't parse value from record %v\n", record)
 					continue
 				}
 				key := data.t + data.cacheGroup + data.cdn + data.deliveryService
@@ -404,7 +396,7 @@ func getDailyStats(res []influx.Result) map[string]dailyStats {
 				var err error
 				data.value, err = record[3].(json.Number).Float64()
 				if err != nil {
-					fmt.Println("Couldn't parse value from record %v\n", record)
+					fmt.Printf("Couldn't parse value from record %v\n", record)
 					continue
 				}
 				key := data.t + data.cdn + data.deliveryService
@@ -413,14 +405,4 @@ func getDailyStats(res []influx.Result) map[string]dailyStats {
 		}
 	}
 	return response
-}
-
-func writeStats(pts []influx.Point, client influx.Client, db string) error {
-	bps := influx.BatchPoints{
-		Points:   pts,
-		Database: db,
-	}
-	var err error
-	_, err = client.Write(bps)
-	return err
 }

--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -27,7 +27,6 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net/http"
-	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -700,13 +699,10 @@ func getURL(url string) ([]byte, error) {
 
 func influxConnect(config StartupConfig, runningConfig RunningConfig) (influx.Client, error) {
 	// Connect to InfluxDb
-	var urls []*url.URL
+	var urls []string
 
 	for _, InfluxHost := range runningConfig.InfluxDBProps {
-		u, err := url.Parse(fmt.Sprintf("http://%s:%d", InfluxHost.Fqdn, InfluxHost.Port))
-		if err != nil {
-			continue
-		}
+		u := fmt.Sprintf("http://%s:%d", InfluxHost.Fqdn, InfluxHost.Port)
 		urls = append(urls, u)
 	}
 
@@ -716,7 +712,7 @@ func influxConnect(config StartupConfig, runningConfig RunningConfig) (influx.Cl
 		urls = append(urls[:n], urls[n+1:]...)
 
 		conf := influx.HTTPConfig{
-			Addr:     url.String(),
+			Addr:     url,
 			Username: config.InfluxUser,
 			Password: config.InfluxPassword,
 		}

--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -85,6 +85,7 @@ type RunningConfig struct {
 	LastSummaryTime time.Time
 }
 
+//Timers struct containts all the timers
 type Timers struct {
 	Poll         <-chan time.Time
 	DailySummary <-chan time.Time
@@ -360,8 +361,8 @@ func queryDB(con *influx.Client, cmd string, database string) (res []influx.Resu
 func writeSummaryStats(config StartupConfig, statsSummary traffic_ops.StatsSummary) {
 	to, err := traffic_ops.Login(config.ToURL, config.ToUser, config.ToPasswd, true)
 	if err != nil {
-		new_err := fmt.Errorf("Could not store summary stats! Error logging in to %v: %v", config.ToURL, err)
-		log.Error(new_err)
+		newErr := fmt.Errorf("Could not store summary stats! Error logging in to %v: %v", config.ToURL, err)
+		log.Error(newErr)
 		return
 	}
 	err = to.AddSummaryStats(statsSummary)
@@ -751,26 +752,27 @@ func sendMetrics(config StartupConfig, runningConfig RunningConfig, bps influx.B
 
 	pts := bps.Points
 	for len(pts) > 0 {
-		chunk_bps := influx.BatchPoints{
+		chunkBps := influx.BatchPoints{
 			Database:        bps.Database,
 			RetentionPolicy: bps.RetentionPolicy,
 		}
 
-		chunk_bps.Points = pts[:IntMin(maxPublishSize, len(pts))]
+		chunkBps.Points = pts[:IntMin(maxPublishSize, len(pts))]
 		pts = pts[IntMin(maxPublishSize, len(pts)):]
 
-		_, err = influxClient.Write(chunk_bps)
+		_, err = influxClient.Write(chunkBps)
 		if err != nil {
 			if retry {
-				config.BpsChan <- chunk_bps
+				config.BpsChan <- chunkBps
 			}
 			errHndlr(err, ERROR)
 		} else {
-			log.Debug("Sent ", len(chunk_bps.Points), " stats")
+			log.Debug("Sent ", len(chunkBps.Points), " stats")
 		}
 	}
 }
 
+//IntMin returns the lesser of two ints
 func IntMin(a, b int) int {
 	if a < b {
 		return a
@@ -778,6 +780,7 @@ func IntMin(a, b int) int {
 	return b
 }
 
+//FloatMax returns the greater of two float64 values
 func FloatMax(a, b float64) float64 {
 	if a > b {
 		return a


### PR DESCRIPTION
This closes #956.

InfluxDb will need to be upgraded to version 0.9.6 or above to support the client change.