### PR TITLE
Update Traffic Router to latest version of Spring Framework

### DIFF
--- a/traffic_router/api/pom.xml
+++ b/traffic_router/api/pom.xml
@@ -81,13 +81,6 @@
 	</build>
 
 	<dependencies>
-
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
-			<version>3.0.5.RELEASE</version>
-		</dependency>
-
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>

--- a/traffic_router/build/pom.xml
+++ b/traffic_router/build/pom.xml
@@ -322,11 +322,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
-			<version>3.0.5.RELEASE</version>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<version>3.0.1</version>
@@ -386,12 +381,6 @@
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-mapper-asl</artifactId>
 			<version>1.8.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-webmvc</artifactId>
-			<version>3.0.5.RELEASE</version>
-			<scope>compile</scope>
 		</dependency>
 
 		<dependency>

--- a/traffic_router/core/pom.xml
+++ b/traffic_router/core/pom.xml
@@ -225,11 +225,7 @@
 			<version>${project.parent.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
-			<version>3.0.5.RELEASE</version>
-		</dependency>
+
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
@@ -327,11 +323,17 @@
 			<artifactId>jackson-mapper-asl</artifactId>
 			<version>1.8.2</version>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework</groupId>
-			<artifactId>spring-webmvc</artifactId>
-			<version>3.0.5.RELEASE</version>
+			<artifactId>spring-web</artifactId>
+			<version>${spring.version}</version>
 			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+			<version>${spring.version}</version>
 		</dependency>
 
 		<dependency>

--- a/traffic_router/pom.xml
+++ b/traffic_router/pom.xml
@@ -35,6 +35,7 @@
 
 	<properties>
 		<deploy.dir>/opt/traffic_router</deploy.dir>
+		<spring.version>4.2.5.RELEASE</spring.version>
 		<wicket.version>6.0.0</wicket.version>
 		<jetty.version>7.6.3.v20120416</jetty.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Update to spring framework 4.2.5, does not require upgrading to anything newer than Java 6