### PR TITLE
Fix Traffic Ops dataload.go extra SQL parameter

### DIFF
--- a/traffic_ops/install/go/src/comcast.com/dataload/dataload.go
+++ b/traffic_ops/install/go/src/comcast.com/dataload/dataload.go
@@ -408,7 +408,7 @@ func loadUsers(db *sql.DB, dbName string) error {
 			return err
 		}
 
-		query := "insert ignore into " + dbName + ".tm_user (username, role, local_passwd, new_user) values (?,(select id from role where name = ?), ?, 1, 0)"
+		query := "insert ignore into " + dbName + ".tm_user (username, role, local_passwd, new_user) values (?,(select id from role where name = ?), ?, 1)"
 		_, err = db.Exec(query, u.Username, "admin", u.Password)
 		if err != nil {
 			fmt.Println("\t An error occured inserting user with name ", u.Username)


### PR DESCRIPTION
This fixes postinstall failing to add the Traffic Ops user to SQL.

Fixes #990