### PR TITLE
BACKPORT - Return a 500 response if an Error is encountered in ConfigFiles.pm

### DIFF
--- a/traffic_ops/app/lib/MojoPlugins/Response.pm
+++ b/traffic_ops/app/lib/MojoPlugins/Response.pm
@@ -126,19 +126,6 @@ sub register {
 		}
 	);
 
-	# Alerts (500)
-	$app->renderer->add_helper(
-		internal_server_error => sub {
-			my $self   = shift || confess("Call on an instance of MojoPlugins::Response");
-			my $alerts = shift || confess("Please supply the alerts hash");
-
-			my $builder ||= MojoPlugins::Response::Builder->new( $self, @_ );
-			my @alerts_response = $builder->build_alerts($alerts);
-
-			return $self->render( $STATUS_KEY => 500, $JSON_KEY => { $ALERTS_KEY => \@alerts_response } );
-		}
-	);
-
 	# Unauthorized (401)
 	$app->renderer->add_helper(
 		unauthorized => sub {

--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -91,6 +91,9 @@ sub genfiles {
 			$text = &take_and_bake( $self, $id, $org_name );
 		}
 	}
+	if ($text =~ /^Error/) {
+		$self->internal_server_error( { Error => $text } );
+	}
 
 	if ( $file ne "all" ) {
 		$self->res->headers->content_type("application/download");


### PR DESCRIPTION
In ConfigFiles.pm, if the response coming back from method called by dispatch table starts with Error, send a 500 response

(cherry picked from commit a864693e7b44dc2775f77a7161505ae1265f6f3a)