### PR TITLE
parent.config -- skip line if no remap origin

### DIFF
--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -1072,6 +1072,7 @@ sub parent_dot_config {
 
 		foreach my $remap ( @{ $data->{dslist} } ) {
 			my $org = $remap->{org};
+			next if !defined $org || $org eq "";
 			next if $done{$org};
 			if ( $remap->{type} eq "HTTP_NO_CACHE" || $remap->{type} eq "HTTP_LIVE" || $remap->{type} eq "DNS_LIVE" ) {
 				my $org_fqdn = $remap->{org};


### PR DESCRIPTION
a blank origin can cause the parent.config to not get loaded.  This avoids that problem.