### PR TITLE
Fixes issue #987 where zones for superdomains (top level domain) are …

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/ZoneManager.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/ZoneManager.java
@@ -603,6 +603,12 @@ public class ZoneManager extends Resolver {
 					zoneMap.put(domain, zholder);
 				}
 
+				final String superdomain = domain.split("\\.", 2)[1];
+
+				if (!superDomains.containsKey(superdomain)) {
+					superDomains.put(superdomain, new ArrayList<Record>());
+				}
+
 				if (host.equalsIgnoreCase(getDnsRoutingName())) {
 					continue;
 				}
@@ -626,14 +632,6 @@ public class ZoneManager extends Resolver {
 							DClass.IN,
 							ZoneUtils.getLong(ttl, AAAA, 60),
 							ip6));
-				}
-
-				final String superdomain = domain.split("\\.", 2)[1];
-				zholder = superDomains.get(superdomain);
-
-				if (zholder == null) {
-					zholder = new ArrayList<Record>();
-					superDomains.put(superdomain, zholder);
 				}
 			}
 		}


### PR DESCRIPTION
…not generated when only DNS delivery services are configured. This closes #987.