### PR TITLE
Traffic Router now can support alternate GeoLocationService providers

### DIFF
--- a/traffic_router/core/pom.xml
+++ b/traffic_router/core/pom.xml
@@ -378,6 +378,11 @@
 			<artifactId>geoip2</artifactId>
 			<version>2.1.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-compress</artifactId>
+			<version>1.8</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/traffic_router/core/src/main/conf/cache.properties
+++ b/traffic_router/core/src/main/conf/cache.properties
@@ -34,3 +34,5 @@ cache.config.json.refresh.period=60000
 
 cache.federations.database=${deploy.dir}/db/federations.json
 cache.federations.database.refresh.period=300000
+
+cache.geolocation.database.compressed=false

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
@@ -16,6 +16,8 @@
 
 package com.comcast.cdn.traffic_control.traffic_router.core.loc;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -24,17 +26,25 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
 
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.apache.wicket.ajax.json.JSONException;
 
 import com.comcast.cdn.traffic_control.traffic_router.core.router.TrafficRouterManager;
+
+import static org.apache.commons.codec.digest.DigestUtils.md5Hex;
 
 public abstract class AbstractServiceUpdater {
 	private static final Logger LOGGER = Logger.getLogger(AbstractServiceUpdater.class);
@@ -46,6 +56,7 @@ public abstract class AbstractServiceUpdater {
 	protected boolean loaded = false;
 	protected ScheduledFuture<?> scheduledService;
 	private TrafficRouterManager trafficRouterManager;
+	protected boolean uncompressDataFile;
 
 	public void destroy() {
 		executorService.shutdownNow();
@@ -53,7 +64,7 @@ public abstract class AbstractServiceUpdater {
 
 	/**
 	 * Gets dataBaseURL.
-	 * 
+	 *
 	 * @return the dataBaseURL
 	 */
 	public String getDataBaseURL() {
@@ -62,7 +73,7 @@ public abstract class AbstractServiceUpdater {
 
 	/**
 	 * Gets pollingInterval.
-	 * 
+	 *
 	 * @return the pollingInterval
 	 */
 	public long getPollingInterval() {
@@ -161,7 +172,7 @@ public abstract class AbstractServiceUpdater {
 
 	/**
 	 * Sets executorService.
-	 * 
+	 *
 	 * @param executorService
 	 *            the executorService to set
 	 */
@@ -171,7 +182,7 @@ public abstract class AbstractServiceUpdater {
 
 	/**
 	 * Sets pollingInterval.
-	 * 
+	 *
 	 * @param pollingInterval
 	 *            the pollingInterval to set
 	 */
@@ -182,51 +193,113 @@ public abstract class AbstractServiceUpdater {
 	boolean filesEqual(final File a, final File b) throws IOException {
 		if(!a.exists() && !b.exists()) { return true; }
 		if(!a.exists() || !b.exists()) { return false; }
-		if(a.length() != b.length()) { return false; }
-		FileInputStream fis = new FileInputStream(a);
-		final String md5a = org.apache.commons.codec.digest.DigestUtils.md5Hex(fis);
-		fis.close();
-		fis = new FileInputStream(b);
-		final String md5b = org.apache.commons.codec.digest.DigestUtils.md5Hex(fis);
-		fis.close();
-		if(md5a.equals(md5b)) { return true; }
-		return false;
+		if (a.isDirectory() && b.isDirectory()) {
+			return compareDirectories(a, b);
+		}
+		return compareFiles(a, b);
 	}
-	protected boolean copyDatabaseIfDifferent(final File existingDB, final File newDB) throws IOException {
-		if (!filesEqual(existingDB, newDB)) {
 
-			if (existingDB != null && existingDB.exists()) {
-				existingDB.setReadable(true, true);
-				existingDB.setWritable(true, false);
-				existingDB.delete();
-			}
+	private boolean compareDirectories(final File a, final File b) throws IOException {
+		final File[] aFileList = a.listFiles();
+		final File[] bFileList = b.listFiles();
 
-			newDB.setReadable(true, true);
-			newDB.setWritable(true, false);
-			final boolean renamed = newDB.renameTo(existingDB);
+		if (aFileList.length != bFileList.length) {
+			return false;
+		}
 
-			if (renamed) {
-				LOGGER.info("Successfully updated location database " + existingDB);
-				return true;
-			} else {
-				LOGGER.fatal("Unable to rename " + newDB + " to " + existingDB + "; current working directory is " + System.getProperty("user.dir"));
+		Arrays.sort(aFileList);
+		Arrays.sort(bFileList);
+
+		for (int i = 0; i < aFileList.length; i++) {
+			if (aFileList[i].length() != bFileList[i].length()) {
 				return false;
 			}
-		} else {
+		}
+
+		return true;
+	}
+
+	private boolean compareFiles(final File a, final File b) throws IOException {
+		if (a.length() != b.length()) {
+			return false;
+		}
+
+		FileInputStream fis = new FileInputStream(a);
+		final String md5a = md5Hex(fis);
+		fis.close();
+		fis = new FileInputStream(b);
+		final String md5b = md5Hex(fis);
+		fis.close();
+
+		if (md5a.equals(md5b)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	protected boolean copyDatabaseIfDifferent(final File existingDB, final File newDB) throws IOException {
+		if (filesEqual(existingDB, newDB)) {
 			LOGGER.info("Location database unchanged.");
 			return false;
 		}
+
+		if (existingDB.isDirectory() && newDB.isDirectory()) {
+			moveDirectory(existingDB, newDB);
+			LOGGER.info("Successfully updated location database " + existingDB);
+			return true;
+		}
+
+		if (existingDB != null && existingDB.exists()) {
+			existingDB.setReadable(true, true);
+			existingDB.setWritable(true, false);
+
+			if (existingDB.isDirectory()) {
+				for (File file : existingDB.listFiles()) {
+					file.delete();
+				}
+				LOGGER.debug("Successfully deleted location database under: " + existingDB);
+			} else {
+				existingDB.delete();
+			}
+		}
+
+		newDB.setReadable(true, true);
+		newDB.setWritable(true, false);
+		final boolean renamed = newDB.renameTo(existingDB);
+
+		if (!renamed) {
+			LOGGER.fatal("Unable to rename " + newDB + " to " + existingDB + "; current working directory is " + System.getProperty("user.dir"));
+			return false;
+		}
+
+		LOGGER.info("Successfully updated location database " + existingDB);
+		return true;
+	}
+
+	private void moveDirectory(final File existingDB, final File newDB) throws IOException {
+		LOGGER.info("Moving Location database from: " + newDB + ", to: " + existingDB);
+
+		for (File file : existingDB.listFiles()) {
+			file.setReadable(true, true);
+			file.setWritable(true, false);
+			file.delete();
+		}
+
+		existingDB.delete();
+		Files.move(newDB.toPath(), existingDB.toPath(), StandardCopyOption.ATOMIC_MOVE);
 	}
 
 	protected boolean sourceCompressed = true;
 	protected String tmpPrefix = "loc";
 	protected String tmpSuffix = ".dat";
+
 	protected File downloadDatabase(final String url, final File existingDb) throws IOException {
 		LOGGER.info("[" + getClass().getSimpleName() + "] Downloading database: " + url);
 		final URL dbURL = new URL(url);
 		final HttpURLConnection conn = (HttpURLConnection) dbURL.openConnection();
 
-		if (existingDb != null && existingDb.exists() && existingDb.lastModified() > 0) {
+		if (useModifiedTimestamp(existingDb)) {
 			conn.setIfModifiedSince(existingDb.lastModified());
 		}
 
@@ -237,7 +310,7 @@ public abstract class AbstractServiceUpdater {
 			return existingDb;
 		}
 
-		if (sourceCompressed) {
+		if (!uncompressDataFile && sourceCompressed) {
 			in = new GZIPInputStream(in);
 		}
 
@@ -248,7 +321,52 @@ public abstract class AbstractServiceUpdater {
 		IOUtils.closeQuietly(in);
 		IOUtils.closeQuietly(out);
 
-		return outputFile;
+		if (!uncompressDataFile) {
+			return outputFile;
+		}
+
+		return uncompressTarGZ(outputFile);
+	}
+
+	private boolean useModifiedTimestamp(final File existingDb) {
+		return existingDb != null && existingDb.exists() && existingDb.lastModified() > 0
+				&& (!existingDb.isDirectory() || existingDb.listFiles().length > 0);
+	}
+
+	protected File uncompressTarGZ(final File tarFile) throws IOException {
+		LOGGER.info("Uncompressing file " + tarFile.getAbsolutePath());
+		final String destFolder = tarFile.getParentFile() + File.separator + "location_db";
+		final File dest = new File(destFolder);
+
+		dest.mkdir();
+
+		final TarArchiveInputStream tarIn = new TarArchiveInputStream(new GzipCompressorInputStream(new BufferedInputStream(new FileInputStream(tarFile))));
+		TarArchiveEntry tarEntry = tarIn.getNextTarEntry();
+		while (tarEntry != null) {
+			final File destPath = new File(dest, tarEntry.getName());
+
+			if (tarEntry.isDirectory()) {
+				destPath.mkdirs();
+			} else {
+				destPath.createNewFile();
+				final byte[] buffer = new byte[1024];
+				final BufferedOutputStream bout = new BufferedOutputStream(new FileOutputStream(destPath));
+				int bytesRead = tarIn.read(buffer);
+
+				while ( bytesRead  != -1) {
+					bout.write(buffer, 0, bytesRead);
+					bytesRead = tarIn.read(buffer);
+				}
+
+				bout.close();
+			}
+
+			tarEntry = tarIn.getNextTarEntry();
+		}
+
+		tarIn.close();
+		tarFile.delete();
+		return dest;
 	}
 
 	protected boolean needsUpdating(final File existingDB) {
@@ -269,4 +387,13 @@ public abstract class AbstractServiceUpdater {
 	public void setTrafficRouterManager(final TrafficRouterManager trafficRouterManager) {
 		this.trafficRouterManager = trafficRouterManager;
 	}
+
+	public boolean isUncompressDataFile() {
+		return uncompressDataFile;
+	}
+
+	public void setUncompressDataFile(final boolean uncompressDataFile) {
+		this.uncompressDataFile = uncompressDataFile;
+	}
+
 }

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/GeolocationDatabaseUpdater.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/GeolocationDatabaseUpdater.java
@@ -29,25 +29,26 @@ public class GeolocationDatabaseUpdater extends AbstractServiceUpdater {
 	public GeolocationDatabaseUpdater() {
 	}
 
-	private GeolocationService geoLocation;
+	private GeolocationService geolocationService;
 	public void setGeoLocation(final GeolocationService geoLocation) {
-		this.geoLocation = geoLocation;
+		this.geolocationService = geoLocation;
 	}
 
 	public void verifyDatabase(final File dbFile) throws IOException {
-		geoLocation.verifyDatabase(dbFile);
+		geolocationService.verifyDatabase(dbFile);
 	}
 	public boolean loadDatabase() throws IOException {
 		LOGGER.info("Reloading location database.");
-		geoLocation.reloadDatabase();
+		geolocationService.setDatabaseFile(new File(databaseLocation));
+		geolocationService.reloadDatabase();
 		LOGGER.info("Successfully reloaded location database.");
 		return true;
 	}
 
 	@Override
 	public boolean isLoaded() {
-		if (geoLocation != null) {
-			return geoLocation.isInitialized();
+		if (geolocationService != null) {
+			return geolocationService.isInitialized();
 		}
 
 		return loaded;

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/MaxmindGeolocationService.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/MaxmindGeolocationService.java
@@ -25,11 +25,14 @@ import org.apache.log4j.Logger;
 import com.maxmind.geoip2.DatabaseReader;
 import com.maxmind.geoip2.exception.AddressNotFoundException;
 import com.maxmind.geoip2.model.CityResponse;
+import org.springframework.stereotype.Component;
 
 import com.comcast.cdn.traffic_control.traffic_router.geolocation.Geolocation;
 import com.comcast.cdn.traffic_control.traffic_router.geolocation.GeolocationException;
 import com.comcast.cdn.traffic_control.traffic_router.geolocation.GeolocationService;
 
+
+@Component("GeolocationService")
 public class MaxmindGeolocationService implements GeolocationService {
 	private static final Logger LOGGER = Logger.getLogger(MaxmindGeolocationService.class);
 	private boolean initialized = false;

--- a/traffic_router/core/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/traffic_router/core/src/main/webapp/WEB-INF/applicationContext.xml
@@ -15,11 +15,14 @@
 	limitations under the License.
  -->
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd"
-	default-init-method="init" default-destroy-method="destroy">
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/context"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd"
+	   default-init-method="init" default-destroy-method="destroy">
 
 	<import resource="classpath:/applicationProperties.xml" />
+
+	<context:component-scan base-package="${geoservice.package:com.comcast.cdn.traffic_control.traffic_router.core.loc}" />
 	<bean id="statTracker" class="com.comcast.cdn.traffic_control.traffic_router.core.router.StatTracker">
 		<property name="dnsRoutingName" value="$[dns.routing.name]" />
 		<property name="httpRoutingName" value="$[http.routing.name]" />
@@ -95,12 +98,6 @@
 	<bean id="trafficOpsUtils" class="com.comcast.cdn.traffic_control.traffic_router.core.util.TrafficOpsUtils">
 		<property name="username" value="$[traffic_ops.username]" />
 		<property name="password" value="$[traffic_ops.password]" />
-	</bean>
-
-	<!-- Geolocation Configuration -->
-	<bean id="GeolocationService"
-		class="com.comcast.cdn.traffic_control.traffic_router.core.loc.MaxmindGeolocationService"
-		init-method="init" destroy-method="destroy">
 	</bean>
 
 	<bean id="geolocationDatabaseUpdater" class="com.comcast.cdn.traffic_control.traffic_router.core.loc.GeolocationDatabaseUpdater"

--- a/traffic_router/core/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/traffic_router/core/src/main/webapp/WEB-INF/applicationContext.xml
@@ -104,6 +104,7 @@
 		init-method="init">
 		<property name="databaseLocation" value="$[cache.geolocation.database]" />
 		<property name="pollingInterval" value="$[cache.geolocation.database.refresh.period]" />
+		<property name="uncompressDataFile" value="$[cache.geolocation.database.compressed]"/>
 		<property name="geoLocation" ref="GeolocationService" />
 		<property name="executorService" ref="ScheduledExecutorService" />
 		<property name="trafficRouterManager" ref="trafficRouterManager" />

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/MaxmindGeoIP2Test.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/MaxmindGeoIP2Test.java
@@ -30,7 +30,9 @@ public class MaxmindGeoIP2Test {
 	@Before
 	public void setUp() throws Exception {
 		maxmindGeolocationService = new MaxmindGeolocationService();
-		maxmindGeolocationService.verifyDatabase(new File(mmdb));
+		File databaseFile = new File(mmdb);
+		maxmindGeolocationService.verifyDatabase(databaseFile);
+		maxmindGeolocationService.setDatabaseFile(databaseFile);
 	}
 
 	@Test

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/router/DnsRoutePerformanceTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/router/DnsRoutePerformanceTest.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
+import com.comcast.cdn.traffic_control.traffic_router.geolocation.Geolocation;
+import com.comcast.cdn.traffic_control.traffic_router.geolocation.GeolocationService;
 import org.apache.commons.pool.impl.GenericObjectPool;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -39,8 +41,6 @@ import com.comcast.cdn.traffic_control.traffic_router.core.dns.ZoneManager;
 import com.comcast.cdn.traffic_control.traffic_router.core.ds.DeliveryService;
 import com.comcast.cdn.traffic_control.traffic_router.core.hash.MD5HashFunctionPoolableObjectFactory;
 import com.comcast.cdn.traffic_control.traffic_router.core.loc.FederationRegistry;
-import com.comcast.cdn.traffic_control.traffic_router.geolocation.Geolocation;
-import com.comcast.cdn.traffic_control.traffic_router.geolocation.GeolocationService;
 import com.comcast.cdn.traffic_control.traffic_router.core.loc.NetworkNode;
 import com.comcast.cdn.traffic_control.traffic_router.core.request.DNSRequest;
 import com.comcast.cdn.traffic_control.traffic_router.core.request.Request;

--- a/traffic_router/core/src/test/resources/cache.properties
+++ b/traffic_router/core/src/test/resources/cache.properties
@@ -42,3 +42,5 @@ cache.config.json.refresh.period=1000
 
 cache.federations.database=src/test/db/federations.json
 cache.federations.database.refresh.period=5000
+
+cache.geolocation.database.compressed=false

--- a/traffic_router/geolocation/src/main/java/com/comcast/cdn/traffic_control/traffic_router/geolocation/GeolocationService.java
+++ b/traffic_router/geolocation/src/main/java/com/comcast/cdn/traffic_control/traffic_router/geolocation/GeolocationService.java
@@ -29,14 +29,14 @@ public interface GeolocationService {
      * @throws GeolocationException
      *             if the IP Address cannot be located.
      */
-    public Geolocation location(String ip) throws GeolocationException;
+    Geolocation location(String ip) throws GeolocationException;
 
     /**
      * Forces a reload of the geolocation database.
      * 
      * @throws IOException
      */
-    public void reloadDatabase() throws IOException;
+    void reloadDatabase() throws IOException;
 
     /**
      * Verifies the specified database is valid.
@@ -46,12 +46,15 @@ public interface GeolocationService {
      * @throws IOException
      *             if the database is not valid.
      */
-    public void verifyDatabase(File dbFile) throws IOException;
+    void verifyDatabase(File dbFile) throws IOException;
 
     /**
      * Exposes whether this GeolocationService has loaded
      * 
      * @return whether this GeolocationService has loaded
      */
-    public boolean isInitialized();
+    boolean isInitialized();
+
+    void setDatabaseFile(final File databaseFile);
+
 }


### PR DESCRIPTION
An alternate GeoLocationService provider can now be bootstrapped into Traffic Router by doing the following: 
- Create a class that implements GeoLocationService and is annotated with @Component("GeolocationService").  
- create a setenv.sh script that contains xport JAVA_OPTS="-Dgeoservice.package=<packageName>"
