### PR TITLE
add Geolimit failure redirect feature (short for NGB)

### DIFF
--- a/docs/source/admin/traffic_router.rst
+++ b/docs/source/admin/traffic_router.rst
@@ -313,3 +313,30 @@ Sample Message
 |      |                                                                     | NXDOMAIN (the domain/name requested does not exist) |
 +------+---------------------------------------------------------------------+-----------------------------------------------------+
 
+.. _rl-tr-ngb:
+
+GeoLimit Failure Redirect feature
+======
+
+Overview
+--------
+This feature is also called 'National GeoBlock' feature which is short for 'NGB' feature. In this section, the acronym 'NGB' will be used for this feature.
+
+In the past, if the Geolimit check fails (for example, the client ip is not in the 'US' region but the geolimit is set to 'CZF + US'), the router will return 503 response; but with this feature, when the check fails, it will return 302 if the redirect url is set in the delivery service.
+
+The Geolimit check failure has such scenarios:
+1) When the GeoLimit is set to 'CZF + only', if the client ip is not in the the CZ file, the check fails
+2) When the GeoLimit is set to any region, like 'CZF + US', if the client ip is not in such region, and the client ip is not in the CZ file, the check fails
+
+
+Configuration
+--------
+To enable the NGB feature, the DS must be configured with the proper redirect url. And the setting lays at 'Delivery Services'->Edit->'GeoLimit Redirect URL'. If no url is put in this field, the feature is disabled.
+
+The url has 3 kinds of formats, which have different meanings:
+1. URL without domain
+   If no domain is in the url (like 'vod/dance.mp4'), the router will try to find a proper cache server within the delivery service and return the redirect url with the format like 'http://<cache server name>.<delivery service's FQDN>/<configured relative path>'
+2. URL with domain that matches with the delivery service
+   The URL has domain and the domain matches with the delivery service. For this URL, the router will also try to find a proper cache server within the delivery service and return the same format url as point 1.
+3. URL with domain that doesn't match with the delivery service
+   The URL has domain but the domain doesn't match with the delivery service. For this URL, the router will return the configured url directly to the client.

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/ds/DeliveryService.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/ds/DeliveryService.java
@@ -54,6 +54,12 @@ public class DeliveryService {
 	private final JSONObject ttls;
 	private final boolean coverageZoneOnly;
 	private final JSONArray geoEnabled;
+	private final String geoRedirectUrl;
+	//store the url file path info
+	private String geoRedirectFile;
+	//check if the geoRedirectUrl belongs to this DeliveryService, avoid calculating this for multiple times
+	//"INVALID_URL" for init status, "DS_URL" means that the request url belongs to this DeliveryService, "NOT_DS_URL" means that the request url doesn't belong to this DeliveryService
+	private String geoRedirectUrlType;
 	private final JSONArray staticDnsEntries;
 	private final JSONArray domains;
 	private final JSONObject bypassDestination;
@@ -78,6 +84,11 @@ public class DeliveryService {
 		}
 		this.coverageZoneOnly = dsJo.getBoolean("coverageZoneOnly");
 		this.geoEnabled = dsJo.optJSONArray("geoEnabled");
+		String rurl = dsJo.optString("geoLimitRedirectURL", null);
+		if (rurl != null && rurl.isEmpty()) { rurl = null; }
+		this.geoRedirectUrl = rurl;
+		this.geoRedirectUrlType = "INVALID_URL";
+		this.geoRedirectFile = this.geoRedirectUrl;
 		this.staticDnsEntries = dsJo.optJSONArray("staticDnsEntries");
 		this.bypassDestination = dsJo.optJSONObject("bypassDestination");
 		this.domains = dsJo.optJSONArray("domains");
@@ -113,6 +124,10 @@ public class DeliveryService {
 	@Override
 	public String toString() {
 		return "DeliveryService [id=" + id + "]";
+	}
+
+	public Geolocation getMissLocation() {
+		return missLocation;
 	}
 
 	public Geolocation supportLocation(final Geolocation clientLocation, final String requestType) {
@@ -442,6 +457,26 @@ public class DeliveryService {
 
 	public Dispersion getDispersion() {
 		return dispersion;
+	}
+
+	public String getGeoRedirectUrl() {
+		return geoRedirectUrl;
+	}
+
+	public String getGeoRedirectUrlType() {
+		return this.geoRedirectUrlType;
+	}
+
+	public void setGeoRedirectUrlType(final String type) {
+		this.geoRedirectUrlType = type;
+	}
+
+	public String getGeoRedirectFile() {
+		return this.geoRedirectFile;
+	}
+
+	public void setGeoRedirectFile(final String filePath) {
+		this.geoRedirectFile = filePath;
 	}
 
 	public boolean isIp6RoutingEnabled() {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/request/RequestMatcher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/request/RequestMatcher.java
@@ -55,7 +55,10 @@ public class RequestMatcher implements Comparable<RequestMatcher> {
 
 		final HTTPRequest httpRequest = (HTTPRequest) request;
 		if (type == Type.HEADER) {
-			return httpRequest.getHeaders().get(requestHeader);
+		   if (httpRequest.getHeaders() != null) {
+			   return httpRequest.getHeaders().get(requestHeader);
+		   }
+		   return null;
 		}
 
 		if (type == Type.PATH) {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/StatTracker.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/StatTracker.java
@@ -107,7 +107,7 @@ public class StatTracker {
 		}
 
 		public static enum ResultType {
-			ERROR, CZ, GEO, MISS, STATIC_ROUTE, DS_REDIRECT, DS_MISS, INIT, FED, RGDENY, RGALT
+			ERROR, CZ, GEO, MISS, STATIC_ROUTE, DS_REDIRECT, DS_MISS, INIT, FED, RGDENY, RGALT, GEO_REDIRECT
 		}
 
 		public enum ResultDetails {

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/config/ConfigHandlerTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/config/ConfigHandlerTest.java
@@ -1,0 +1,239 @@
+package com.comcast.cdn.traffic_control.traffic_router.core.config;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.comcast.cdn.traffic_control.traffic_router.core.request.HTTPRequest;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doAnswer;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+
+
+import com.comcast.cdn.traffic_control.traffic_router.core.cache.CacheRegister;
+import com.comcast.cdn.traffic_control.traffic_router.core.ds.DeliveryService;
+import org.powermock.reflect.Whitebox;
+
+
+public class ConfigHandlerTest {
+    private ConfigHandler handler;
+
+    @Before
+    public void before() throws Exception {
+        handler = mock(ConfigHandler.class);
+    }
+
+    @Test
+    public void itTestRelativeUrl() throws Exception {
+        final String redirectUrl = "relative/url";
+        final String dsId = "relative-url";
+        final String[] urlType = {""};
+        final String[] typeUrl = {""};
+
+        Map<String, DeliveryService> dsMap = new HashMap<String, DeliveryService>();
+
+        DeliveryService ds = mock(DeliveryService.class);
+        when(ds.getId()).thenReturn(dsId);
+        when(ds.getGeoRedirectUrl()).thenReturn(redirectUrl);
+        doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+                Object[] args = invocation.getArguments();
+                System.out.println("called with arguments: " + Arrays.toString(args));
+                typeUrl[0] = (String)(args[0]);
+                return null;
+            }
+        }).when(ds).setGeoRedirectFile(anyString());
+        doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+                Object[] args = invocation.getArguments();
+                System.out.println("called with arguments: " + Arrays.toString(args));
+                urlType[0] = (String)args[0];
+                return null;
+            }
+        }).when(ds).setGeoRedirectUrlType(anyString());
+
+        dsMap.put(dsId, ds);
+        
+        CacheRegister register = PowerMockito.mock(CacheRegister.class);
+
+        Whitebox.invokeMethod(handler, "initGeoFailedRedirect", dsMap, register);
+        assertThat(urlType[0], equalTo("DS_URL"));
+        assertThat(typeUrl[0], equalTo(""));
+    }
+
+    @Test
+    public void itTestRelativeUrlNegative() throws Exception {
+        final String redirectUrl = "://invalid";
+        final String dsId = "relative-url";
+        final String[] urlType = {""};
+        final String[] typeUrl = {""};
+
+        Map<String, DeliveryService> dsMap = new HashMap<String, DeliveryService>();
+
+        DeliveryService ds = mock(DeliveryService.class);
+        when(ds.getId()).thenReturn(dsId);
+        when(ds.getGeoRedirectUrl()).thenReturn(redirectUrl);
+        doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+                Object[] args = invocation.getArguments();
+                System.out.println("called with arguments: " + Arrays.toString(args));
+                typeUrl[0] = (String)(args[0]);
+                return null;
+            }
+        }).when(ds).setGeoRedirectFile(anyString());
+        doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+                Object[] args = invocation.getArguments();
+                System.out.println("called with arguments: " + Arrays.toString(args));
+                urlType[0] = (String)args[0];
+                return null;
+            }
+        }).when(ds).setGeoRedirectUrlType(anyString());
+
+        dsMap.put(dsId, ds);
+
+        CacheRegister register = PowerMockito.mock(CacheRegister.class);
+
+        Whitebox.invokeMethod(handler, "initGeoFailedRedirect", dsMap, register);
+        assertThat(urlType[0], equalTo(""));
+        assertThat(typeUrl[0], equalTo(""));
+    }
+
+    @Test
+    public void itTestNoSuchDsUrl() throws Exception {
+        final String path = "/ds/url";
+        final String redirectUrl = "http://test.com" + path;
+        final String dsId = "relative-url";
+        final String[] urlType = {""};
+        final String[] typeUrl = {""};
+
+        Map<String, DeliveryService> dsMap = new HashMap<String, DeliveryService>();
+
+        DeliveryService ds = mock(DeliveryService.class);
+        when(ds.getId()).thenReturn(dsId);
+        when(ds.getGeoRedirectUrl()).thenReturn(redirectUrl);
+        doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+                Object[] args = invocation.getArguments();
+                System.out.println("called with arguments: " + Arrays.toString(args));
+                typeUrl[0] = (String)(args[0]);
+                return null;
+            }
+        }).when(ds).setGeoRedirectFile(anyString());
+        doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+                Object[] args = invocation.getArguments();
+                System.out.println("called with arguments: " + Arrays.toString(args));
+                urlType[0] = (String)args[0];
+                return null;
+            }
+        }).when(ds).setGeoRedirectUrlType(anyString());
+
+        dsMap.put(dsId, ds);
+
+        CacheRegister register = PowerMockito.mock(CacheRegister.class);
+
+        when(register.getDeliveryService(any(HTTPRequest.class), anyBoolean())).thenReturn(null);
+
+        Whitebox.invokeMethod(handler, "initGeoFailedRedirect", dsMap, register);
+        assertThat(urlType[0], equalTo("NOT_DS_URL"));
+        assertThat(typeUrl[0], equalTo(path));
+    }
+
+    @Test
+    public void itTestNotThisDsUrl() throws Exception {
+        final String path = "/ds/url";
+        final String redirectUrl = "http://test.com" + path;
+        final String dsId = "relative-ds";
+        final String anotherId = "another-ds";
+        final String[] urlType = {""};
+        final String[] typeUrl = {""};
+
+        Map<String, DeliveryService> dsMap = new HashMap<String, DeliveryService>();
+
+        DeliveryService ds = mock(DeliveryService.class);
+        when(ds.getId()).thenReturn(dsId);
+        when(ds.getGeoRedirectUrl()).thenReturn(redirectUrl);
+        doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+                Object[] args = invocation.getArguments();
+                System.out.println("called with arguments: " + Arrays.toString(args));
+                typeUrl[0] = (String)(args[0]);
+                return null;
+            }
+        }).when(ds).setGeoRedirectFile(anyString());
+        doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+                Object[] args = invocation.getArguments();
+                System.out.println("called with arguments: " + Arrays.toString(args));
+                urlType[0] = (String)args[0];
+                return null;
+            }
+        }).when(ds).setGeoRedirectUrlType(anyString());
+
+        dsMap.put(dsId, ds);
+
+        DeliveryService anotherDs = mock(DeliveryService.class);
+        when(ds.getId()).thenReturn(anotherId);
+        CacheRegister register = PowerMockito.mock(CacheRegister.class);
+
+        when(register.getDeliveryService(any(HTTPRequest.class), anyBoolean())).thenReturn(anotherDs);
+
+        Whitebox.invokeMethod(handler, "initGeoFailedRedirect", dsMap, register);
+        assertThat(urlType[0], equalTo("NOT_DS_URL"));
+        assertThat(typeUrl[0], equalTo(path));
+    }
+
+    @Test
+    public void itTestThisDsUrl() throws Exception {
+        final String path = "/ds/url";
+        final String redirectUrl = "http://test.com" + path;
+        final String dsId = "relative-ds";
+        final String[] urlType = {""};
+        final String[] typeUrl = {""};
+
+        Map<String, DeliveryService> dsMap = new HashMap<String, DeliveryService>();
+
+        DeliveryService ds = mock(DeliveryService.class);
+        when(ds.getId()).thenReturn(dsId);
+        when(ds.getGeoRedirectUrl()).thenReturn(redirectUrl);
+        doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+                Object[] args = invocation.getArguments();
+                System.out.println("called with arguments: " + Arrays.toString(args));
+                typeUrl[0] = (String)(args[0]);
+                return null;
+            }
+        }).when(ds).setGeoRedirectFile(anyString());
+        doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+                Object[] args = invocation.getArguments();
+                System.out.println("called with arguments: " + Arrays.toString(args));
+                urlType[0] = (String)args[0];
+                return null;
+            }
+        }).when(ds).setGeoRedirectUrlType(anyString());
+
+        dsMap.put(dsId, ds);
+
+        CacheRegister register = PowerMockito.mock(CacheRegister.class);
+
+        when(register.getDeliveryService(any(HTTPRequest.class), anyBoolean())).thenReturn(ds);
+
+        Whitebox.invokeMethod(handler, "initGeoFailedRedirect", dsMap, register);
+        assertThat(urlType[0], equalTo("DS_URL"));
+        assertThat(typeUrl[0], equalTo(path));
+    }
+}


### PR DESCRIPTION
In the past, if the Geolimit check fails (for example, the client ip is not in the 'US' region but the geolimit is set to 'CZ + US'), the router will return 503 response; but with this feature, when the check fails, it will return 302 if the redirect url is set in the delivery service.

The Geolimit check failure has such scenarios:
1) When the geolimt is set to 'CZ + only', if the client ip is not the the CZ file, the check fails
2) When the geolimit is set to any region, like 'CZ + US', if the client ip is not in such region, the check fails

And different configured redirect urls have different meanings:
1. If no domain is in the url (like 'vod/dance.mp4'), the router will try to find a proper cache server and return  the redirect url with the format like '`http://<cache server name>.<delivery service's FQDN>/<configured relative path>`'
2. If has domain, it has two different scenarios:
      1) If the domain matches with the delivery service, the router will also try to find a proper cache server and return the same format url as point 1.
      2) If the domain doesn't match with the delivery service, the router will return the configured url directly to the client.
3. If no url is set, this feature will be disabled for this delivery service