### PR TITLE
Router and Monitor no longer require TRAFFIC_CONTROL_VERSION env var to run maven

### DIFF
--- a/traffic_monitor/build/build_rpm.sh
+++ b/traffic_monitor/build/build_rpm.sh
@@ -37,7 +37,6 @@ function buildRpmTrafficMonitor () {
 
 	cd "$TM_DIR" || { echo "Could not cd to $TM_DIR: $?"; exit 1; }
 	export TRAFFIC_CONTROL_VERSION="$TC_VERSION"
-    mvn -versions:set -DnewVersion=$TRAFFIC_CONTROL_VERSION
 	export GIT_REV_COUNT=$(getRevCount)
 	mvn clean package || { echo "RPM BUILD FAILED: $?"; exit 1; }
 
@@ -63,10 +62,14 @@ function initBuildArea() {
 
 	tm_dest=$(createSourceDir traffic_monitor)
 
+	export TRAFFIC_CONTROL_VERSION="$TC_VERSION"
+    export MVN_CMD="mvn versions:set -DnewVersion=$TRAFFIC_CONTROL_VERSION"
+    echo $MVN_CMD
+    $MVN_CMD
 	cp -r "$TM_DIR"/{build,etc,src} "$tm_dest"/. || { echo "Could not copy to $tm_dest: $?"; exit 1; }
 	cp  "$TM_DIR"/pom.xml "$tm_dest" || { echo "Could not copy to $tm_dest: $?"; exit 1; }
 
-	tar -czvf "$tm_dest.tgz" -C "$RPMBUILD"/SOURCES $(basename "$tm_dest") || { echo "Could not create tar archive $tm_dest.tgz: $?"; exit 1; }
+	tar -czf "$tm_dest.tgz" -C "$RPMBUILD"/SOURCES $(basename "$tm_dest") || { echo "Could not create tar archive $tm_dest.tgz: $?"; exit 1; }
 
 	echo "The build area has been initialized."
 }

--- a/traffic_monitor/build/build_rpm.sh
+++ b/traffic_monitor/build/build_rpm.sh
@@ -37,6 +37,7 @@ function buildRpmTrafficMonitor () {
 
 	cd "$TM_DIR" || { echo "Could not cd to $TM_DIR: $?"; exit 1; }
 	export TRAFFIC_CONTROL_VERSION="$TC_VERSION"
+    mvn -versions:set -DnewVersion=$TRAFFIC_CONTROL_VERSION
 	export GIT_REV_COUNT=$(getRevCount)
 	mvn clean package || { echo "RPM BUILD FAILED: $?"; exit 1; }
 
@@ -53,13 +54,6 @@ function buildRpmTrafficMonitor () {
 	mkdir -p "$DIST" || { echo "Could not create $DIST: $?"; exit 1; }
 
 	cp "$rpm" "$DIST/." || { echo "Could not copy $RPM to $DIST: $?"; exit 1; }
-
-	# TODO: build src rpm separately -- mvn rpm plugin does not do src rpms
-	#cd "RPMBUILD" && \
-	#	rpmbuild -bs --define "_topdir $(pwd)" \
-        #                 --define "traffic_control_version $TC_VERSION" \
-        #                 --define "build_number $BUILD_NUMBER" -ba SPECS/traffic_monitor.spec
-	#cp "$RPMBUILD"/SRPMS/*/*.rpm "$DIST/." || { echo "Could not copy source rpm to $DIST: $?"; exit 1; }
 }
 
 # ---------------------------------------

--- a/traffic_monitor/pom.xml
+++ b/traffic_monitor/pom.xml
@@ -3,18 +3,17 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
+
 	<groupId>com.comcast.cdn.traffic_control</groupId>
+	<artifactId>traffic_monitor</artifactId>
+	<version>1.5.0</version>
 	<packaging>war</packaging>
-	<version>${env.TRAFFIC_CONTROL_VERSION}</version>
-	<name>traffic_monitor</name>
-	<description></description>
 
 	<scm>
 		<connection>scm:git:file://</connection>
 		<developerConnection>scm:git:file://</developerConnection>
 	</scm>
 
-	<!-- <organization> <name>company name</name> <url>company url</url> </organization> -->
 	<properties>
 		<deploy.dir>/opt/traffic_monitor</deploy.dir>
 		<wicket.version>6.0.0</wicket.version>
@@ -22,17 +21,11 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<dependencies>
-		<!-- WICKET DEPENDENCIES -->
 		<dependency>
 			<groupId>org.apache.wicket</groupId>
 			<artifactId>wicket-core</artifactId>
 			<version>${wicket.version}</version>
 		</dependency>
-		<!-- OPTIONAL DEPENDENCY <dependency> <groupId>org.apache.wicket</groupId> 
-			<artifactId>wicket-extensions</artifactId> <version>${wicket.version}</version> 
-			</dependency> -->
-
-		<!-- LOGGING DEPENDENCIES - LOG4J -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
@@ -280,21 +273,6 @@
 				<version>1.4.1</version>
 				<executions>
 					<execution>
-						<phase>validate</phase>
-						<id>enforce-environment-variable-is-set0</id>
-						<goals>
-							<goal>enforce</goal>
-						</goals>
-						<configuration>
-							<rules>
-								<requireEnvironmentVariable>
-									<variableName>TRAFFIC_CONTROL_VERSION</variableName>
-								</requireEnvironmentVariable>
-							</rules>
-							<fail>true</fail>
-						</configuration>
-					</execution>
-					<execution>
 						<phase>package</phase>
 						<id>enforce-environment-variable-is-set</id>
 						<goals>
@@ -517,5 +495,4 @@
 			</snapshots>
 		</repository>
 	</repositories>
-	<artifactId>traffic_monitor</artifactId>
 </project>

--- a/traffic_router/api/pom.xml
+++ b/traffic_router/api/pom.xml
@@ -20,13 +20,11 @@
 	<parent>
 		<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
 		<artifactId>traffic_router</artifactId>
-		<version>${env.TRAFFIC_CONTROL_VERSION}</version>
+		<version>1.5.0</version>
 	</parent>
 
 	<artifactId>traffic_router_api</artifactId>
-	<version>1.0.0</version>
 	<packaging>war</packaging>
-	<name>traffic_router_api</name>
 
 	<properties>
 		<deploy.dir>/opt/traffic_router</deploy.dir>
@@ -50,28 +48,6 @@
 	<build>
 		<finalName>ROOT</finalName>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>1.4.1</version>
-				<executions>
-					<execution>
-						<phase>validate</phase>
-						<id>enforce-environment-variable-is-set</id>
-						<goals>
-							<goal>enforce</goal>
-						</goals>
-						<configuration>
-							<rules>
-								<requireEnvironmentVariable>
-									<variableName>TRAFFIC_CONTROL_VERSION</variableName>
-								</requireEnvironmentVariable>
-							</rules>
-							<fail>true</fail>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 			<plugin>
 				<artifactId>maven-pmd-plugin</artifactId>
 				<version>2.5</version>

--- a/traffic_router/build/build_rpm.sh
+++ b/traffic_router/build/build_rpm.sh
@@ -57,8 +57,6 @@ function buildRpmTrafficRouter () {
 	installDnsSec
 
 	cd "$TR_DIR" || { echo "Could not cd to $TR_DIR: $?"; exit 1; }
-	export TRAFFIC_CONTROL_VERSION="$TC_VERSION"
-	mvn -versions:set -DnewVersion=$TRAFFIC_CONTROL_VERSION
 	export GIT_REV_COUNT=$(getRevCount)
 	mvn -Dmaven.test.skip=true -DminimumTPS=1 clean package ||  \
 		{ echo "RPM BUILD FAILED: $?"; exit 1; }
@@ -108,6 +106,7 @@ function checkEnvironment() {
 	echo "TC_VERSION: $TC_VERSION"
 	echo "RPM: $RPM"
 	echo "--------------------------------------------------"
+    export TRAFFIC_CONTROL_VERSION="$TC_VERSION"
 }
 
 # ---------------------------------------
@@ -115,15 +114,16 @@ function initBuildArea() {
 	echo "Initializing the build area."
 	mkdir -p "$RPMBUILD"/{SPECS,SOURCES,RPMS,SRPMS,BUILD,BUILDROOT} || { echo "Could not create $RPMBUILD: $?"; exit 1; }
 
-	tr_dest=$(createSourceDir traffic_monitor)
+	tr_dest=$(createSourceDir traffic_router)
 
-	# TODO: what can be cut out here?
+	export MVN_CMD="mvn versions:set -DnewVersion=$TRAFFIC_CONTROL_VERSION"
+	echo $MVN_CMD
+	$MVN_CMD
 	cp -r "$TR_DIR"/{api,build,connector,core} "$tr_dest"/. || { echo "Could not copy to $tr_dest: $?"; exit 1; }
 	cp  "$TR_DIR"/pom.xml "$tr_dest" || { echo "Could not copy to $tr_dest: $?"; exit 1; }
-	cp -r "$tr_dest"/* "$BLDPATH"
 
 	# tar/gzip the source
-	tar -czvf "$tr_dest".tgz -C "$RPMBUILD/SOURCES" $(basename $tr_dest) || { echo "Could not create tar archive $tr_dest: $?"; exit 1; }
+	tar -czf "$tr_dest".tgz -C "$RPMBUILD/SOURCES" $(basename $tr_dest) || { echo "Could not create tar archive $tr_dest: $?"; exit 1; }
 
 	echo "The build area has been initialized."
 }

--- a/traffic_router/build/build_rpm.sh
+++ b/traffic_router/build/build_rpm.sh
@@ -58,6 +58,7 @@ function buildRpmTrafficRouter () {
 
 	cd "$TR_DIR" || { echo "Could not cd to $TR_DIR: $?"; exit 1; }
 	export TRAFFIC_CONTROL_VERSION="$TC_VERSION"
+	mvn -versions:set -DnewVersion=$TRAFFIC_CONTROL_VERSION
 	export GIT_REV_COUNT=$(getRevCount)
 	mvn -Dmaven.test.skip=true -DminimumTPS=1 clean package ||  \
 		{ echo "RPM BUILD FAILED: $?"; exit 1; }
@@ -74,13 +75,6 @@ function buildRpmTrafficRouter () {
 	mkdir -p "$DIST" || { echo "Could not create $DIST: $?"; exit 1; }
 
 	cp "$rpm" "$DIST/." || { echo "Could not copy $rpm to $DIST: $?"; exit 1; }
-
-	# TODO: build src rpm separately -- mvn rpm plugin does not do src rpms
-	#cd "RPMBUILD" && \
-	#	rpmbuild -bs --define "_topdir $(pwd)" \
-        #                 --define "traffic_control_version $TC_VERSION" \
-        #                 --define "build_number $BUILD_NUMBER" -ba SPECS/${PACKAGE}.spec
-	#cp "$RPMBUILD"/SRPMS/*/*.rpm "$DIST/." || { echo "Could not copy source rpm to $DIST: $?"; exit 1; }
 }
 
 

--- a/traffic_router/build/pom.xml
+++ b/traffic_router/build/pom.xml
@@ -19,12 +19,11 @@
 
 	<artifactId>traffic_router_rpm</artifactId>
 	<packaging>pom</packaging>
-	<name>traffic_router_rpm</name>
 
 	<parent>
 		<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
 		<artifactId>traffic_router</artifactId>
-		<version>${env.TRAFFIC_CONTROL_VERSION}</version>
+		<version>1.5.0</version>
 	</parent>
 
 	<scm>
@@ -129,21 +128,6 @@
 				<artifactId>maven-enforcer-plugin</artifactId>
 				<version>1.4.1</version>
 				<executions>
-					<execution>
-						<phase>validate</phase>
-						<id>enforce-environment-variable-is-set0</id>
-						<goals>
-							<goal>enforce</goal>
-						</goals>
-						<configuration>
-							<rules>
-								<requireEnvironmentVariable>
-									<variableName>TRAFFIC_CONTROL_VERSION</variableName>
-								</requireEnvironmentVariable>
-							</rules>
-							<fail>true</fail>
-						</configuration>
-					</execution>
 					<execution>
 						<phase>package</phase>
 						<id>enforce-environment-variable-is-set</id>
@@ -322,7 +306,7 @@
 		<dependency>
 			<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
 			<artifactId>traffic_router_connector</artifactId>
-			<version>1.0.0</version>
+			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
@@ -333,7 +317,7 @@
 		<dependency>
 			<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
 			<artifactId>traffic_router_api</artifactId>
-			<version>1.0.0</version>
+			<version>${project.parent.version}</version>
 			<type>war</type>
 		</dependency>
 

--- a/traffic_router/connector/pom.xml
+++ b/traffic_router/connector/pom.xml
@@ -17,17 +17,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
-	<artifactId>traffic_router_connector</artifactId>
-	<packaging>jar</packaging>
-	<version>1.0.0</version>
-	<name>traffic_router_connector</name>
-
 	<parent>
 		<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
 		<artifactId>traffic_router</artifactId>
-        <version>${env.TRAFFIC_CONTROL_VERSION}</version>
+        <version>1.5.0</version>
 	</parent>
+
+	<artifactId>traffic_router_connector</artifactId>
+	<packaging>jar</packaging>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -35,28 +32,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>1.4.1</version>
-				<executions>
-					<execution>
-						<phase>validate</phase>
-						<id>enforce-environment-variable-is-set</id>
-						<goals>
-							<goal>enforce</goal>
-						</goals>
-						<configuration>
-							<rules>
-								<requireEnvironmentVariable>
-									<variableName>TRAFFIC_CONTROL_VERSION</variableName>
-								</requireEnvironmentVariable>
-							</rules>
-							<fail>true</fail>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 			<plugin>
 				<artifactId>maven-pmd-plugin</artifactId>
 				<version>2.5</version>

--- a/traffic_router/core/pom.xml
+++ b/traffic_router/core/pom.xml
@@ -16,15 +16,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>traffic_router_core</artifactId>
-	<packaging>war</packaging>
-	<name>traffic_router_core</name>
-
 	<parent>
 		<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
 		<artifactId>traffic_router</artifactId>
-		<version>${env.TRAFFIC_CONTROL_VERSION}</version>
+		<version>1.5.0</version>
 	</parent>
+
+	<artifactId>traffic_router_core</artifactId>
+	<packaging>war</packaging>
 
 	<scm>
 		<connection>scm:git:file://</connection>
@@ -80,28 +79,6 @@
 			</testResource>
 		</testResources>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>1.4.1</version>
-				<executions>
-					<execution>
-						<phase>validate</phase>
-						<id>enforce-environment-variable-is-set</id>
-						<goals>
-							<goal>enforce</goal>
-						</goals>
-						<configuration>
-							<rules>
-								<requireEnvironmentVariable>
-									<variableName>TRAFFIC_CONTROL_VERSION</variableName>
-								</requireEnvironmentVariable>
-							</rules>
-							<fail>true</fail>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 			<plugin>
 				<artifactId>maven-pmd-plugin</artifactId>
 				<version>2.5</version>
@@ -239,7 +216,7 @@
 		<dependency>
 			<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
 			<artifactId>traffic_router_connector</artifactId>
-			<version>1.0.0</version>
+			<version>${project.parent.version}</version>
 		</dependency>
 
 		<dependency>

--- a/traffic_router/pom.xml
+++ b/traffic_router/pom.xml
@@ -19,7 +19,7 @@
 
 	<artifactId>traffic_router</artifactId>
 	<groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
-	<version>${env.TRAFFIC_CONTROL_VERSION}</version>
+	<version>1.5.0</version>
 	<packaging>pom</packaging>
 	<name>traffic_router</name>
 
@@ -53,28 +53,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>1.4.1</version>
-				<executions>
-					<execution>
-						<phase>validate</phase>
-						<id>enforce-environment-variable-is-set</id>
-						<goals>
-							<goal>enforce</goal>
-						</goals>
-						<configuration>
-							<rules>
-								<requireEnvironmentVariable>
-									<variableName>TRAFFIC_CONTROL_VERSION</variableName>
-								</requireEnvironmentVariable>
-							</rules>
-							<fail>true</fail>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 			<plugin>
 				<inherited>true</inherited>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/traffic_router/testServer/pom.xml
+++ b/traffic_router/testServer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
         <artifactId>traffic_router</artifactId>
-	<version>${env.TRAFFIC_CONTROL_VERSION}</version>
+	<version>9.8.7</version>
     </parent>
 
     <artifactId>traffic_router_test_server</artifactId>
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
             <artifactId>traffic_router_core</artifactId>
-            <version>${parent.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
             <artifactId>traffic_router_api</artifactId>
-            <version>1.0.0</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.aggregate</groupId>

--- a/traffic_router/testServer/pom.xml
+++ b/traffic_router/testServer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.comcast.cdn.traffic_control.traffic_router</groupId>
         <artifactId>traffic_router</artifactId>
-	<version>9.8.7</version>
+	<version>1.5.0</version>
     </parent>
 
     <artifactId>traffic_router_test_server</artifactId>


### PR DESCRIPTION
Fixes #1080 and should still support our build_rpm.sh