### PR TITLE
BACKPORT -- fix issue with daily_maxgbps being written as daily_bytesserved

### DIFF
--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -329,7 +329,9 @@ func calcDailySummary(now time.Time, config StartupConfig, runningConfig Running
 			statsSummary.StatName = "daily_bytesserved"
 			statsSummary.StatValue = strconv.FormatFloat(bytesServedTb, 'f', 2, 64)
 			go writeSummaryStats(config, statsSummary)
-
+			fields = map[string]interface{}{
+				"value": bytesServedTb,
+			}
 			pt, err = influx.NewPoint(
 				statsSummary.StatName,
 				tags,


### PR DESCRIPTION
I will need to create a 1.4.1 release.  How I let this make it through 10 RCs I do not know.

(cherry picked from commit e88fd0b53718d8e0dc37fb6abe0d1ef9d06099a7)