### PR TITLE
Update mvn goals in TR and TM build script

### DIFF
--- a/traffic_monitor/build/build_rpm.sh
+++ b/traffic_monitor/build/build_rpm.sh
@@ -38,7 +38,7 @@ function buildRpmTrafficMonitor () {
 	cd "$TM_DIR" || { echo "Could not cd to $TM_DIR: $?"; exit 1; }
 	export TRAFFIC_CONTROL_VERSION="$TC_VERSION"
 	export GIT_REV_COUNT=$(getRevCount)
-	mvn package || { echo "RPM BUILD FAILED: $?"; exit 1; }
+	mvn clean package || { echo "RPM BUILD FAILED: $?"; exit 1; }
 
 	local rpm=$(find -name \*.rpm)
 	if [[ -z $rpm ]]; then

--- a/traffic_router/build/build_rpm.sh
+++ b/traffic_router/build/build_rpm.sh
@@ -59,7 +59,7 @@ function buildRpmTrafficRouter () {
 	cd "$TR_DIR" || { echo "Could not cd to $TR_DIR: $?"; exit 1; }
 	export TRAFFIC_CONTROL_VERSION="$TC_VERSION"
 	export GIT_REV_COUNT=$(getRevCount)
-	mvn -Dmaven.test.skip=true -DminimumTPS=1 package ||  \
+	mvn -Dmaven.test.skip=true -DminimumTPS=1 clean package ||  \
 		{ echo "RPM BUILD FAILED: $?"; exit 1; }
 
 	local rpm=$(find -name \*.rpm)


### PR DESCRIPTION
Updated the build script for TR and TM to do a "clean" before doing a "package".  The prevents issues from occurring when multiple builds are happening from the same location (such as in a ci environment).

(cherry picked from commit 622937edbaa2d347d4e6ef3f292e27cf5b90c2bc)