### PR TITLE
Updated scripted dashboards to use continuous queries

### DIFF
--- a/traffic_ops/app/lib/TrafficOpsRoutes.pm
+++ b/traffic_ops/app/lib/TrafficOpsRoutes.pm
@@ -778,10 +778,8 @@ sub traffic_stats_routes {
 	$r->get( "/api/$version/deliveryservice_stats" => [ format => [qw(json)] ] )->over( authenticated => 1 )
 		->to( 'DeliveryServiceStats#index', namespace => $namespace );
 	$r->get( "/api/$version/cache_stats" => [ format => [qw(json)] ] )->over( authenticated => 1 )->to( 'CacheStats#index', namespace => $namespace );
-	$r->get( "internal/api/$version/current_bandwidth"   => [ format => [qw(json)] ] )->to( 'CacheStats#current_bandwidth',   namespace => $namespace );
-	$r->get( "internal/api/$version/current_connections" => [ format => [qw(json)] ] )->to( 'CacheStats#current_connections', namespace => $namespace );
-	$r->get( "internal/api/$version/current_capacity"    => [ format => [qw(json)] ] )->to( 'CacheStats#current_capacity',    namespace => $namespace );
 	$r->get( "internal/api/$version/daily_summary"       => [ format => [qw(json)] ] )->to( 'CacheStats#daily_summary',       namespace => $namespace );
+	$r->get( "internal/api/$version/current_stats"       => [ format => [qw(json)] ] )->to( 'CacheStats#current_stats',    namespace => $namespace );
 }
 
 sub catch_all {

--- a/traffic_ops/app/templates/visual_status/graphs.html.ep
+++ b/traffic_ops/app/templates/visual_status/graphs.html.ep
@@ -28,67 +28,36 @@ $(function () {
 </script>
 <script>
 
-function refreshStats()
-{
-     % foreach my $cdn_name (sort @{ $cdn_names } ) {
-        getCurrentBandwidth("<%= $cdn_name %>");
-        getCurrentConnections("<%= $cdn_name %>");
-    % } 
-    getCurrentBandwidth();
-    getCurrentConnections();
-
-}
-
-function getCurrentBandwidth(cdn_name) {
-    var bwUrl = "/internal/api/1.2/current_bandwidth.json";
-    if (cdn_name != null) {
-        var bandwidth = 0;
-        // get bandwidth
-        $.getJSON( bwUrl + "?cdnName=" + cdn_name, function() {})
-         .done(function(data) {
-            bandwidth = data.response.bandwidth.toFixed(2);
-            $('#' + cdn_name + '_gbps_val').text(bandwidth);
-            // get capacity
-            var capacityUrl = "/internal/api/1.2/current_capacity.json";
-            $.getJSON( capacityUrl + "?cdnName=" + cdn_name, function() {})
-            .done(function(data) {
-            var capacity = Math.round(data.response.capacity);
-            var percentage = Math.round(bandwidth/capacity * 100);
-            setProgress(cdn_name + "_percent_indicator", percentage);
-            setText(cdn_name + "_percent_indicator", "avail: " + capacity + ", used: " + percentage);
-            $('#' + cdn_name + '_gbps_val').text(bandwidth);
-            });
-        });
-        
-    }
-    else {
-        $.getJSON( bwUrl, function() {})
-         .done(function(data) {
-            $('#total_gbps_val').text(data.response.bandwidth.toFixed(2));
-        });   
-    }
-}
-
-function getCurrentConnections(cdn_name) {
-    var url = "/internal/api/1.2/current_connections.json";
-    if (cdn_name != null) {
-        $.getJSON( url + "?cdnName=" + cdn_name, function() {})
-         .done(function(data) {
-            var connections = Math.round(data.response.connections).toString();
-            $('#' + cdn_name + '_conn_val').text(connections.replace(/\B(?=(\d{3})+(?!\d))/g, ",")); //toLocaleString doesnt work across browsers, this regex does.
-        });
-    }
-    else {
-        $.getJSON( url, function() {})
-         .done(function(data) {
-            var connections = Math.round(data.response.connections).toString();
+function getCurrentStats() {
+  var bwURL = "/internal/api/1.2/current_stats.json";
+  $.getJSON( bwURL, function() {})
+  .done(function(data) {
+    $.each( data.response.currentStats, function( i, item ) {
+      % foreach my $cdn_name (sort @{ $cdn_names } ) {
+        var cdn_name = "<%= $cdn_name %>";
+        if (item.cdn == cdn_name) {
+          var bandwidth = item.bandwidth.toFixed(2);
+          $('#' + cdn_name + '_gbps_val').text(bandwidth);
+          var connections = Math.round(item.connections).toString();
+          $('#' + cdn_name + '_conn_val').text(connections.replace(/\B(?=(\d{3})+(?!\d))/g, ",")); //toLocaleString doesnt work across browsers, this regex does.
+          var capacity = Math.round(item.capacity);
+          var percentage = Math.round(bandwidth/capacity * 100);
+          setProgress(cdn_name + "_percent_indicator", percentage);
+          setText(cdn_name + "_percent_indicator", "avail: " + capacity + ", used: " + percentage);
+        }
+        if (item.cdn == "total") {
+            var bandwidth = item.bandwidth.toFixed(2);
+            $('#total_gbps_val').text(item.bandwidth.toFixed(2));
+            var connections = Math.round(item.connections).toString();
             $('#total_conn_val').text(connections.replace(/\B(?=(\d{3})+(?!\d))/g, ",")); //toLocaleString doesnt work across browsers, this regex does.
-        });   
-    }
+        }
+     % }
+    });
+  });
 }
 
 //refresh every 30 seconds
-setInterval('refreshStats()', 30000);
+setInterval('getCurrentStats()', 30000);
 
 </script>
 <script type="text/javascript" src="/js/percentagebar.js"></script>

--- a/traffic_stats/grafana/traffic_ops_cachegroup.js
+++ b/traffic_stats/grafana/traffic_ops_cachegroup.js
@@ -116,7 +116,7 @@ dashboard.title = which;
           "targets": [
             {
               "rawQuery": true,
-              "query": "SELECT sum(value)*1000/6 FROM \"bandwidth\" WHERE cachegroup='" + which + "' and $timeFilter GROUP BY time(60s), hostname",
+              "query": "SELECT sum(value)*1000 FROM \"monthly\".\"bandwidth.1min\" WHERE cachegroup='" + which + "' and $timeFilter GROUP BY time(60s), hostname",
               "alias": "$tag_hostname"
             }
           ],

--- a/traffic_stats/grafana/traffic_ops_deliveryservice.js
+++ b/traffic_stats/grafana/traffic_ops_deliveryservice.js
@@ -108,7 +108,7 @@ dashboard.title = which;
           "targets": [
             {
               "measurement": "bw",
-              "query": "SELECT mean(value)*1000 FROM \"kbps\" WHERE deliveryservice='" + which + "' and cachegroup = 'total'  and $timeFilter GROUP BY time(60s), deliveryservice ORDER BY asc",
+              "query": "SELECT mean(value)*1000 FROM \"monthly\".\"kbps.ds.1min\" WHERE deliveryservice='" + which + "' and cachegroup = 'total'  and $timeFilter GROUP BY time(60s), deliveryservice ORDER BY asc",
               "rawQuery": true,
               "tags": {
                 "deliveryservice": which
@@ -198,24 +198,24 @@ dashboard.title = which;
               "tags": {
                 "deliveryservice": which
               },
-              "query": "SELECT mean(value) FROM \"tps_2xx\" WHERE $timeFilter AND deliveryservice='" + which + "' GROUP BY time($interval) ORDER BY asc",
+              "query": "SELECT mean(value) FROM \"monthly\".\"tps_2xx.ds.1min\" WHERE $timeFilter AND deliveryservice='" + which + "' GROUP BY time(60s) ORDER BY asc",
               "hide": false,
               "rawQuery": true
             },
             {
               "target": "",
               "rawQuery": true,
-              "query": "SELECT mean(value) FROM \"tps_3xx\" WHERE $timeFilter AND deliveryservice='" + which + "' GROUP BY time($interval) ORDER BY asc"
+              "query": "SELECT mean(value) FROM \"monthly\".\"tps_3xx.ds.1min\" WHERE $timeFilter AND deliveryservice='" + which + "' GROUP BY time(60s) ORDER BY asc"
             },
             {
               "target": "",
               "rawQuery": true,
-              "query": "SELECT mean(value) FROM \"tps_4xx\" WHERE $timeFilter AND deliveryservice='" + which + "' GROUP BY time($interval) ORDER BY asc"
+              "query": "SELECT mean(value) FROM \"monthly\".\"tps_4xx.ds.1min\" WHERE $timeFilter AND deliveryservice='" + which + "' GROUP BY time(60s) ORDER BY asc"
             },
             {
               "target": "",
               "rawQuery": true,
-              "query": "SELECT mean(value) FROM \"tps_5xx\" WHERE $timeFilter AND deliveryservice='" + which + "' GROUP BY time($interval) ORDER BY asc"
+              "query": "SELECT mean(value) FROM \"monthly\".\"tps_5xx.ds.1min\" WHERE $timeFilter AND deliveryservice='" + which + "' GROUP BY time(60s) ORDER BY asc"
             }
           ],
           "aliasColors": {},
@@ -273,7 +273,7 @@ dashboard.title = which;
           "steppedLine": false,
           "targets": [
             {
-              "query": "SELECT sum(value)*1000/6 FROM \"kbps\" WHERE deliveryservice='" + which + "' and cachegroup != 'total' and $timeFilter GROUP BY time(60s), cachegroup",
+              "query": "SELECT mean(value)*1000 FROM \"monthly\".\"kbps.ds.1min\" WHERE deliveryservice='" + which + "' and cachegroup != 'total' and $timeFilter GROUP BY time(60s), cachegroup",
               "rawQuery": true,
               "alias": "$tag_cachegroup"
             }

--- a/traffic_stats/grafana/traffic_ops_scripted.js
+++ b/traffic_stats/grafana/traffic_ops_scripted.js
@@ -112,7 +112,7 @@ if (type == "deliveryservice") {
           "targets": [
             {
               "measurement": "bw",
-              "query": "SELECT mean(value)*1000 FROM \"kbps\" WHERE deliveryservice='" + which + "' and cachegroup = 'total'  and $timeFilter GROUP BY time(60s), deliveryservice ORDER BY asc",
+              "query": "SELECT mean(value)*1000 FROM \"monthly\".\"kbps.ds.1min\" WHERE deliveryservice='" + which + "' and cachegroup = 'total'  and $timeFilter GROUP BY time(60s), deliveryservice ORDER BY asc",
               "rawQuery": true,
               "tags": {
                 "deliveryservice": which
@@ -201,24 +201,24 @@ if (type == "deliveryservice") {
               "tags": {
                 "deliveryservice": which
               },
-              "query": "SELECT mean(value) FROM \"tps_2xx\" WHERE $timeFilter AND deliveryservice='" + which + "' GROUP BY time($interval) ORDER BY asc",
+              "query": "SELECT mean(value) FROM \"monthly\".\"tps_2xx.ds.1min\" WHERE $timeFilter AND deliveryservice='" + which + "' GROUP BY time(60s) ORDER BY asc",
               "hide": false,
               "rawQuery": true
             },
             {
               "target": "",
               "rawQuery": true,
-              "query": "SELECT mean(value) FROM \"tps_3xx\" WHERE $timeFilter AND deliveryservice='" + which + "' GROUP BY time($interval) ORDER BY asc"
+              "query": "SELECT mean(value) FROM \"monthly\".\"tps_3xx.ds.1min\" WHERE $timeFilter AND deliveryservice='" + which + "' GROUP BY time(60s) ORDER BY asc"
             },
             {
               "target": "",
               "rawQuery": true,
-              "query": "SELECT mean(value) FROM \"tps_4xx\" WHERE $timeFilter AND deliveryservice='" + which + "' GROUP BY time($interval) ORDER BY asc"
+              "query": "SELECT mean(value) FROM \"monthly\".\"tps_4xx.ds.1min\" WHERE $timeFilter AND deliveryservice='" + which + "' GROUP BY time(60s) ORDER BY asc"
             },
             {
               "target": "",
               "rawQuery": true,
-              "query": "SELECT mean(value) FROM \"tps_5xx\" WHERE $timeFilter AND deliveryservice='" + which + "' GROUP BY time($interval) ORDER BY asc"
+              "query": "SELECT mean(value) FROM \"monthly\".\"tps_5xx.ds.1min\" WHERE $timeFilter AND deliveryservice='" + which + "' GROUP BY time(60s) ORDER BY asc"
             }
           ],
           "aliasColors": {},
@@ -276,7 +276,7 @@ if (type == "deliveryservice") {
           "steppedLine": false,
           "targets": [
             {
-              "query": "SELECT sum(value)*1000/6 FROM \"kbps\" WHERE deliveryservice='" + which + "' and cachegroup != 'total' and $timeFilter GROUP BY time(60s), cachegroup",
+              "query": "SELECT mean(value)*1000 FROM \"monthly\".\"kbps.ds.1min\" WHERE deliveryservice='" + which + "' and cachegroup != 'total' and $timeFilter GROUP BY time(60s), cachegroup",
               "rawQuery": true
             }
           ],
@@ -359,7 +359,7 @@ else if ( type == "cachegroup" ) {
           "targets": [
             {
               "rawQuery": true,
-              "query": "SELECT sum(value)*1000/6 FROM \"bandwidth\" WHERE cachegroup='" + which + "' and $timeFilter GROUP BY time(60s), hostname"
+              "query": "SELECT mean(value)*1000 FROM \"monthly\".\"bandwidth.1min\" WHERE cachegroup='" + which + "' and $timeFilter GROUP BY time(60s), hostname"
             }
           ],
           "aliasColors": {},
@@ -434,7 +434,7 @@ else if ( type == "server" ) {
             {
               "measurement": "bandwidth",
               "tags": {},
-              "query": "SELECT sum(value)*1000/6 FROM \"bandwidth\" WHERE hostname='" + which + "'  and $timeFilter GROUP BY time(60s)",
+              "query": "SELECT mean(value)*1000 FROM \"monthly\".\"bandwidth.1min\" WHERE hostname='" + which + "'  and $timeFilter GROUP BY time(60s)",
               "rawQuery": true
             }
           ],
@@ -506,7 +506,7 @@ else if ( type == "server" ) {
             {
               "measurement": "bandwidth",
               "tags": {},
-              "query": "SELECT sum(value)*1000/6 FROM \"ats.proxy.process.http.current_client_connections\" WHERE hostname='" + which + "'  and $timeFilter GROUP BY time(60s)",
+              "query": "SELECT mean(value)*1000 FROM \"monthly\".\"connections.1min\" WHERE hostname='" + which + "'  and $timeFilter GROUP BY time(60s)",
               "rawQuery": true
             }
           ],

--- a/traffic_stats/grafana/traffic_ops_server.js
+++ b/traffic_stats/grafana/traffic_ops_server.js
@@ -118,7 +118,7 @@ dashboard.title = which;
             {
               "measurement": "bandwidth",
               "tags": {},
-              "query": "SELECT sum(value)*1000/6 FROM \"bandwidth\" WHERE hostname='" + which + "'  and $timeFilter GROUP BY time(60s)",
+              "query": "SELECT mean(value)*1000 FROM \"monthly\".\"bandwidth.1min\" WHERE hostname='" + which + "'  and $timeFilter GROUP BY time(60s)",
               "rawQuery": true
             }
           ],
@@ -190,7 +190,7 @@ dashboard.title = which;
             {
               "measurement": "bandwidth",
               "tags": {},
-              "query": "SELECT sum(value)*1000/6 FROM \"ats.proxy.process.http.current_client_connections\" WHERE hostname='" + which + "'  and $timeFilter GROUP BY time(60s)",
+              "query": "SELECT mean(value)*1000 FROM \"monthly\".\"connections.1min\" WHERE hostname='" + which + "'  and $timeFilter GROUP BY time(60s)",
               "rawQuery": true
             }
           ],


### PR DESCRIPTION
Since the continuous queries are now created when running traffic_stats/influxdb_tools/create_databases, the dashboards can be updated to use the continuous queries as well.

Also removed the individual internal APIs that were used to populate the graphs table and replaced with a single API call.  