### PR TITLE
Fix formatting of lat,long in traffic router access log 

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/http/HTTPAccessEventBuilder.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/http/HTTPAccessEventBuilder.java
@@ -82,7 +82,7 @@ public class HTTPAccessEventBuilder {
         final Geolocation resultLocation = httpAccessRecord.getResultLocation();
 
         if (resultLocation != null) {
-            final DecimalFormat decimalFormat = new DecimalFormat(".##");
+            final DecimalFormat decimalFormat = new DecimalFormat("0.00");
             decimalFormat.setRoundingMode(RoundingMode.DOWN);
             rloc = decimalFormat.format(resultLocation.getLatitude()) + "," + decimalFormat.format(resultLocation.getLongitude());
         }

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
@@ -78,6 +78,7 @@ public class TrafficRouter {
 
 	private final Random random = new Random(System.nanoTime());
 	private Set<String> requestHeaders = new HashSet<String>();
+	private static final Geolocation GEO_ZERO_ZERO = new Geolocation(0,0);
 
 	public TrafficRouter(final CacheRegister cr, 
 			final GeolocationService geolocationService, 
@@ -199,6 +200,9 @@ public class TrafficRouter {
 			final List<Cache> caches = selectCache(location, ds);
 			if (caches != null) {
 				track.setResultLocation(location.getGeolocation());
+				if (track.getResultLocation().equals(GEO_ZERO_ZERO)) {
+					LOGGER.error("Location " + location.getId() + " has Geolocation " + location.getGeolocation());
+				}
 				return caches;
 			}
 			locationsTested++;


### PR DESCRIPTION
and log an error if a cache group with a location of 0.0,0.0 is selected during Geo lookup

(cherry picked from commit a06b20443078c19a4726104b88af3c38f4cfba1d)