### PR TITLE
Add Traffic Ops 2.0 service to get ATS configs

### DIFF
--- a/traffic_ops/experimental/ats_config/ats_config.go
+++ b/traffic_ops/experimental/ats_config/ats_config.go
@@ -1,0 +1,141 @@
+// Copyright 2015 Comcast Cable Communications Management, LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+)
+
+// Args encapsulates the command line arguments
+type Args struct {
+	Port           int
+	TrafficOpsUri  string
+	TrafficOpsUser string
+	TrafficOpsPass string
+}
+
+// getFlags parses and returns the command line arguments. The returned error
+// will be non-nil if any expected arg is missing.
+func getFlags() (Args, error) {
+	var args Args
+	flag.IntVar(&args.Port, "port", -1, "the port to serve on")
+	flag.IntVar(&args.Port, "p", -1, "the port to serve on (shorthand)")
+	flag.StringVar(&args.TrafficOpsUri, "uri", "", "the Traffic Ops URI")
+	flag.StringVar(&args.TrafficOpsUri, "u", "", "the Traffic Ops URI (shorthand)")
+	flag.StringVar(&args.TrafficOpsUser, "user", "", "the Traffic Ops username")
+	flag.StringVar(&args.TrafficOpsUser, "U", "", "the Traffic Ops username (shorthand)")
+	flag.StringVar(&args.TrafficOpsPass, "Pass", "", "the Traffic Ops password")
+	flag.StringVar(&args.TrafficOpsPass, "P", "", "the Traffic Ops password (shorthand)")
+	flag.Parse()
+	if args.Port == -1 {
+		return args, errors.New("Missing port")
+	}
+	if args.Port < 0 || args.Port > 65535 {
+		return args, errors.New("Invalid port")
+	}
+	if args.TrafficOpsUri == "" {
+		return args, errors.New("Missing CDN URI")
+	}
+	if args.TrafficOpsUser == "" {
+		return args, errors.New("Missing CDN user")
+	}
+	if args.TrafficOpsPass == "" {
+		return args, errors.New("Missing CDN password")
+	}
+	return args, nil
+}
+
+func printUsage() {
+	fmt.Println("Usage:")
+	flag.PrintDefaults()
+	fmt.Println("Example: ats-config -port 3001 -uri http://my-traffic-ops.mycdn -user bill -pass thelizard")
+}
+
+// route routes HTTP requests to /traffic-server-host/config-file.config
+// This should be registered with http.HandleFunc at "/"
+// This could be changed to serve at an arbitrary endpoint, by removing the ^ in the regex
+func route(trafficOpsUri string, trafficOpsCookie string, w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+
+	hostnameRegex := `((?:(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*(?:[A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]))`
+	configfileRegex := `([a-zA-z]*\.config)`
+	// \todo precompile
+	re := regexp.MustCompile(`^` + `/` + hostnameRegex + `/` + configfileRegex + `$`)
+
+	url := r.URL.String()
+	match := re.FindStringSubmatch(url)
+	if len(match) < 3 {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "Error this address is not a config file: '%s'", url)
+		return
+	}
+
+	server := match[1]
+	configFile := match[2]
+
+	profile, err := GetServerProfileName(trafficOpsUri, trafficOpsCookie, server)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "Error getting profile for server '%s': '%v'", server, err)
+		return
+	}
+
+	params, err := GetParameters(trafficOpsUri, trafficOpsCookie, profile) // \todo fix magic profile
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "Error getting parameters for server '%s' profile '%s': '%v'", server, profile, err)
+		return
+	}
+
+	config, err := GetConfig(configFile, trafficOpsUri, server, params)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "Error getting config for server '%s' profile '%s': '%v'", server, profile, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, config)
+}
+
+func main() {
+	args, err := getFlags()
+	if err != nil {
+		fmt.Println(err)
+		printUsage()
+		return
+	}
+
+	trafficOpsCookie, err := GetTrafficOpsCookie(args.TrafficOpsUri, args.TrafficOpsUser, args.TrafficOpsPass)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		route(args.TrafficOpsUri, trafficOpsCookie, w, r)
+	})
+
+	err = http.ListenAndServe(":"+strconv.Itoa(args.Port), nil)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+}

--- a/traffic_ops/experimental/ats_config/configfiles.go
+++ b/traffic_ops/experimental/ats_config/configfiles.go
@@ -1,0 +1,109 @@
+// Copyright 2015 Comcast Cable Communications Management, LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+// To add a config file:
+//   add your function which creates the text of the config file
+//   to the case statement in `GetConfig`
+//
+
+package main
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+// GetConfig takes the name of the config file, and the Traffic Ops parameters for a server,
+// and returns the text of that config file for that server.
+func GetConfig(configFileName string, trafficOpsHost string, trafficServerHost string, params []TrafficOpsParameter) (string, error) {
+	switch configFileName {
+	case "storage.config":
+		return createStorageDotConfig(trafficOpsHost, trafficServerHost, params)
+	default:
+		return "", errors.New("Config file '%s' not valid")
+	}
+}
+
+// createParamsMap returns a map[ConfigFile]map[ParameterName]ParameterValue.
+// Helper function for createStorageDotConfig.
+func createParamsMap(params []TrafficOpsParameter) map[string]map[string]string {
+	m := make(map[string]map[string]string)
+	for _, param := range params {
+		if m[param.ConfigFile] == nil {
+			m[param.ConfigFile] = make(map[string]string)
+		}
+		m[param.ConfigFile][param.Name] = param.Value
+	}
+	return m
+}
+
+func createStorageDotConfig(trafficOpsHost string, trafficServerHost string, params []TrafficOpsParameter) (string, error) {
+	// # DO NOT EDIT - Generated for my-edge-0 by Traffic Ops (https://localhost) on Fri Feb 19 22:16:34 UTC 2016
+	// /dev/ram0 volume=1
+	// /dev/ram1 volume=2
+	// /dev/ram2 volume=3
+
+	s := "# DO NOT EDIT - Generated for " + trafficServerHost + " by Traffic Ops (" + trafficOpsHost + ") on " + time.Now().String() + "\n"
+
+	paramMap := createParamsMap(params)
+
+	if _, ok := paramMap["storage.config"]; !ok {
+		return "", errors.New("No storage config parameters")
+	}
+
+	storageConfigParams := paramMap["storage.config"]
+
+	volumePrefixes := []string{"", "RAM_", "SSD_"}
+
+	numVolumes := 0
+	for _, prefix := range volumePrefixes {
+		if _, ok := storageConfigParams[prefix+"Drive_Prefix"]; ok {
+			numVolumes++
+		}
+	}
+
+	hasMultipleVolumes := numVolumes > 1
+
+	volumeText := func(volume, prefix, letters string, hasMultipleVolumes bool) string {
+		s := ""
+		lettersSlice := strings.Split(letters, ",")
+		for _, letter := range lettersSlice {
+			s += prefix + letter
+			if hasMultipleVolumes {
+				s += " volume=" + volume
+			}
+			s += "\n"
+		}
+		return s
+	}
+
+	for _, prefix := range volumePrefixes {
+		volumeParamName := "Volume"
+		if prefix != "" {
+			volumeParamName = prefix + volumeParamName
+		} else {
+			volumeParamName = "Disk_" + volumeParamName
+		}
+
+		drivePrefix, hasDrivePrefix := storageConfigParams[prefix+"Drive_Prefix"]
+		driveLetters, hasDriveLetters := storageConfigParams[prefix+"Drive_Letters"]
+		driveVolume, hasDriveVolume := storageConfigParams[volumeParamName]
+		if hasDrivePrefix && hasDriveLetters && hasDriveVolume {
+			s += volumeText(driveVolume, drivePrefix, driveLetters, hasMultipleVolumes)
+		}
+	}
+	return s, nil
+}

--- a/traffic_ops/experimental/ats_config/trafficops.go
+++ b/traffic_ops/experimental/ats_config/trafficops.go
@@ -1,0 +1,184 @@
+// Copyright 2015 Comcast Cable Communications Management, LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// \todo move Traffic Ops API to its own package
+
+package main
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+// getClient gets a http client object.
+// This exists to encapsulate TLS cert verification failure skipping.
+// TODO(fix to not skip cert verification, when the api cert is valid)
+func getClient() *http.Client {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	return &http.Client{Transport: tr}
+}
+
+type TrafficOpsParameter struct {
+	LastUpdated string `json:"lastUpdated"`
+	Value       string `json:"value"`
+	Name        string `json:"name"`
+	ConfigFile  string `json:"configFile"`
+}
+
+type TrafficOpsParametersResponse struct {
+	Response []TrafficOpsParameter `json:"response"`
+}
+
+func GetParameters(uri, cookie, profile string) ([]TrafficOpsParameter, error) {
+	endpointUri := uri + "/api/1.2/parameters/profile/" + profile + ".json"
+	req, err := http.NewRequest("GET", endpointUri, strings.NewReader(""))
+	if err != nil {
+		return nil, err
+	}
+	req.AddCookie(&http.Cookie{Name: "mojolicious", Value: cookie})
+
+	client := getClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var paramsResp TrafficOpsParametersResponse
+	if err := json.Unmarshal(data, &paramsResp); err != nil {
+		return nil, err
+	}
+
+	return paramsResp.Response, nil
+}
+
+// GetTrafficOpsCookie logs in to Traffic Ops and returns an auth cookie
+func GetTrafficOpsCookie(cdnUri, user, pass string) (string, error) {
+	uri := cdnUri + `/api/1.2/user/login`
+	postdata := `{"u":"` + user + `", "p":"` + pass + `"}`
+	req, err := http.NewRequest("POST", uri, strings.NewReader(postdata))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Add("Accept", "application/json")
+
+	client := getClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	for _, cookie := range resp.Cookies() {
+		if cookie.Name == `mojolicious` {
+			return cookie.Value, nil
+		}
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return "", errors.New("No login cookie received: " + string(data))
+}
+
+type TrafficOpsServer struct {
+	Profile        string `json:"profile"`
+	IloUsername    string `json:"iloUsername"`
+	Status         string `json:"statusn"`
+	IpAddress      string `json:"ipAddress"`
+	PhysLocation   string `json:"physLocation"`
+	Cachegroup     string `json:"cachegroup"`
+	Ip6Gateway     string `json:"ip6Gateway"`
+	InterfaceName  string `json:"interfaceName"`
+	IloPassword    string `json:"iloPassword"`
+	Id             string `json:"id"`
+	RouterPortName string `json:"routerPortNamen"`
+	LastUpdated    string `json:"lastUpdated"`
+	IpNetmask      string `json:"ipNetmask"`
+	TcpPort        string `json:"tcpPort"`
+	IpGateway      string `json:"ipGateway"`
+	MgmtIpAddress  string `json:"mgmtIpAddress"`
+	Ip6Address     string `json:"ip6Address"`
+	IloIpGateway   string `json:"iloIpGateway"`
+	InterfaceMtu   string `json:"interfaceMtu"`
+	CdnName        string `json:"cdnName"`
+	HostName       string `json:"hostName"`
+	IloIpAddress   string `json:"iloIpAddress"`
+	MgmtIpNetmask  string `json:"mgmtIpNetmask"`
+	Rack           string `json:"rack"`
+	MgmtIpGateway  string `json:"mgmtIpGateway"`
+	Type           string `json:"type"`
+	IloIpNetmask   string `json:"iloIpNetmask"`
+	DomainName     string `json:"domainName"`
+	RouterHostName string `json:"routerHostName"`
+}
+
+type TrafficOpsServersResponse struct {
+	Response []TrafficOpsServer `json:"response"`
+}
+
+func GetServers(trafficOpsUri, trafficOpsCookie string) ([]TrafficOpsServer, error) {
+	uri := trafficOpsUri + `/api/1.2/servers.json`
+	req, err := http.NewRequest("GET", uri, strings.NewReader(""))
+	if err != nil {
+		return nil, err
+	}
+	req.AddCookie(&http.Cookie{Name: "mojolicious", Value: trafficOpsCookie})
+
+	client := getClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var serversResponse TrafficOpsServersResponse
+	if err := json.Unmarshal(data, &serversResponse); err != nil {
+		return nil, err
+	}
+
+	return serversResponse.Response, nil
+}
+
+func GetServerProfileName(trafficOpsUri, cookie, serverHostname string) (string, error) {
+	servers, err := GetServers(trafficOpsUri, cookie)
+	if err != nil {
+		return "", err
+	}
+
+	for _, server := range servers {
+		if server.HostName == serverHostname {
+			return server.Profile, nil
+		}
+	}
+
+	return "", errors.New("Server not found")
+}


### PR DESCRIPTION
This service acts as a 'microservice' and serves ATS config files, by querying the Traffic Ops API.

This currently only creates storage.config, as a proof-of-concept. But it has the framework to easily add the rest of the configs. If we decided not to do the microservice thing, the config file logic easily be adapted to a library within a larger service. In fact, it would probably be good to make it a package anyway.