### PR TITLE
Add support for http, https, and udp protocols to Traffic Stats

### DIFF
--- a/traffic_stats/traffic_stats.cfg
+++ b/traffic_stats/traffic_stats.cfg
@@ -12,5 +12,6 @@
 	"dailySummaryPollingInterval": 300,
 	"cacheRetentionPolicy": "daily",
 	"dsRetentionPolicy": "daily",
-	"dailySummaryRetentionPolicy": "indefinite"
+	"dailySummaryRetentionPolicy": "indefinite",
+	"influxProtocol": "http"
 }


### PR DESCRIPTION
Can be configured by the following value to /opt/traffic_stats/traffic_stats.cfg `"influxProtocol": "http"`.
If no protocol is defined in the config, Traffic Stats will default to http.

In order for https to work you need a "real" cert.  Trying to use a self-signed cert results an error like: `[ERROR] 2016-03-16 15:51:10 Get https://localhost:8086/query?db=&q=show+databases: x509: certificate signed by unknown authority`

For influxdb configuration questions, see the influxdb documentation.

this closes #1143 