### PR TITLE
Tm pom cleanup

### DIFF
--- a/traffic_monitor/README.md
+++ b/traffic_monitor/README.md
@@ -1,5 +1,10 @@
 # Traffic Monitor
 
+### Manually building the rpm
+
+execute the following command:
+`GIT_REV_COUNT=$(git rev-list HEAD 2>/dev/null | wc -l) mvn clean verify -P rpm-build`
+
 ### Why Tests are not in exactly matching packages
 
 The "com.comcast.cdn.traffic_control.traffic_monitor" portion of the package name was omitted from unit

--- a/traffic_monitor/pom.xml
+++ b/traffic_monitor/pom.xml
@@ -71,6 +71,26 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<artifactId>maven-pmd-plugin</artifactId>
+				<version>2.5</version>
+				<configuration>
+					<targetJdk>1.6</targetJdk>
+					<failurePriority>2</failurePriority>
+					<rulesets>
+						<ruleset>build/pmd/ruleset.xml</ruleset>
+					</rulesets>
+				</configuration>
+				<executions>
+					<execution>
+						<id>PMD</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/traffic_monitor/pom.xml
+++ b/traffic_monitor/pom.xml
@@ -91,6 +91,14 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-eclipse-plugin</artifactId>
+				<version>2.9</version>
+				<configuration>
+					<downloadSources>true</downloadSources>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/traffic_monitor/pom.xml
+++ b/traffic_monitor/pom.xml
@@ -9,490 +9,72 @@
 	<version>1.5.0</version>
 	<packaging>war</packaging>
 
-	<scm>
-		<connection>scm:git:file://</connection>
-		<developerConnection>scm:git:file://</developerConnection>
-	</scm>
-
-	<properties>
-		<deploy.dir>/opt/traffic_monitor</deploy.dir>
-		<wicket.version>6.0.0</wicket.version>
-		<jetty.version>7.6.3.v20120416</jetty.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
 	<dependencies>
-		<dependency>
-			<groupId>org.apache.wicket</groupId>
-			<artifactId>wicket-core</artifactId>
-			<version>${wicket.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.4</version>
-		</dependency>
 		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
-			<version>1.2.16</version>
-		</dependency>
-
-		<!-- JETTY DEPENDENCIES FOR TESTING -->
-		<dependency>
-			<groupId>org.eclipse.jetty.aggregate</groupId>
-			<artifactId>jetty-all-server</artifactId>
-			<version>${jetty.version}</version>
-			<scope>provided</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.wicket</groupId>
-			<artifactId>wicket-datetime</artifactId>
-			<version>6.0.0</version>
+			<version>1.2.17</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.wicket</groupId>
-			<artifactId>wicket-examples</artifactId>
-			<version>6.0.0</version>
-			<type>war</type>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>1.3.2</version>
-		</dependency>
-		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.6</version>
+			<artifactId>wicket-core</artifactId>
+			<version>7.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.wicket</groupId>
-			<artifactId>wicket-examples-war</artifactId>
-			<version>0.2</version>
-			<classifier>test-sources</classifier>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.wicket</groupId>
-					<artifactId>wicket-atmosphere</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.wicket</groupId>
-			<artifactId>wicket-spring</artifactId>
-			<version>6.0.0</version>
-		</dependency>
-		<dependency>
-			<groupId>commons-codec</groupId>
-			<artifactId>commons-codec</artifactId>
-			<version>1.6</version>
+			<artifactId>wicket-extensions</artifactId>
+			<version>7.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ning</groupId>
 			<artifactId>async-http-client</artifactId>
-			<version>1.7.17</version>
+			<version>1.9.33</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.9</version>
 		</dependency>
 
 		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-all</artifactId>
-			<version>1.3</version>
-			<scope>test</scope>
-		</dependency>
-		<!-- JUNIT DEPENDENCY FOR TESTING -->
-		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.10</version>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-core</artifactId>
+			<version>1.6.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-api-mockito</artifactId>
 			<version>1.6.4</version>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>
-			<version>1.6.2</version>
+			<version>1.6.4</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>java-hamcrest</artifactId>
+			<version>2.0.0.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-server</artifactId>
+			<version>7.6.3.v20120416</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-webapp</artifactId>
+			<version>7.6.3.v20120416</version>
+		</dependency>
 	</dependencies>
-
-	<build>
-		<finalName>ROOT</finalName>
-		<resources>
-			<resource>
-				<filtering>false</filtering>
-				<directory>src/main/resources</directory>
-			</resource>
-			<resource>
-				<filtering>true</filtering>
-				<directory>src/main/resources</directory>
-				<includes>
-					<include>**/*.prop</include>
-				</includes>
-			</resource>
-			<resource>
-				<filtering>false</filtering>
-				<directory>src/main/java</directory>
-				<includes>
-					<include>**</include>
-				</includes>
-				<excludes>
-					<exclude>**/*.java</exclude>
-				</excludes>
-			</resource>
-		</resources>
-		<testResources>
-			<testResource>
-				<filtering>false</filtering>
-				<directory>src/test/resources</directory>
-			</testResource>
-			<testResource>
-				<filtering>false</filtering>
-				<directory>src/test/java</directory>
-				<includes>
-					<include>**</include>
-				</includes>
-				<excludes>
-					<exclude>**/*.java</exclude>
-				</excludes>
-			</testResource>
-		</testResources>
-		<plugins>
-			<plugin>
-				<artifactId>maven-pmd-plugin</artifactId>
-				<version>2.5</version>
-				<executions>
-					<execution>
-						<id>PMD</id>
-						<phase>compile</phase>
-						<goals>
-							<goal>check</goal>
-						</goals>
-						<configuration>
-							<targetJdk>1.6</targetJdk>
-							<verbose>true</verbose>
-							<failurePriority>2</failurePriority>
-							<rulesets>
-								<ruleset>build/pmd/ruleset.xml</ruleset>
-							</rulesets>
-						</configuration>
-					</execution>
-				</executions>
-				<configuration>
-					<targetJdk>1.6</targetJdk>
-					<verbose>true</verbose>
-					<failurePriority>2</failurePriority>
-					<rulesets>
-						<ruleset>build/pmd/ruleset.xml</ruleset>
-					</rulesets>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>buildnumber-maven-plugin</artifactId>
-				<version>1.2</version>
-				<executions>
-					<execution>
-						<phase>initialize</phase>
-						<goals>
-							<goal>create</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<shortRevisionLength>9</shortRevisionLength>
-					<doCheck>false</doCheck>
-					<doUpdate>false</doUpdate>
-					<timestampFormat>
-						{0,date,yyyy-MM-dd}
-					</timestampFormat>
-					<getRevisionOnlyOnce>false</getRevisionOnlyOnce>
-					<format>{0}</format>
-					<items>
-						<item>scmVersion</item>
-						<!-- <item>buildNumber</item>  -->
-					</items>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>tomcat-maven-plugin</artifactId>
-				<version>1.1</version>
-				<configuration>
-				</configuration>
-			</plugin>
-			<plugin>
-				<inherited>true</inherited>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.5.1</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-					<encoding>UTF-8</encoding>
-					<showWarnings>true</showWarnings>
-					<showDeprecation>true</showDeprecation>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.mortbay.jetty</groupId>
-				<artifactId>jetty-maven-plugin</artifactId>
-				<version>${jetty.version}</version>
-				<configuration>
-					<connectors>
-						<connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
-							<port>8080</port>
-							<maxIdleTime>3600000</maxIdleTime>
-						</connector>
-						<connector implementation="org.eclipse.jetty.server.ssl.SslSocketConnector">
-							<port>8443</port>
-							<maxIdleTime>3600000</maxIdleTime>
-							<keystore>${project.build.directory}/test-classes/keystore</keystore>
-							<password>wicket</password>
-							<keyPassword>wicket</keyPassword>
-						</connector>
-					</connectors>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-eclipse-plugin</artifactId>
-				<version>2.9</version>
-				<configuration>
-					<downloadSources>true</downloadSources>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>1.4.1</version>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<id>enforce-environment-variable-is-set</id>
-						<goals>
-							<goal>enforce</goal>
-						</goals>
-						<configuration>
-							<rules>
-								<requireEnvironmentVariable>
-									<variableName>GIT_REV_COUNT</variableName>
-								</requireEnvironmentVariable>
-							</rules>
-							<fail>true</fail>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
-
-	<profiles>
-		<profile>
-			<id>rpm-build</id>
-			<activation>
-				<os>
-					<name>linux</name>
-				</os>
-			</activation>
-			<build>
-				<finalName>ROOT</finalName>
-				<plugins>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>rpm-maven-plugin</artifactId>
-						<version>2.1.4</version>
-						<extensions>true</extensions>
-						<executions>
-							<execution>
-								<id>package-rpm</id>
-								<goals>
-									<goal>attached-rpm</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<copyright>2011-2014, Comcast Converged Products</copyright>
-							<group>Applications/Internet</group>
-							<release>${env.GIT_REV_COUNT}.${buildNumber}.el6</release>
-							<needarch>x86_64</needarch>
-							<mappings>
-								<mapping>
-									<directory>${deploy.dir}</directory>
-									<filemode>755</filemode>
-									<username>root</username>
-									<groupname>root</groupname>
-								</mapping>
-								<mapping>
-									<directory>${deploy.dir}/conf</directory>
-									<filemode>700</filemode>
-									<username>root</username>
-									<groupname>root</groupname>
-								</mapping>
-								<mapping>
-									<directory>${deploy.dir}/conf</directory>
-									<directoryIncluded>false</directoryIncluded>
-									<configuration>noreplace</configuration>
-									<filemode>600</filemode>
-									<username>root</username>
-									<groupname>root</groupname>
-									<sources>
-										<source>
-											<filter>true</filter>
-											<location>src/main/conf</location>
-										</source>
-									</sources>
-								</mapping>
-
-								<mapping>
-									<directory>${deploy.dir}/var</directory>
-									<filemode>755</filemode>
-									<username>root</username>
-									<groupname>root</groupname>
-								</mapping>
-								<mapping>
-									<directory>${deploy.dir}/var/log</directory>
-									<filemode>755</filemode>
-									<username>root</username>
-									<groupname>root</groupname>
-								</mapping>
-								<mapping>
-									<directory>${deploy.dir}/db</directory>
-									<filemode>755</filemode>
-									<username>root</username>
-									<groupname>root</groupname>
-								</mapping>
-								<mapping>
-									<directory>${deploy.dir}/bin</directory>
-									<filemode>700</filemode>
-									<username>root</username>
-									<groupname>root</groupname>
-								</mapping>
-								<mapping>
-									<directory>${deploy.dir}/lib</directory>
-									<filemode>755</filemode>
-									<username>root</username>
-									<groupname>root</groupname>
-								</mapping>
-								<mapping>
-									<directory>${deploy.dir}/bin</directory>
-									<directoryIncluded>false</directoryIncluded>
-									<filemode>700</filemode>
-									<username>root</username>
-									<groupname>root</groupname>
-									<sources>
-										<source>
-											<filter>true</filter>
-											<location>src/main/bin</location>
-										</source>
-									</sources>
-								</mapping>
-								<mapping>
-									<directory>${deploy.dir}/lib</directory>
-									<directoryIncluded>false</directoryIncluded>
-									<filemode>755</filemode>
-									<username>root</username>
-									<groupname>root</groupname>
-									<artifact>
-										<classifiers>
-											<classifier />
-										</classifiers>
-									</artifact>
-									<dependency />
-								</mapping>
-								<mapping>
-									<directory>/etc/init.d</directory>
-									<directoryIncluded>false</directoryIncluded>
-									<filemode>700</filemode>
-									<username>root</username>
-									<groupname>root</groupname>
-									<sources>
-										<source>
-											<filter>true</filter>
-											<location>src/main/etc/init.d</location>
-										</source>
-									</sources>
-								</mapping>
-
-								<mapping>
-									<directory>/var/run/tomcat</directory>
-									<filemode>755</filemode>
-									<username>root</username>
-									<groupname>root</groupname>
-								</mapping>
-								<mapping>
-									<directory>${deploy.dir}/webapps</directory>
-									<directoryIncluded>false</directoryIncluded>
-									<filemode>644</filemode>
-									<username>root</username>
-									<groupname>root</groupname>
-									<artifact>
-										<classifiers>
-											<classifier />
-										</classifiers>
-									</artifact>
-								</mapping>
-								<mapping>
-									<directory>/opt/tomcat/conf</directory>
-									<directoryIncluded>true</directoryIncluded>
-									<configuration>true</configuration>
-									<filemode>644</filemode>
-									<username>root</username>
-									<groupname>root</groupname>
-									<sources>
-										<source>
-											<filter>true</filter>
-											<location>src/main/opt/tomcat/conf</location>
-										</source>
-									</sources>
-								</mapping>
-								<mapping>
-									<directory>/var/run/tomcat</directory>
-									<filemode>755</filemode>
-									<username>root</username>
-									<groupname>root</groupname>
-								</mapping>
-							</mappings>
-							<requires>
-								<require>jdk</require>
-								<require>perl-JSON</require>
-								<require>perl-WWW-Curl</require>
-							</requires>
-
-							<preinstallScriptlet>
-								<scriptFile>src/main/scripts/preinstall.sh</scriptFile>
-							</preinstallScriptlet>
-							<postinstallScriptlet>
-								<scriptFile>src/main/scripts/postinstall.sh</scriptFile>
-							</postinstallScriptlet>
-							<preremoveScriptlet>
-								<scriptFile>src/main/scripts/preremove.sh</scriptFile>
-							</preremoveScriptlet>
-							<postremoveScriptlet>
-								<scriptFile>src/main/scripts/postremove.sh</scriptFile>
-							</postremoveScriptlet>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-
-	<repositories>
-		<repository>
-			<id>Apache Nexus</id>
-			<url>https://repository.apache.org/content/repositories/snapshots/</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
 </project>

--- a/traffic_monitor/pom.xml
+++ b/traffic_monitor/pom.xml
@@ -10,9 +10,14 @@
 	<packaging>war</packaging>
 
 	<properties>
+		<deploy.dir>/opt/traffic_monitor</deploy.dir>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
+
+	<scm>
+		<connection>scm:git:git://localhost/${basedir}</connection>
+	</scm>
 
 	<build>
 		<finalName>ROOT</finalName>
@@ -41,6 +46,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.18.1</version>
 				<executions>
 					<execution>
 						<goals>
@@ -55,6 +61,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>2.19</version>
 				<executions>
 					<execution>
 						<goals>
@@ -101,6 +108,246 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>rpm-build</id>
+			<activation>
+				<os>
+					<name>linux</name>
+				</os>
+			</activation>
+			<build>
+				<finalName>ROOT</finalName>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-enforcer-plugin</artifactId>
+						<version>1.4.1</version>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<id>enforce-environment-variable-is-set</id>
+								<goals>
+									<goal>enforce</goal>
+								</goals>
+								<configuration>
+									<rules>
+										<requireEnvironmentVariable>
+											<variableName>GIT_REV_COUNT</variableName>
+										</requireEnvironmentVariable>
+									</rules>
+									<fail>true</fail>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>buildnumber-maven-plugin</artifactId>
+						<version>1.4</version>
+						<executions>
+							<execution>
+								<phase>validate</phase>
+								<goals>
+									<goal>create</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<shortRevisionLength>9</shortRevisionLength>
+							<doCheck>false</doCheck>
+							<doUpdate>false</doUpdate>
+							<timestampFormat>
+								{0,date,yyyy-MM-dd}
+							</timestampFormat>
+							<getRevisionOnlyOnce>false</getRevisionOnlyOnce>
+							<format>{0}</format>
+							<items>
+								<item>scmVersion</item>
+								<!-- <item>buildNumber</item>  -->
+							</items>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>rpm-maven-plugin</artifactId>
+						<version>2.1.4</version>
+						<extensions>true</extensions>
+						<executions>
+							<execution>
+								<id>package-rpm</id>
+								<goals>
+									<goal>attached-rpm</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<copyright>2011-2014, Comcast Converged Products</copyright>
+							<group>Applications/Internet</group>
+							<release>${env.GIT_REV_COUNT}.${buildNumber}.el6</release>
+							<needarch>x86_64</needarch>
+							<mappings>
+								<mapping>
+									<directory>${deploy.dir}</directory>
+									<filemode>755</filemode>
+									<username>root</username>
+									<groupname>root</groupname>
+								</mapping>
+								<mapping>
+									<directory>${deploy.dir}/conf</directory>
+									<filemode>700</filemode>
+									<username>root</username>
+									<groupname>root</groupname>
+								</mapping>
+								<mapping>
+									<directory>${deploy.dir}/conf</directory>
+									<directoryIncluded>false</directoryIncluded>
+									<configuration>noreplace</configuration>
+									<filemode>600</filemode>
+									<username>root</username>
+									<groupname>root</groupname>
+									<sources>
+										<source>
+											<filter>true</filter>
+											<location>src/main/conf</location>
+										</source>
+									</sources>
+								</mapping>
+
+								<mapping>
+									<directory>${deploy.dir}/var</directory>
+									<filemode>755</filemode>
+									<username>root</username>
+									<groupname>root</groupname>
+								</mapping>
+								<mapping>
+									<directory>${deploy.dir}/var/log</directory>
+									<filemode>755</filemode>
+									<username>root</username>
+									<groupname>root</groupname>
+								</mapping>
+								<mapping>
+									<directory>${deploy.dir}/db</directory>
+									<filemode>755</filemode>
+									<username>root</username>
+									<groupname>root</groupname>
+								</mapping>
+								<mapping>
+									<directory>${deploy.dir}/bin</directory>
+									<filemode>700</filemode>
+									<username>root</username>
+									<groupname>root</groupname>
+								</mapping>
+								<mapping>
+									<directory>${deploy.dir}/lib</directory>
+									<filemode>755</filemode>
+									<username>root</username>
+									<groupname>root</groupname>
+								</mapping>
+								<mapping>
+									<directory>${deploy.dir}/bin</directory>
+									<directoryIncluded>false</directoryIncluded>
+									<filemode>700</filemode>
+									<username>root</username>
+									<groupname>root</groupname>
+									<sources>
+										<source>
+											<filter>true</filter>
+											<location>src/main/bin</location>
+										</source>
+									</sources>
+								</mapping>
+								<mapping>
+									<directory>${deploy.dir}/lib</directory>
+									<directoryIncluded>false</directoryIncluded>
+									<filemode>755</filemode>
+									<username>root</username>
+									<groupname>root</groupname>
+									<artifact>
+										<classifiers>
+											<classifier />
+										</classifiers>
+									</artifact>
+									<dependency />
+								</mapping>
+								<mapping>
+									<directory>/etc/init.d</directory>
+									<directoryIncluded>false</directoryIncluded>
+									<filemode>700</filemode>
+									<username>root</username>
+									<groupname>root</groupname>
+									<sources>
+										<source>
+											<filter>true</filter>
+											<location>src/main/etc/init.d</location>
+										</source>
+									</sources>
+								</mapping>
+
+								<mapping>
+									<directory>/var/run/tomcat</directory>
+									<filemode>755</filemode>
+									<username>root</username>
+									<groupname>root</groupname>
+								</mapping>
+								<mapping>
+									<directory>${deploy.dir}/webapps</directory>
+									<directoryIncluded>false</directoryIncluded>
+									<filemode>644</filemode>
+									<username>root</username>
+									<groupname>root</groupname>
+									<artifact>
+										<classifiers>
+											<classifier />
+										</classifiers>
+									</artifact>
+								</mapping>
+								<mapping>
+									<directory>/opt/tomcat/conf</directory>
+									<directoryIncluded>true</directoryIncluded>
+									<configuration>true</configuration>
+									<filemode>644</filemode>
+									<username>root</username>
+									<groupname>root</groupname>
+									<sources>
+										<source>
+											<filter>true</filter>
+											<location>src/main/opt/tomcat/conf</location>
+										</source>
+									</sources>
+								</mapping>
+								<mapping>
+									<directory>/var/run/tomcat</directory>
+									<filemode>755</filemode>
+									<username>root</username>
+									<groupname>root</groupname>
+								</mapping>
+							</mappings>
+							<requires>
+								<require>jdk</require>
+								<require>perl-JSON</require>
+								<require>perl-WWW-Curl</require>
+							</requires>
+
+							<preinstallScriptlet>
+								<scriptFile>src/main/scripts/preinstall.sh</scriptFile>
+							</preinstallScriptlet>
+							<postinstallScriptlet>
+								<scriptFile>src/main/scripts/postinstall.sh</scriptFile>
+							</postinstallScriptlet>
+							<preremoveScriptlet>
+								<scriptFile>src/main/scripts/preremove.sh</scriptFile>
+							</preremoveScriptlet>
+							<postremoveScriptlet>
+								<scriptFile>src/main/scripts/postremove.sh</scriptFile>
+							</postremoveScriptlet>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 	<dependencies>
 		<dependency>

--- a/traffic_monitor/pom.xml
+++ b/traffic_monitor/pom.xml
@@ -9,6 +9,71 @@
 	<version>1.5.0</version>
 	<packaging>war</packaging>
 
+	<properties>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<finalName>ROOT</finalName>
+
+		<resources>
+			<resource>
+				<filtering>false</filtering>
+				<directory>src/main/resources</directory>
+			</resource>
+			<resource>
+				<filtering>true</filtering>
+				<directory>src/main/resources</directory>
+				<includes>
+					<include>**/*.prop</include>
+				</includes>
+			</resource>
+			<resource>
+				<filtering>false</filtering>
+				<directory>src/main/java</directory>
+				<includes>
+					<include>**/*.html</include>
+				</includes>
+			</resource>
+		</resources>
+
+		<plugins>
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<redirectTestOutputToFile>true</redirectTestOutputToFile>
+					<excludedGroups>test.IntegrationTest</excludedGroups>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+						<configuration>
+							<redirectTestOutputToFile>true</redirectTestOutputToFile>
+							<groups>test.IntegrationTest</groups>
+							<includes>
+								<include>**/*.java</include>
+							</includes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
 	<dependencies>
 		<dependency>
 			<groupId>log4j</groupId>
@@ -18,12 +83,12 @@
 		<dependency>
 			<groupId>org.apache.wicket</groupId>
 			<artifactId>wicket-core</artifactId>
-			<version>7.2.0</version>
+			<version>6.22.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.wicket</groupId>
 			<artifactId>wicket-extensions</artifactId>
-			<version>7.2.0</version>
+			<version>6.22.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ning</groupId>
@@ -34,6 +99,18 @@
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
 			<version>1.9</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.4</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+			<version>1.6.4</version>
+			<scope>runtime</scope>
 		</dependency>
 
 		<dependency>

--- a/traffic_monitor/src/main/java/com/comcast/cdn/traffic_control/traffic_monitor/health/CacheStatisticsClient.java
+++ b/traffic_monitor/src/main/java/com/comcast/cdn/traffic_control/traffic_monitor/health/CacheStatisticsClient.java
@@ -25,12 +25,8 @@ public class CacheStatisticsClient {
 			.setProxyServer(proxyServer)
 			.build();
 
-		try {
-			final Future<Object> future = asyncHttpClient.executeRequest(request, cacheStateUpdater);
-			cacheStateUpdater.setFuture(future);
-		} catch (IOException e) {
-			LOGGER.warn("Failed to fetch cache statistics from " + request.getUrl(),e);
-		}
+		final Future<Object> future = asyncHttpClient.executeRequest(request, cacheStateUpdater);
+		cacheStateUpdater.setFuture(future);
 	}
 
 

--- a/traffic_monitor/src/test/java/application/MonitorApplicationTest.java
+++ b/traffic_monitor/src/test/java/application/MonitorApplicationTest.java
@@ -4,10 +4,12 @@ import com.comcast.cdn.traffic_control.traffic_monitor.MonitorApplication;
 import com.comcast.cdn.traffic_control.traffic_monitor.config.ConfigHandler;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
+import test.IntegrationTest;
 
 import java.security.AccessControlException;
 import java.security.Permission;
@@ -19,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
+@Category(IntegrationTest.class)
 @PrepareForTest({MonitorApplication.class, ConfigHandler.class})
 @RunWith(PowerMockRunner.class)
 public class MonitorApplicationTest {

--- a/traffic_monitor/src/test/java/com/comcast/cdn/traffic_control/traffic_monitor/TestHomePage.java
+++ b/traffic_monitor/src/test/java/com/comcast/cdn/traffic_control/traffic_monitor/TestHomePage.java
@@ -22,9 +22,11 @@ import com.comcast.cdn.traffic_control.traffic_monitor.health.CacheWatcher;
 import org.apache.wicket.util.tester.WicketTester;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import test.IntegrationTest;
 
 import javax.net.ssl.SSLContext;
 
@@ -36,6 +38,7 @@ import java.io.File;
 
 import static org.mockito.Matchers.anyString;
 
+@Category(IntegrationTest.class)
 @PrepareForTest({ConfigHandler.class, CacheWatcher.class, SSLContext.class})
 @RunWith(PowerMockRunner.class)
 public class TestHomePage {

--- a/traffic_monitor/src/test/java/test/IntegrationTest.java
+++ b/traffic_monitor/src/test/java/test/IntegrationTest.java
@@ -1,0 +1,7 @@
+package test;
+
+/**
+ * Created by tacker001c on 3/2/16.
+ */
+public interface IntegrationTest {
+}


### PR DESCRIPTION
In addition to removing unused items from the pom, now the fast running unit tests will run before the integration tests. See the Category annotation in MonitorApplicationTest and the maven-surefire-plugin and maven-failsafe-plugin configuration in the pom.

This does change how to run all the tests.

It used to be that running 'mvn test' would run all tests, now it runs only tests without Category annotation (meant to indicate unit tests)

To run all tests run either 'mvn integration-test' or 'mvn verify'