### PR TITLE
revert change only to create_table.sql

### DIFF
--- a/traffic_ops/app/db/create_tables.sql
+++ b/traffic_ops/app/db/create_tables.sql
@@ -615,6 +615,7 @@ CREATE TABLE `tm_user` (
   `phone_number` varchar(25) DEFAULT NULL,
   `postal_code` varchar(11) DEFAULT NULL,
   `country` varchar(256) DEFAULT NULL,
+  `local_user` tinyint(1) NOT NULL DEFAULT '0',
   `token` varchar(50) DEFAULT NULL,
   `registration_sent` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
   PRIMARY KEY (`id`),


### PR DESCRIPTION
#964 modified create_table.sql to remove local_user,  but that's not necessary because there's a migration that drops the column.   ```db/admin.pl reset``` gives me this: 

2016/01/23 00:32:07 FAIL 20160102193037_drop_local_user.sql (Received #1091 error from MySQL server: "Can't DROP 'local_user'; check that column/key exists"), quitting migration.

The column needs to exist for the migration to drop it..