### PR TITLE
Traffic Stats scripted dashboard updates

### DIFF
--- a/docs/source/admin/traffic_stats.rst
+++ b/docs/source/admin/traffic_stats.rst
@@ -157,13 +157,13 @@ Configuration
 	+---------------------------+------------------------------------------------------------------------------------------------+
 	| server_graph_url          | https://<grafanaHost>/dashboard/script/traffic_ops_server.js?which=                            |
 	+---------------------------+------------------------------------------------------------------------------------------------+
-	| visual_status_panel_1     | https://<grafanaHost>/dashboard/solo/db/cdn-stats?panelId=2&fullscreen&from=now-24h&to=now-60s |
+	| visual_status_panel_1     | https://<grafanaHost>/dashboard-solo/db/cdn-stats?panelId=2&fullscreen&from=now-24h&to=now-60s |
 	+---------------------------+------------------------------------------------------------------------------------------------+
-	| visual_status_panel_2     | https://<grafanaHost>/dashboard/solo/db/cdn-stats?panelId=1&fullscreen&from=now-24h&to=now-60s |
+	| visual_status_panel_2     | https://<grafanaHost>/dashboard-solo/db/cdn-stats?panelId=1&fullscreen&from=now-24h&to=now-60s |
 	+---------------------------+------------------------------------------------------------------------------------------------+
-	| daily_bw_url              | https://<grafanaHost>/dashboard/solo/db/daily-summary?panelId=1&fullscreen&from=now-3y&to=now  |
+	| daily_bw_url              | https://<grafanaHost>/dashboard-solo/db/daily-summary?panelId=1&fullscreen&from=now-3y&to=now  |
 	+---------------------------+------------------------------------------------------------------------------------------------+
-	| daily_served_url          | https://<grafanaHost>/dashboard/solo/db/daily-summary?panelId=2&fullscreen&from=now-3y&to=now  |
+	| daily_served_url          | https://<grafanaHost>/dashboard-solo/db/daily-summary?panelId=2&fullscreen&from=now-3y&to=now  |
 	+---------------------------+------------------------------------------------------------------------------------------------+
 
 InfluxDb Tools

--- a/docs/source/admin/traffic_stats.rst
+++ b/docs/source/admin/traffic_stats.rst
@@ -110,6 +110,7 @@ Configuration
 	::
 
 				ProxyPass /dashboard http://localhost:3000/dashboard
+				ProxyPass /dashboard-solo http://localhost:3000/dashboard-solo
 				ProxyPass /css http://localhost:3000/css
 				ProxyPass /app http://localhost:3000/app
 				ProxyPass /api http://localhost:3000/api

--- a/traffic_stats/grafana/traffic_ops_cachegroup.js
+++ b/traffic_stats/grafana/traffic_ops_cachegroup.js
@@ -56,6 +56,8 @@ if(!_.isUndefined(ARGS.which)) {
 
 // Set a title
 dashboard.title = which;
+//set refresh interval
+dashboard.refresh = "30s";
 
 {
   dashboard.rows.push( {
@@ -108,7 +110,7 @@ dashboard.title = which;
           "nullPointMode": "connected",
           "steppedLine": false,
           "tooltip": {
-            "value_type": "cumulative",
+            "value_type": "individual",
             "shared": true
           },
           "timeFrom": null,

--- a/traffic_stats/grafana/traffic_ops_deliveryservice.js
+++ b/traffic_stats/grafana/traffic_ops_deliveryservice.js
@@ -55,6 +55,8 @@ if(!_.isUndefined(ARGS.which)) {
 
 // Set a title
 dashboard.title = which;
+//set refresh interval
+dashboard.refresh = "30s";
 
 {
     dashboard.rows.push( {
@@ -269,11 +271,11 @@ dashboard.title = which;
           "renderer": "flot",
           "seriesOverrides": [],
           "span": 12,
-          "stack": false,
+          "stack": true,
           "steppedLine": false,
           "targets": [
             {
-              "query": "SELECT mean(value)*1000 FROM \"monthly\".\"kbps.ds.1min\" WHERE deliveryservice='" + which + "' and cachegroup != 'total' and $timeFilter GROUP BY time(60s), cachegroup",
+              "query": "SELECT mean(value)*1000 FROM \"monthly\".\"kbps.cg.1min\" WHERE deliveryservice='" + which + "' and cachegroup != 'total' and $timeFilter GROUP BY time(60s), cachegroup",
               "rawQuery": true,
               "alias": "$tag_cachegroup"
             }
@@ -282,19 +284,19 @@ dashboard.title = which;
           "timeShift": null,
           "title": "bandwidth by cachegroup",
           "tooltip": {
-            "shared": false,
-            "value_type": "cumulative"
+            "shared": true,
+            "value_type": "individual"
           },
           "type": "graph",
           "x-axis": true,
           "y-axis": true,
           "y_formats": [
-            "bps",
-            "short"
+            "bps"
           ]
         }
       ],
       "title": "bwByCg"
-  )};
+  }
+  );
 }
 return dashboard;

--- a/traffic_stats/grafana/traffic_ops_scripted.js
+++ b/traffic_stats/grafana/traffic_ops_scripted.js
@@ -59,6 +59,8 @@ if(!_.isUndefined(ARGS.type)) {
 }
 // Set a title
 dashboard.title = which;
+//set refresh interval
+dashboard.refresh = "30s";
 
 if (type == "deliveryservice") {
   dashboard.rows.push( {
@@ -456,13 +458,12 @@ else if ( type == "server" ) {
           "span": 12,
           "editable": true,
           "type": "graph",
-          "id": 1,
+          "id": 2,
           "datasource": "cache_stats",
           "renderer": "flot",
           "x-axis": true,
           "y-axis": true,
           "y_formats": [
-            "bps",
             "short"
           ],
           "grid": {

--- a/traffic_stats/grafana/traffic_ops_server.js
+++ b/traffic_stats/grafana/traffic_ops_server.js
@@ -55,6 +55,8 @@ if(!_.isUndefined(ARGS.which)) {
 
 // Set a title
 dashboard.title = which;
+//set refresh interval
+dashboard.refresh = "30s";
 
 
 {
@@ -140,13 +142,12 @@ dashboard.title = which;
           "span": 12,
           "editable": true,
           "type": "graph",
-          "id": 1,
+          "id": 2,
           "datasource": "cache_stats",
           "renderer": "flot",
           "x-axis": true,
           "y-axis": true,
           "y_formats": [
-            "bps",
             "short"
           ],
           "grid": {


### PR DESCRIPTION
While doing some QA I found some issues with the scripted dashboards, so I fixed them.  I also updated the traffic stats documentation to use the correct URLs that grafana now uses for solo dashboards (as of 2.1.x, latest is 2.6.x).