### PR TITLE
This updates traffic stats to use the new github repo for influxdb (github.com/influxdata)

### DIFF
--- a/traffic_stats/build/traffic_stats.spec
+++ b/traffic_stats/build/traffic_stats.spec
@@ -65,7 +65,7 @@ oldpwd=$(pwd)
   cd "$godir" && \
   cp -r "$TC_DIR"/traffic_stats/* . && \
   go get -d -v && \
-  go_get_version "$oldpwd"/src/github.com/influxdb/influxdb v0.9.6.1 && \
+  go_get_version "$oldpwd"/src/github.com/influxdata/influxdb && \
   go install -v \
 ) || { echo "Could not build go program at $(pwd): $!"; exit 1; }
 

--- a/traffic_stats/influxdb_tools/README.txt
+++ b/traffic_stats/influxdb_tools/README.txt
@@ -6,14 +6,14 @@ For more information see: http://traffic-control-cdn.net/docs/latest/admin/traff
 
 Pre-Requisites: 
 1. Go 1.5.x or later
-2. Influxdb 0.9.6.1 or later
+2. Influxdb
 3. configured $GOPATH (e.g. export GOPATH=~/go)
 
 Using create_ts_databases.go
-1. Install InfluxDb Client (0.9.6.1 version)
+1. Install InfluxDb Client
 	- go get github.com/influxdata/influxdb
 	- cd $GOPATH/src/github.com/influxdata/influxdb
-	- git checkout 0.9.6.1
+	- git checkout v0.9.6.1 (or whatever version of influxdb you are running)
 	- go install
 
 2. Build it
@@ -28,10 +28,10 @@ Using create_ts_databases.go
 
 
 Using sync_ts_databases.go
-1. Install InfluxDb Client (0.9.4 version)
+1. Install InfluxDb Client (0.9.6.1 version)
 	- go get github.com/influxdata/influxdb
 	- cd $GOPATH/src/github.com/influxdata/influxdb
-	- git checkout 0.9.4
+	- git checkout v0.9.6.1
 	- go install
 
 2. Build it

--- a/traffic_stats/influxdb_tools/create_ts_databases.go
+++ b/traffic_stats/influxdb_tools/create_ts_databases.go
@@ -23,7 +23,7 @@ import (
 	"flag"
 	"fmt"
 
-	influx "github.com/influxdb/influxdb/client/v2"
+	influx "github.com/influxdata/influxdb/client/v2"
 )
 
 func main() {

--- a/traffic_stats/influxdb_tools/sync_ts_databases.go
+++ b/traffic_stats/influxdb_tools/sync_ts_databases.go
@@ -26,7 +26,7 @@ import (
 	"os"
 	"time"
 
-	influx "github.com/influxdb/influxdb/client/v2"
+	influx "github.com/influxdata/influxdb/client/v2"
 )
 
 type cacheStats struct {

--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -36,7 +36,7 @@ import (
 
 	traffic_ops "github.com/Comcast/traffic_control/traffic_ops/client"
 	log "github.com/cihub/seelog"
-	influx "github.com/influxdb/influxdb/client/v2"
+	influx "github.com/influxdata/influxdb/client/v2"
 )
 
 const (


### PR DESCRIPTION
The spec file will now build with the master branch of InfluxDb, because I could not getting working with a specific branch due to the github repo moving.  I suspect that once a new tag is created by influxdb we can make this work again.