### PR TITLE
Workaround for ORT plugin without params

### DIFF
--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -863,7 +863,7 @@ sub remap_dot_config {
 				$mid_remap{ $remap->{org} } .= " \@plugin=cacheurl.so \@pparam=" . $remap->{cacheurl_file};
 			}
 			if ( $remap->{range_request_handling} == 2 ) {
-				$mid_remap{ $remap->{org} } .= " \@plugin=cache_range_requests.so";
+				$mid_remap{ $remap->{org} } .= " \@plugin=cache_range_requests.so \@pparam=none";
 			}
 		}
 		foreach my $key ( keys %mid_remap ) {
@@ -945,7 +945,7 @@ sub build_remap_line {
 		$text .= " \@plugin=background_fetch.so \@pparam=bg_fetch.config";
 	}
 	elsif ( $remap->{range_request_handling} == 2 ) {
-		$text .= " \@plugin=cache_range_requests.so ";
+		$text .= " \@plugin=cache_range_requests.so \@pparam=none";
 	}
 	if ( defined( $remap->{remap_text} ) ) {
 		$text .= " " . $remap->{remap_text};


### PR DESCRIPTION
Fixes #968. The ORT script has a problem when a plugin doesn’t have
@pparam. This fixes the problem using `cache_range_request` and ACL
(@allow).

@mtorluemke Here's a good one for you.. I checked with @jrushf1239k and his plugin doesn't care about params. This is basically a workaround to ORT parsing.