### PR TITLE
Fix TO 2.0 nil reference

### DIFF
--- a/traffic_ops/experimental/server/auth/auth.go
+++ b/traffic_ops/experimental/server/auth/auth.go
@@ -126,12 +126,19 @@ func GetLoginFunc(db *sqlx.DB) http.HandlerFunc {
 
 		encBytes := sha1.Sum([]byte(password))
 		encString := hex.EncodeToString(encBytes[:])
-		if err != nil || u.LocalPasswd.String != encString {
+		if err != nil {
 			ctx.Set(r, "user", nil)
-			log.Println("Invalid passwd")
+			log.Println("Invalid password")
 			http.Error(w, "Invalid password: "+err.Error(), http.StatusUnauthorized)
 			return
 		}
+		if u.LocalPasswd.String != encString {
+			ctx.Set(r, "user", nil)
+			log.Println("Invalid password")
+			http.Error(w, "Invalid password", http.StatusUnauthorized)
+			return
+		}
+
 		// Create the token
 		token := jwt.New(jwt.SigningMethodHS256)
 		// Set some claims


### PR DESCRIPTION
It was calling err.Error() even when `err` was nil, namely when the
password was wrong but no error was returned.