### PR TITLE
no strict refs when invoking extension sub

### DIFF
--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -1304,6 +1304,7 @@ sub to_ext_dot_config {
 		eval "use $package;";
 
 		# And call it - the below calls the subroutine in the var $subroutine.
+		no strict 'refs';
 		$text .= $subroutine->( $self, $id, $file );
 
 		# $text .= &{ \&{$subroutine} }( $self, $id, $file );


### PR DESCRIPTION
bypass strict check when loading extension thru ConfigFiles.pm
