### PR TITLE
if param is blank, accept default passed instead

### DIFF
--- a/traffic_ops/app/lib/MojoPlugins/DeliveryService.pm
+++ b/traffic_ops/app/lib/MojoPlugins/DeliveryService.pm
@@ -36,7 +36,11 @@ sub register {
 			my $p       = shift;
 			my $default = shift;
 
-			return scalar( $self->param($p) // $default );
+			my $v = $self->param($p);
+			if ( $v eq '' ) {
+				$v = $default;
+			}
+			return scalar($v);
 		},
 	);
 


### PR DESCRIPTION
fixes #1089, #1090 
blank params should get undef unless another default value is specified