### PR TITLE
use http for code.jquery -- works around curl version issue on centos 6

### DIFF
--- a/traffic_ops/install/bin/web_deps.txt
+++ b/traffic_ops/install/bin/web_deps.txt
@@ -34,9 +34,9 @@ flot				, 0.8.3		, http://www.flotcharts.org/downloads/flot-0.8.3.zip											
 flot				, 0.8.3		, http://www.flotcharts.org/downloads/flot-0.8.3.zip																, zip	, jquery.flot.time.js						, flot/											, ../../app/public/js/flot/
 flot				, 0.8.3		, https://github.com/krzysu/flot.tooltip/releases/download/0.8.4/jquery.flot.tooltip-0.8.4.zip						, zip	, jquery.flot.tooltip.js					, 			      								, ../../app/public/js/flot/
 flot				, 0.8.3		, https://gflot.googlecode.com/svn-history/r154/trunk/flot/jquery.flot.axislabels.js						    	, none	, jquery.flot.axislabels.js		    		, flot/											, ../../app/public/js/flot/
-jquery				, 1.11.2	, https://code.jquery.com/jquery-1.11.2.min.js																		, none	, jquery-1.11.2.min.js						, .												, ../../app/public/js/
-jquery-ui 			, 1.11.4 	, https://code.jquery.com/ui/1.11.4/jquery-ui.min.js 																, none 	, jquery-ui.min.js 							, . 											, ../../app/public/js/
-jquery-ui-dark-hive	, 1.7.3 	, https://code.jquery.com/ui/1.7.3/themes/dark-hive/jquery-ui.css 													, none 	, jquery-ui.css 							, . 											, ../../app/public/css/
+jquery				, 1.11.2	, http://code.jquery.com/jquery-1.11.2.min.js																		, none	, jquery-1.11.2.min.js						, .												, ../../app/public/js/
+jquery-ui 			, 1.11.4 	, http://code.jquery.com/ui/1.11.4/jquery-ui.min.js 																, none 	, jquery-ui.min.js 							, . 											, ../../app/public/js/
+jquery-ui-dark-hive	, 1.7.3 	, http://code.jquery.com/ui/1.7.3/themes/dark-hive/jquery-ui.css 													, none 	, jquery-ui.css 							, . 											, ../../app/public/css/
 jquery-ui-dark-hive , 1.7.3 	, http://jquery-ui.googlecode.com/svn/tags/1.7.3/themes/dark-hive/images/ui-bg_flat_30_cccccc_40x100.png 			, none 	, ui-bg_flat_30_cccccc_40x100.png 			, .												, ../../app/public/css/images/
 jquery-ui-dark-hive , 1.7.3 	, http://jquery-ui.googlecode.com/svn/tags/1.7.3/themes/dark-hive/images/ui-bg_flat_50_5c5c5c_40x100.png 			, none 	, ui-bg_flat_50_5c5c5c_40x100.png 			, . 											, ../../app/public/css/images/
 jquery-ui-dark-hive , 1.7.3 	, http://jquery-ui.googlecode.com/svn/tags/1.7.3/themes/dark-hive/images/ui-bg_glass_40_ffc73d_1x400.png 			, none 	, ui-bg_glass_40_ffc73d_1x400.png 			, . 											, ../../app/public/css/images/


### PR DESCRIPTION
fixes #1042 