### PR TITLE
Add TO 2.0 Relational Caching Proxy config

### DIFF
--- a/traffic_ops/experimental/server/api/api.go
+++ b/traffic_ops/experimental/server/api/api.go
@@ -104,44 +104,45 @@ func ApiHandlers() map[string]ApiHandlerFuncMap {
 		"federation_resolver/{id}":            ApiHandlerFuncMap{GET: idWrap(getFederationResolverById), PUT: idBodyWrap(putFederationResolver), DELETE: idWrap(delFederationResolver)},
 		"federation_tmuser":                   ApiHandlerFuncMap{GET: emptyWrap(getFederationTmusers), POST: bodyWrap(postFederationTmuser)},
 		"federation_tmuser/{id}":              ApiHandlerFuncMap{GET: idWrap(getFederationTmuserById), PUT: idBodyWrap(putFederationTmuser), DELETE: idWrap(delFederationTmuser)},
-		"job":                    ApiHandlerFuncMap{GET: emptyWrap(getJobs), POST: bodyWrap(postJob)},
-		"job/{id}":               ApiHandlerFuncMap{GET: idWrap(getJobById), PUT: idBodyWrap(putJob), DELETE: idWrap(delJob)},
-		"job_result":             ApiHandlerFuncMap{GET: emptyWrap(getJobResults), POST: bodyWrap(postJobResult)},
-		"job_result/{id}":        ApiHandlerFuncMap{GET: idWrap(getJobResultById), PUT: idBodyWrap(putJobResult), DELETE: idWrap(delJobResult)},
-		"job_status":             ApiHandlerFuncMap{GET: emptyWrap(getJobStatuss), POST: bodyWrap(postJobStatus)},
-		"job_status/{id}":        ApiHandlerFuncMap{GET: idWrap(getJobStatusById), PUT: idBodyWrap(putJobStatus), DELETE: idWrap(delJobStatus)},
-		"log":                    ApiHandlerFuncMap{GET: emptyWrap(getLogs), POST: bodyWrap(postLog)},
-		"log/{id}":               ApiHandlerFuncMap{GET: idWrap(getLogById), PUT: idBodyWrap(putLog), DELETE: idWrap(delLog)},
-		"parameter":              ApiHandlerFuncMap{GET: emptyWrap(getParameters), POST: bodyWrap(postParameter)},
-		"parameter/{id}":         ApiHandlerFuncMap{GET: idWrap(getParameterById), PUT: idBodyWrap(putParameter), DELETE: idWrap(delParameter)},
-		"phys_location":          ApiHandlerFuncMap{GET: emptyWrap(getPhysLocations), POST: bodyWrap(postPhysLocation)},
-		"phys_location/{id}":     ApiHandlerFuncMap{GET: idWrap(getPhysLocationById), PUT: idBodyWrap(putPhysLocation), DELETE: idWrap(delPhysLocation)},
-		"profile":                ApiHandlerFuncMap{GET: emptyWrap(getProfiles), POST: bodyWrap(postProfile)},
-		"profile/{id}":           ApiHandlerFuncMap{GET: idWrap(getProfileById), PUT: idBodyWrap(putProfile), DELETE: idWrap(delProfile)},
-		"profile_parameter":      ApiHandlerFuncMap{GET: emptyWrap(getProfileParameters), POST: bodyWrap(postProfileParameter)},
-		"profile_parameter/{id}": ApiHandlerFuncMap{GET: idWrap(getProfileParameterById), PUT: idBodyWrap(putProfileParameter), DELETE: idWrap(delProfileParameter)},
-		"regex":                  ApiHandlerFuncMap{GET: emptyWrap(getRegexs), POST: bodyWrap(postRegex)},
-		"regex/{id}":             ApiHandlerFuncMap{GET: idWrap(getRegexById), PUT: idBodyWrap(putRegex), DELETE: idWrap(delRegex)},
-		"region":                 ApiHandlerFuncMap{GET: emptyWrap(getRegions), POST: bodyWrap(postRegion)},
-		"region/{id}":            ApiHandlerFuncMap{GET: idWrap(getRegionById), PUT: idBodyWrap(putRegion), DELETE: idWrap(delRegion)},
-		"role":                   ApiHandlerFuncMap{GET: emptyWrap(getRoles), POST: bodyWrap(postRole)},
-		"role/{id}":              ApiHandlerFuncMap{GET: idWrap(getRoleById), PUT: idBodyWrap(putRole), DELETE: idWrap(delRole)},
-		"server":                 ApiHandlerFuncMap{GET: emptyWrap(getServers), POST: bodyWrap(postServer)},
-		"server/{id}":            ApiHandlerFuncMap{GET: idWrap(getServerById), PUT: idBodyWrap(putServer), DELETE: idWrap(delServer)},
-		"servercheck":            ApiHandlerFuncMap{GET: emptyWrap(getServerchecks), POST: bodyWrap(postServercheck)},
-		"servercheck/{id}":       ApiHandlerFuncMap{GET: idWrap(getServercheckById), PUT: idBodyWrap(putServercheck), DELETE: idWrap(delServercheck)},
-		"staticdnsentry":         ApiHandlerFuncMap{GET: emptyWrap(getStaticdnsentrys), POST: bodyWrap(postStaticdnsentry)},
-		"staticdnsentry/{id}":    ApiHandlerFuncMap{GET: idWrap(getStaticdnsentryById), PUT: idBodyWrap(putStaticdnsentry), DELETE: idWrap(delStaticdnsentry)},
-		"stats_summary":          ApiHandlerFuncMap{GET: emptyWrap(getStatsSummarys), POST: bodyWrap(postStatsSummary)},
-		"stats_summary/{id}":     ApiHandlerFuncMap{GET: idWrap(getStatsSummaryById), PUT: idBodyWrap(putStatsSummary), DELETE: idWrap(delStatsSummary)},
-		"status":                 ApiHandlerFuncMap{GET: emptyWrap(getStatuss), POST: bodyWrap(postStatus)},
-		"status/{id}":            ApiHandlerFuncMap{GET: idWrap(getStatusById), PUT: idBodyWrap(putStatus), DELETE: idWrap(delStatus)},
-		"tm_user":                ApiHandlerFuncMap{GET: emptyWrap(getTmUsers), POST: bodyWrap(postTmUser)},
-		"tm_user/{id}":           ApiHandlerFuncMap{GET: idWrap(getTmUserById), PUT: idBodyWrap(putTmUser), DELETE: idWrap(delTmUser)},
-		"to_extension":           ApiHandlerFuncMap{GET: emptyWrap(getToExtensions), POST: bodyWrap(postToExtension)},
-		"to_extension/{id}":      ApiHandlerFuncMap{GET: idWrap(getToExtensionById), PUT: idBodyWrap(putToExtension), DELETE: idWrap(delToExtension)},
-		"type":                   ApiHandlerFuncMap{GET: emptyWrap(getTypes), POST: bodyWrap(postType)},
-		"type/{id}":              ApiHandlerFuncMap{GET: idWrap(getTypeById), PUT: idBodyWrap(putType), DELETE: idWrap(delType)},
+		"job":                         ApiHandlerFuncMap{GET: emptyWrap(getJobs), POST: bodyWrap(postJob)},
+		"job/{id}":                    ApiHandlerFuncMap{GET: idWrap(getJobById), PUT: idBodyWrap(putJob), DELETE: idWrap(delJob)},
+		"job_result":                  ApiHandlerFuncMap{GET: emptyWrap(getJobResults), POST: bodyWrap(postJobResult)},
+		"job_result/{id}":             ApiHandlerFuncMap{GET: idWrap(getJobResultById), PUT: idBodyWrap(putJobResult), DELETE: idWrap(delJobResult)},
+		"job_status":                  ApiHandlerFuncMap{GET: emptyWrap(getJobStatuss), POST: bodyWrap(postJobStatus)},
+		"job_status/{id}":             ApiHandlerFuncMap{GET: idWrap(getJobStatusById), PUT: idBodyWrap(putJobStatus), DELETE: idWrap(delJobStatus)},
+		"log":                         ApiHandlerFuncMap{GET: emptyWrap(getLogs), POST: bodyWrap(postLog)},
+		"log/{id}":                    ApiHandlerFuncMap{GET: idWrap(getLogById), PUT: idBodyWrap(putLog), DELETE: idWrap(delLog)},
+		"parameter":                   ApiHandlerFuncMap{GET: emptyWrap(getParameters), POST: bodyWrap(postParameter)},
+		"parameter/{id}":              ApiHandlerFuncMap{GET: idWrap(getParameterById), PUT: idBodyWrap(putParameter), DELETE: idWrap(delParameter)},
+		"phys_location":               ApiHandlerFuncMap{GET: emptyWrap(getPhysLocations), POST: bodyWrap(postPhysLocation)},
+		"phys_location/{id}":          ApiHandlerFuncMap{GET: idWrap(getPhysLocationById), PUT: idBodyWrap(putPhysLocation), DELETE: idWrap(delPhysLocation)},
+		"profile":                     ApiHandlerFuncMap{GET: emptyWrap(getProfiles), POST: bodyWrap(postProfile)},
+		"profile/{id}":                ApiHandlerFuncMap{GET: idWrap(getProfileById), PUT: idBodyWrap(putProfile), DELETE: idWrap(delProfile)},
+		"profile_parameter":           ApiHandlerFuncMap{GET: emptyWrap(getProfileParameters), POST: bodyWrap(postProfileParameter)},
+		"profile_parameter/{id}":      ApiHandlerFuncMap{GET: idWrap(getProfileParameterById), PUT: idBodyWrap(putProfileParameter), DELETE: idWrap(delProfileParameter)},
+		"regex":                       ApiHandlerFuncMap{GET: emptyWrap(getRegexs), POST: bodyWrap(postRegex)},
+		"regex/{id}":                  ApiHandlerFuncMap{GET: idWrap(getRegexById), PUT: idBodyWrap(putRegex), DELETE: idWrap(delRegex)},
+		"region":                      ApiHandlerFuncMap{GET: emptyWrap(getRegions), POST: bodyWrap(postRegion)},
+		"region/{id}":                 ApiHandlerFuncMap{GET: idWrap(getRegionById), PUT: idBodyWrap(putRegion), DELETE: idWrap(delRegion)},
+		"role":                        ApiHandlerFuncMap{GET: emptyWrap(getRoles), POST: bodyWrap(postRole)},
+		"role/{id}":                   ApiHandlerFuncMap{GET: idWrap(getRoleById), PUT: idBodyWrap(putRole), DELETE: idWrap(delRole)},
+		"server":                      ApiHandlerFuncMap{GET: emptyWrap(getServers), POST: bodyWrap(postServer)},
+		"server/{id}":                 ApiHandlerFuncMap{GET: idWrap(getServerById), PUT: idBodyWrap(putServer), DELETE: idWrap(delServer)},
+		"servercheck":                 ApiHandlerFuncMap{GET: emptyWrap(getServerchecks), POST: bodyWrap(postServercheck)},
+		"servercheck/{id}":            ApiHandlerFuncMap{GET: idWrap(getServercheckById), PUT: idBodyWrap(putServercheck), DELETE: idWrap(delServercheck)},
+		"staticdnsentry":              ApiHandlerFuncMap{GET: emptyWrap(getStaticdnsentrys), POST: bodyWrap(postStaticdnsentry)},
+		"staticdnsentry/{id}":         ApiHandlerFuncMap{GET: idWrap(getStaticdnsentryById), PUT: idBodyWrap(putStaticdnsentry), DELETE: idWrap(delStaticdnsentry)},
+		"stats_summary":               ApiHandlerFuncMap{GET: emptyWrap(getStatsSummarys), POST: bodyWrap(postStatsSummary)},
+		"stats_summary/{id}":          ApiHandlerFuncMap{GET: idWrap(getStatsSummaryById), PUT: idBodyWrap(putStatsSummary), DELETE: idWrap(delStatsSummary)},
+		"status":                      ApiHandlerFuncMap{GET: emptyWrap(getStatuss), POST: bodyWrap(postStatus)},
+		"status/{id}":                 ApiHandlerFuncMap{GET: idWrap(getStatusById), PUT: idBodyWrap(putStatus), DELETE: idWrap(delStatus)},
+		"tm_user":                     ApiHandlerFuncMap{GET: emptyWrap(getTmUsers), POST: bodyWrap(postTmUser)},
+		"tm_user/{id}":                ApiHandlerFuncMap{GET: idWrap(getTmUserById), PUT: idBodyWrap(putTmUser), DELETE: idWrap(delTmUser)},
+		"to_extension":                ApiHandlerFuncMap{GET: emptyWrap(getToExtensions), POST: bodyWrap(postToExtension)},
+		"to_extension/{id}":           ApiHandlerFuncMap{GET: idWrap(getToExtensionById), PUT: idBodyWrap(putToExtension), DELETE: idWrap(delToExtension)},
+		"type":                        ApiHandlerFuncMap{GET: emptyWrap(getTypes), POST: bodyWrap(postType)},
+		"type/{id}":                   ApiHandlerFuncMap{GET: idWrap(getTypeById), PUT: idBodyWrap(putType), DELETE: idWrap(delType)},
+		"caching_proxy_record/{name}": ApiHandlerFuncMap{GET: nameWrap(getCachingProxyConfig)},
 	}
 }
 
@@ -149,6 +150,8 @@ type EmptyHandlerFunc func(db *sqlx.DB) (interface{}, error)
 type IntHandlerFunc func(id int, db *sqlx.DB) (interface{}, error)
 type BodyHandlerFunc func(payload []byte, db *sqlx.DB) (interface{}, error)
 type IntBodyHandlerFunc func(id int, payload []byte, db *sqlx.DB) (interface{}, error)
+type StringHandlerFunc func(s string, db *sqlx.DB) (interface{}, error)
+type StringBodyHandlerFunc func(s string, payload []byte, db *sqlx.DB) (interface{}, error)
 
 func idBodyWrap(f IntBodyHandlerFunc) ApiHandlerFunc {
 	return func(pathParams map[string]string, payload []byte, db *sqlx.DB) (interface{}, error) {
@@ -172,6 +175,22 @@ func bodyWrap(f BodyHandlerFunc) ApiHandlerFunc {
 	return func(pathParams map[string]string, payload []byte, db *sqlx.DB) (interface{}, error) {
 		return f(payload, db)
 	}
+}
+
+func nameBodyWrap(f StringBodyHandlerFunc) ApiHandlerFunc {
+	return func(pathParams map[string]string, payload []byte, db *sqlx.DB) (interface{}, error) {
+		if name, ok := pathParams["name"]; !ok {
+			return nil, errors.New("Name missing")
+		} else {
+			return f(name, payload, db)
+		}
+	}
+}
+
+func nameWrap(f StringHandlerFunc) ApiHandlerFunc {
+	return nameBodyWrap(func(name string, payload []byte, db *sqlx.DB) (interface{}, error) {
+		return f(name, db)
+	})
 }
 
 func emptyWrap(f EmptyHandlerFunc) ApiHandlerFunc {

--- a/traffic_ops/experimental/server/api/caching_proxy_config.go
+++ b/traffic_ops/experimental/server/api/caching_proxy_config.go
@@ -1,0 +1,593 @@
+// Copyright 2015 Comcast Cable Communications Management, LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// \todo change time members to ISO 8601 strings, instead of nanosecond integers.
+
+package api
+
+import (
+	_ "github.com/Comcast/traffic_control/traffic_ops/experimental/server/output_format" // needed for swagger
+	"github.com/jmoiron/sqlx"
+	"log"
+	"time"
+)
+
+type CachingProxyRecordPort struct {
+	Port uint `json:"port"`
+	IPv6 bool `json:"ipv6"`
+	SSL  bool `json:"ssl"`
+}
+
+type CachingProxyRecordSSL struct {
+	Profile                  string `db:"profile" json:"-"`
+	ClientCaCertFilename     string `db:"client_ca_cert_filename"`
+	ClientCaCertPath         string `db:"client_ca_cert_path"`
+	ClientCertFilename       string `db:"client_cert_filename"`
+	ClientCertPath           string `db:"client_cert_path"`
+	ClientCertificationLevel int    `db:"client_certification_level"`
+	ClientPrivateKeyFilename string `db:"client_private_key_filename"`
+	ClientPrivateKeyPath     string `db:"client_private_key_path"`
+	ClientVerifyServer       int    `db:"client_verify_server"`
+	Compression              int    `db:"compression"`
+	NumberThreads            int    `db:"number_threads"`
+	ServerCertPath           string `db:"server_cert_path"`
+	ServerCertChainFilename  string `db:"server_cert_chain_filename"`
+	ServerCipherSuite        string `db:"server_cipher_suite"`
+	ServerHonorCipherOrder   int    `db:"server_honor_cipher_order"`
+	ServerMulticertFilename  string `db:"server_multicert_filename"`
+	ServerPrivateKeyPath     string `db:"server_private_key_path"`
+	Sslv2                    bool   `db:"sslv2"`
+	Sslv3                    bool   `db:"sslv3"`
+	Tlsv1                    bool   `db:"tlsv1"`
+	CaCertFilename           string `db:"ca_cert_filename"`
+	CaCertPath               string `db:"ca_cert_path"`
+}
+
+type CachingProxyRecordHostDb struct {
+	Profile          string        `db:"profile" json:"-"`
+	ServerStaleFor   time.Duration `db:"server_stale_for"`
+	Size             int           `db:"size"`
+	StorageSize      int           `db:"storage_size"`
+	StrictRoundRobin bool          `db:"strict_round_robin"`
+	Timeout          int           `db:"timeout"`
+	TtlMode          string        `db:"ttl_mode"`
+}
+
+type CachingProxyRecordCache struct {
+	Profile                   string `db:"profile" json:"-"`
+	ControlFilename           string `db:"filename"`
+	HostingFilename           string `db:"hosting_filename"`
+	HttpCompatability420Fixup int    `db:"http_compatability_420_fixup"`
+	LimitsHttpMaxAlts         int    `db:"limits_http_max_alts"`
+	MaxDocSize                int    `db:"max_doc_size"`
+	MinAverageObjectSize      int    `db:"min_average_object_size"`
+	MutexRetryDelay           int    `db:"mutex_retry_delay"`
+	PermitPinning             int    `db:"permit_pinning"`
+	RamCacheAlgorithm         int    `db:"ram_cache_algorithm"`
+	RamCacheCompress          int    `db:"ram_cache_compress"`
+	RamCacheSize              int    `db:"ram_cache_size"`
+	RamCacheUseSeenFilter     bool   `db:"ram_cache_use_seen_filter"`
+	RamCacheCutoff            int    `db:"ram_cache_cutoff"`
+	TargetFragmentSize        int    `db:"target_fragment_size"`
+	ThreadsPerDisk            int    `db:"threads_per_disk"`
+}
+
+type CachingProxyRecordHttpCache struct {
+	Profile                        string        `db:"profile" json:"-"`
+	AllowEmptyDoc                  bool          `db:"allow_empty_doc"`
+	CacheResponsesToCookies        string        `db:"cache_responses_to_cookies"`
+	CacheUrlsThatLookDynamic       bool          `db:"cache_urls_that_look_dynamic"`
+	EnableDefaultVaryHeaders       bool          `db:"enable_default_vary_headers"`
+	FuzzProbability                float64       `db:"fuzz_probability"`
+	FuzzTime                       time.Duration `db:"fuzz_time"`
+	HeuristicLmFactor              float64       `db:"heuristic_lm_factor"`
+	HeuristicMaxLifetime           int           `db:"heuristic_max_lifetime"`
+	HeuristicMinLifetime           int           `db:"heuristic_min_lifetime"`
+	Http                           bool          `db:"http"`
+	IgnoreAcceptEncodingMismatch   bool          `db:"ignore_accept_encoding_mismatch"`
+	IgnoreAuthentication           bool          `db:"ignore_authentication"`
+	IgnoreClientCcMaxAge           int           `db:"ignore_client_cc_max_age"`
+	IgnoreClientNoCache            bool          `db:"ignore_client_no_cache"`
+	IgnoreServerNoCache            bool          `db:"ignore_server_no_cache"`
+	ImsOnClientNoCache             bool          `db:"ims_on_client_no_cache"`
+	MaxStaleAge                    int           `db:"max_stale_age"`
+	RangeLookup                    bool          `db:"range_lookup"`
+	RequiredHeaders                string        `db:"required_headers"`
+	VaryDefaultImages              string        `db:"vary_default_images"`
+	VaryDefaultOther               string        `db:"vary_default_other"`
+	VaryDefaultText                string        `db:"vary_default_text"`
+	WhenToAddNoCacheToMsieRequests int           `db:"when_to_add_no_cache_to_msie_requests"`
+	WhenToRevalidate               string        `db:"when_to_revalidate"`
+}
+
+type CachingProxyRecordHttp struct {
+	Profile string `db:"profile" json:"-"`
+	Cache   CachingProxyRecordHttpCache
+
+	AcceptNoActivityTimeout                       int           `db:"accept_no_activity_timeout"`
+	AnonymizeInsertClientIp                       int           `db:"anonymize_insert_client_ip"`
+	AnonymizeOtherHeaderList                      string        `db:"anonymize_other_header_list"`
+	AnonymizeRemoveClientIp                       bool          `db:"anonymize_remove_client_ip"`
+	AnonymizeRemoveCookie                         bool          `db:"anonymize_remove_cookie"`
+	AnonymizeRemoveFrom                           bool          `db:"anonymize_remove_from"`
+	AnonymizeRemoveReferer                        bool          `db:"anonymize_remove_referer"`
+	AnonymizeRemoveUserAgent                      bool          `db:"anonymize_remove_user_agent"`
+	BackgroundFillActiveTimeout                   int           `db:"background_fill_active_timeout"`
+	BackgroundFillCompletedThreshold              float64       `db:"background_fill_completed_threshold"`
+	ChunkingEnabled                               string        `db:"chunking_enabled"`
+	CongestionControlEnabled                      bool          `db:"congestion_control_enabled"`
+	ConnectAttemptsMaxRetries                     int           `db:"connect_attempts_max_retries"`
+	ConnectAttemptsMaxRetriesDeadServer           int           `db:"connect_attempts_max_retries_dead_server"`
+	ConnectAttemptsRrRetries                      int           `db:"connect_attempts_rr_retries"`
+	ConnectAttemptsTimeout                        int           `db:"connect_attempts_timeout"`
+	DownServerAbortThreshold                      int           `db:"down_server_abort_threshold"`
+	DownServerCacheTime                           int           `db:"down_server_cache_time"`
+	EnableHttpStats                               bool          `db:"enable_http_stats"`
+	EnableUrlExpandomatic                         bool          `db:"enable_url_expandomatic"`
+	ForwardProxyAuthToParent                      bool          `db:"forward_proxy_auth_to_parent"`
+	InsertAgeInResponse                           bool          `db:"insert_age_in_response"`
+	InsertRequestViaStr                           string        `db:"insert_request_via_str"`
+	InsertResponseViaStr                          string        `db:"insert_response_via_str"`
+	InsertSquidXForwardedFor                      bool          `db:"insert_squid_x_forwarded_for"`
+	KeepAliveEnabledIn                            bool          `db:"keep_alive_enabled_in"`
+	KeepAliveEnabledOut                           bool          `db:"keep_alive_enabled_out"`
+	KeepAliveEnabledNoActivityTimeoutIn           int           `db:"keep_alive_enabled_no_activity_timeout_in"`
+	KeepAliveEnabledNoActivityTimeoutOut          int           `db:"keep_alive_enabled_no_activity_timeout_out"`
+	NegativeCachingEnabled                        bool          `db:"negative_caching_enabled"`
+	NegativeCachingLifetime                       int           `db:"negative_caching_lifetime"`
+	NoDnsJustForwardToParent                      bool          `db:"no_dns_just_forward_to_parent"`
+	NormalizeAeGzip                               bool          `db:"normalize_ae_gzip"`
+	OriginServerPipeline                          int           `db:"origin_server_pipeline"`
+	ParentProxyConnectAttemptsTimeout             int           `db:"parent_proxy_connect_attempts_timeout"`
+	ParentProxyFailThreshold                      int           `db:"parent_proxy_fail_threshold"`
+	ParentProxyFile                               string        `db:"parent_proxy_file"`
+	ParentProxyPerParentConnectionAttempts        int           `db:"parent_proxy_per_parent_connection_attempts"`
+	ParentProxyParentProxyRetryTime               int           `db:"parent_proxy_parent_proxy_retry_time"`
+	ParentProxyParentProxyTotalConnectionAttempts int           `db:"parent_proxy_parent_proxy_total_connection_attempts"`
+	ParentProxyParentProxyRoutingEnable           bool          `db:"parent_proxy_parent_proxy_routing_enable"`
+	PostConnectAttemptsTimeout                    int           `db:"post_connect_attempts_timeout"`
+	ParentPushMethodEnabled                       bool          `db:"parent_push_method_enabled"`
+	RefererDefaultRedirect                        string        `db:"referer_default_redirect"`
+	RefererFilter                                 int           `db:"referer_filter"`
+	RefererFormatRedirect                         int           `db:"referer_format_redirect"`
+	ResponseServerEnabled                         string        `db:"response_server_enabled"`
+	SendHttp11Requests                            string        `db:"send_http11_requests"`
+	ShareServerSessions                           int           `db:"share_server_sessions"`
+	SlowLogThreshold                              int           `db:"slow_log_threshold"`
+	TransactionActiveTimeoutIn                    time.Duration `db:"transaction_active_timeout_in"`
+	TransactionActiveTimeoutOut                   time.Duration `db:"transaction_active_timeout_out"`
+	TransactionNoActivityTimeoutIn                time.Duration `db:"transaction_no_activity_timeout_in"`
+	TransactionNoActivityTimeoutOut               time.Duration `db:"transaction_no_activity_timeout_out"`
+	UncacheableRequestsBypassParent               bool          `db:"uncacheable_requests_bypass_parent"`
+	UserAgentPipeline                             int           `db:"user_agent_pipeline"`
+}
+
+type CachingProxyRecordLogData struct {
+	Profile string `db:"profile" json:"-"`
+	Name    string `db:"name"`
+	Enabled bool   `db:"enabled"`
+	Header  string `db:"header"`
+	IsAscii bool   `db:"is_ascii"`
+}
+
+type CachingProxyRecordLog struct {
+	Profile string `db:"profile" json:"-"`
+
+	Squid     CachingProxyRecordLogData
+	Common    CachingProxyRecordLogData
+	Extended2 CachingProxyRecordLogData
+	Extended  CachingProxyRecordLogData
+
+	AutoDeleteRolledFiles   bool          `db:"auto_delete_rolled_files"`
+	CollationHost           string        `db:"collation_host"`
+	CollationHostTagged     bool          `db:"collation_host_tagged"`
+	CollationPort           int           `db:"collation_port"`
+	CollationRetry          time.Duration `db:"collation_retry"`
+	CollationSecret         string        `db:"collation_secret"`
+	CustomLogsEnabled       int           `db:"custom_logs_enabled"`
+	Hostname                string        `db:"hostname"`
+	LogfileDir              string        `db:"logfile_dir"`
+	LogfilePerm             string        `db:"logfile_perm"`
+	LoggingEnabled          string        `db:"logging_enabled"`
+	MaxSecsPerBuffer        int           `db:"max_secs_per_buffer"`
+	MaxSpaceMbForLogs       int           `db:"max_space_mb_for_logs"`
+	MaxSpaceMbForOrphanLogs int           `db:"max_space_mb_for_orphan_logs"`
+	MaxSpaceMbHeadroom      int           `db:"max_space_mb_headroom"`
+	RollingEnabled          string        `db:"rolling_enabled"`
+	RollingInterval         time.Duration `db:"rolling_interval"`
+	RollingOffset           time.Duration `db:"rolling_offset"`
+	RollingSizeMb           int           `db:"rolling_size_mb"`
+	SamplingFrequency       int           `db:"sampling_frequency"`
+	SeparateHostLogs        int           `db:"separate_host_logs"`
+	SeparateIcpLogs         int           `db:"separate_icp_logs"`
+	XmlConfigFile           string        `db:"xml_config_file"`
+}
+
+type CachingProxyRecord struct {
+	Profile string `db:"profile"`
+
+	Ssl    CachingProxyRecordSSL
+	HostDb CachingProxyRecordHostDb
+	Cache  CachingProxyRecordCache
+	Http   CachingProxyRecordHttp
+	Log    CachingProxyRecordLog
+
+	// \todo add these to sql schema
+	Location         string        `db:"location"`
+	DnsLookupTimeout time.Duration `db:"dns_lookup_timeout"`
+	IpAllowFilename  string        `db:"ip_allow_filename"`
+
+	AcceptThreads                         int           `db:"accept_threads"`
+	AdminUser                             string        `db:"admin_user"`
+	UserId                                string        `db:"user_id"`
+	AutoconfPort                          int           `db:"autoconf_port"`
+	NumberConfig                          int           `db:"number_config"`
+	AlarmAbsPath                          string        `db:"alarm_abs_path"`
+	AlarmBin                              string        `db:"alarm_bin"`
+	AlarmEmail                            string        `db:"alarm_email"`
+	AllocatorDebugFilter                  int           `db:"allocator_debug_filter"`
+	AllocatorEnableReclaim                bool          `db:"allocator_enable_reclaim"`
+	AllocatorHugePages                    bool          `db:"allocator_huge_pages"`
+	AllocatorMaxOverage                   int           `db:"allocator_max_overage"`
+	AllocatorThreadFreelistSize           int           `db:"allocator_thread_freelist_size"`
+	BodyFactoryEnableCustomizations       string        `db:"body_factory_enable_customizations"`
+	BodyFactoryEnableLogging              bool          `db:"body_factory_enable_logging"`
+	BodyFactoryResponseSuppressionMode    string        `db:"body_factory_response_suppression_mode"`
+	BodyFactoryTemplateSetsDir            string        `db:"body_factory_template_sets_dir"`
+	EnableReadWhileWriter                 string        `db:"enable_read_while_writer"`
+	ClusterConfiguration                  string        `db:"cluster_configuration"`
+	ClusterClusterPort                    int           `db:"cluster_cluster_port"`
+	ClusterEthernetInterface              string        `db:"cluster_ethernet_interface"`
+	ClusterLogBogusMcMsgs                 int           `db:"cluster_log_bogus_mc_msgs"`
+	ClusterMcGroupAddr                    string        `db:"cluster_mc_group_addr"`
+	ClusterMcTtl                          int           `db:"cluster_mc_ttl"`
+	ClusterMcport                         int           `db:"cluster_mcport"`
+	ClusterRsport                         int           `db:"cluster_rsport"`
+	ConfigDir                             string        `db:"config_dir"`
+	CoreLimit                             int           `db:"core_limit"`
+	DiagsDebugEnabled                     bool          `db:"diags_debug_enabled"`
+	DiagsDebugTags                        string        `db:"diags_debug_tags"`
+	DiagsShowLocation                     bool          `db:"diags_show_location"`
+	DnsMaxDnsInFlight                     int           `db:"dns_max_dns_in_flight"`
+	DnsNameservers                        string        `db:"dns_nameservers"`
+	DnsResolvConf                         string        `db:"dns_resolv_conf"`
+	DnsRoundRobinNameservers              bool          `db:"dns_round_robin_nameservers"`
+	DnsSearchDefaultDomains               string        `db:"dns_search_default_domains"`
+	DnsSplitDnsEnabled                    bool          `db:"dns_splitdns_enabled"`
+	DnsUrlExpansions                      string        `db:"dns_url_expansions"`
+	DnsValidateQueryName                  bool          `db:"dns_validate_query_name"`
+	DumpMemInfoFrequency                  int           `db:"dump_mem_info_frequency"`
+	EnvPrep                               string        `db:"env_prep"`
+	ExecThreadAffinity                    string        `db:"exec_thread_affinity"`
+	ExecThreadAutoconfig                  bool          `db:"exec_thread_autoconfig"`
+	ExecThreadAutoconfigScale             float64       `db:"exec_thread_autoconfig_scale"`
+	ExecThreadLimit                       int           `db:"exec_thread_limit"`
+	ParseNoHostUrlRedirect                string        `db:"parse_no_host_url_redirect"`
+	IcpEnabled                            string        `db:"icp_enabled"`
+	IcpInterface                          string        `db:"icp_interface"`
+	IcpPort                               int           `db:"icp_port"`
+	IcpMulticastEnabled                   int           `db:"icp_multicast_enabled"`
+	IcpQueryTimeout                       int           `db:"icp_query_timeout"`
+	MlocEnabled                           int           `db:"mloc_enabled"`
+	NetConnectionsThrottle                int           `db:"net_connections_throttle"`
+	NetDeferAccept                        bool          `db:"net_defer_accept"`
+	NetSockRecvBufferSizeIn               int           `db:"net_sock_recv_buffer_size_in"`
+	NetSockRecvBufferSizeOut              int           `db:"net_sock_recv_buffer_size_out"`
+	NetSockSendBufferSizeIn               int           `db:"net_sock_send_buffer_size_in"`
+	NetSockSendBufferSizeOut              int           `db:"net_sock_send_buffer_size_out"`
+	OutputLogfile                         string        `db:"output_logfile"`
+	ProcessManagerManagementPort          int           `db:"process_manager_management_port"`
+	ProxyBinaryOpts                       string        `db:"proxy_binary_opts"`
+	ProxyName                             string        `db:"proxy_name"`
+	ReverseProxyEnabled                   bool          `db:"reverse_proxy_enabled"`
+	SnapshotDir                           string        `db:"snapshot_dir"`
+	StackDumpEnabled                      int           `db:"stack_dump_enabled"`
+	SyslogFacility                        string        `db:"syslog_facility"`
+	SystemMmapMax                         int           `db:"system_mmap_max"`
+	TaskThreads                           int           `db:"task_threads"`
+	TempDir                               string        `db:"temp_dir"`
+	UpdateConcurrentUpdates               int           `db:"update_concurrent_updates"`
+	UpdateEnabled                         int           `db:"update_enabled"`
+	UpdateForce                           int           `db:"update_force"`
+	UpdateRetryCount                      int           `db:"update_retry_count"`
+	UpdateRetryInterval                   time.Duration `db:"update_retry_interval"`
+	UrlRemapDefaultToServerPac            int           `db:"url_remap_default_to_server_pac"`
+	UrlRemapDefaultToServerPacPort        *int          `db:"url_remap_default_to_server_pac_port"`
+	UrlRemapFilename                      string        `db:"url_remap_filename"`
+	UrlRemapPristineHostHdr               int           `db:"url_remap_pristine_host_hdr"`
+	UrlRemapRemapRequired                 int           `db:"url_remap_remap_required"`
+	CronOrtSyncdsCdn                      string        `db:"cron_ort_syncds_cdn"`
+	DomainName                            string        `db:"domain_name"`
+	HealthConnectionTimeout               int           `db:"health_connection_timeout"`
+	HealthPollingUrl                      string        `db:"health_polling_url"`
+	HealthThresholdAvailableBandwidthKbps int           `db:"health_threshold_available_bandwidth_kbps"`
+	HealthThresholdLoadAverage            int           `db:"health_threshold_load_average"`
+	HealthThresholdQueryTime              int           `db:"health_threshold_query_time"`
+	HistoryCount                          int           `db:"history_count"`
+	LocalClusterType                      int           `db:"local_cluster_type"`
+
+	LocalLogCollationMode  int           `db:"local_log_collation_mode"`
+	LogFormatFormat        string        `db:"log_format_format"`
+	LogFormatName          string        `db:"log_format_name"`
+	MaxRevalDuration       time.Duration `db:"max_reval_duration"`
+	AstatsPath             string        `db:"astats_path"`
+	Qstring                string        `db:"qstring"`
+	AstatsRecordTypes      int           `db:"astats_record_types"`
+	RegexRevalidate        string        `db:"regex_revalidate"`
+	AstatsLibrary          string        `db:"astats_library"`
+	TrafficServerChkconfig string        `db:"traffic_server_chkconfig"`
+
+	CrconfigWeight     float64 `db:"crconfig_weight"`
+	ParentConfigWeight float64 `db:"parent_config_weight"`
+	ServerPorts        []CachingProxyRecordPort
+	ConnectPorts       []uint
+
+	CacheInterimStorage string `db:"cache_interim_storage"`
+}
+
+func loadCachingProxyRecordSsl(profile string, db *sqlx.DB) (CachingProxyRecordSSL, error) {
+	ret := []CachingProxyRecordSSL{}
+	arg := CachingProxyRecordSSL{Profile: profile}
+	queryStr := `select profile, ca_cert_filename, ca_cert_path, client_ca_cert_filename, client_ca_cert_path, client_cert_filename, client_cert_path, client_certification_level, client_private_key_filename, client_private_key_path, client_verify_server, compression, number_threads, server_cert_path, server_cert_chain_filename, server_cipher_suite, server_honor_cipher_order, server_multicert_filename, server_private_key_path, SSLv2, SSLv3, TLSv1 from caching_proxy_record_data_ssl where profile=:profile`
+	nstmt, err := db.PrepareNamed(queryStr)
+	err = nstmt.Select(&ret, arg)
+	if err != nil {
+		log.Println(err)
+		return CachingProxyRecordSSL{}, err
+	}
+	nstmt.Close()
+
+	log.Println("DEBUG 0")
+
+	if len(ret) != 1 {
+		log.Printf("loadCachingProxyRecordSsl expecting 1 record, query returned %d", len(ret))
+		return CachingProxyRecordSSL{}, err
+	}
+
+	return ret[0], nil
+}
+
+func loadCachingProxyRecordHostDb(profile string, db *sqlx.DB) (CachingProxyRecordHostDb, error) {
+	ret := []CachingProxyRecordHostDb{}
+	arg := CachingProxyRecordHostDb{Profile: profile}
+	queryStr := `select profile, extract(epoch from server_stale_for) as server_stale_for, size, storage_size, strict_round_robin, timeout, ttl_mode from caching_proxy_record_data_hostdb where profile=:profile`
+	nstmt, err := db.PrepareNamed(queryStr)
+	err = nstmt.Select(&ret, arg)
+	if err != nil {
+		log.Println(err)
+		return CachingProxyRecordHostDb{}, err
+	}
+	nstmt.Close()
+
+	if len(ret) != 1 {
+		log.Printf("loadCachingProxyRecordHostDb expecting 1 record, query returned %d", len(ret))
+		return CachingProxyRecordHostDb{}, err
+	}
+
+	hostdb := ret[0]
+	hostdb.ServerStaleFor *= time.Second // Postgres epoch returns seconds. This multiplies it into nanoseconds, which are the correct internal representation of time.Duration
+	return hostdb, nil
+}
+
+func loadCachingProxyRecordCache(profile string, db *sqlx.DB) (CachingProxyRecordCache, error) {
+	ret := []CachingProxyRecordCache{}
+	arg := CachingProxyRecordCache{Profile: profile}
+	queryStr := `select profile, filename, hosting_filename, http_compatability_420_fixup, limits_http_max_alts, max_doc_size, min_average_object_size, mutex_retry_delay, permit_pinning, ram_cache_algorithm, ram_cache_compress, ram_cache_size, ram_cache_use_seen_filter, ram_cache_cutoff, target_fragment_size, threads_per_disk from caching_proxy_cache where profile=:profile`
+	nstmt, err := db.PrepareNamed(queryStr)
+	err = nstmt.Select(&ret, arg)
+	if err != nil {
+		log.Println(err)
+		return CachingProxyRecordCache{}, err
+	}
+	nstmt.Close()
+
+	if len(ret) != 1 {
+		log.Printf("loadCachingProxyRecordCache expecting 1 record, query returned %d", len(ret))
+		return CachingProxyRecordCache{}, err
+	}
+
+	return ret[0], nil
+}
+
+func loadCachingProxyRecordHttpCache(profile string, db *sqlx.DB) (CachingProxyRecordHttpCache, error) {
+	ret := []CachingProxyRecordHttpCache{}
+	arg := CachingProxyRecordHttpCache{Profile: profile}
+	queryStr := `select profile, allow_empty_doc, cache_responses_to_cookies, cache_urls_that_look_dynamic, enable_default_vary_headers, fuzz_probability, extract(epoch from fuzz_time) as fuzz_time, heuristic_lm_factor, heuristic_max_lifetime, heuristic_min_lifetime, http, ignore_accept_encoding_mismatch, ignore_authentication, ignore_client_cc_max_age, ignore_client_no_cache, ignore_server_no_cache, ims_on_client_no_cache, max_stale_age, range_lookup, required_headers, vary_default_images, vary_default_other, vary_default_text, when_to_add_no_cache_to_msie_requests, when_to_revalidate from caching_proxy_record_data_http_cache where profile=:profile`
+	nstmt, err := db.PrepareNamed(queryStr)
+	err = nstmt.Select(&ret, arg)
+	if err != nil {
+		log.Println(err)
+		return CachingProxyRecordHttpCache{}, err
+	}
+	nstmt.Close()
+
+	if len(ret) != 1 {
+		log.Printf("loadCachingProxyRecordHttpCache expecting 1 record, query returned %d", len(ret))
+		return CachingProxyRecordHttpCache{}, err
+	}
+
+	httpCache := ret[0]
+	httpCache.FuzzTime *= time.Second // Postgres epoch returns seconds. This multiplies it into nanoseconds, which are the correct internal representation of time.Duration
+	return httpCache, nil
+}
+
+func loadCachingProxyRecordHttp(profile string, db *sqlx.DB) (CachingProxyRecordHttp, error) {
+	ret := []CachingProxyRecordHttp{}
+	arg := CachingProxyRecordHttp{Profile: profile}
+	queryStr := `select profile, accept_no_activity_timeout, anonymize_insert_client_ip, anonymize_other_header_list, anonymize_remove_client_ip, anonymize_remove_cookie, anonymize_remove_from, anonymize_remove_referer, anonymize_remove_user_agent, background_fill_active_timeout, background_fill_completed_threshold, chunking_enabled, congestion_control_enabled, connect_attempts_max_retries, connect_attempts_max_retries_dead_server, connect_attempts_rr_retries, connect_attempts_timeout, down_server_abort_threshold, down_server_cache_time, enable_http_stats, enable_url_expandomatic, forward_proxy_auth_to_parent, insert_age_in_response, insert_request_via_str, insert_response_via_str, insert_squid_x_forwarded_for, keep_alive_enabled_in, keep_alive_enabled_out, keep_alive_enabled_no_activity_timeout_in, keep_alive_enabled_no_activity_timeout_out, negative_caching_enabled, negative_caching_lifetime, no_dns_just_forward_to_parent, normalize_ae_gzip, origin_server_pipeline, parent_proxy_connect_attempts_timeout, parent_proxy_fail_threshold, parent_proxy_file, parent_proxy_per_parent_connection_attempts, parent_proxy_parent_proxy_retry_time, parent_proxy_parent_proxy_total_connection_attempts, parent_proxy_parent_proxy_routing_enable, post_connect_attempts_timeout, parent_push_method_enabled, referer_default_redirect, referer_filter, referer_format_redirect, response_server_enabled, send_http11_requests, share_server_sessions, slow_log_threshold, extract(epoch from transaction_active_timeout_in) as transaction_active_timeout_in, extract(epoch from transaction_active_timeout_out) as transaction_active_timeout_out, extract(epoch from transaction_no_activity_timeout_in) as transaction_no_activity_timeout_in, extract(epoch from transaction_no_activity_timeout_out) as transaction_no_activity_timeout_out, uncacheable_requests_bypass_parent, user_agent_pipeline from caching_proxy_record_data_http where profile=:profile`
+	nstmt, err := db.PrepareNamed(queryStr)
+	err = nstmt.Select(&ret, arg)
+	if err != nil {
+		log.Println(err)
+		return CachingProxyRecordHttp{}, err
+	}
+	nstmt.Close()
+
+	if len(ret) != 1 {
+		log.Printf("loadCachingProxyRecordHttp expecting 1 record, query returned %d", len(ret))
+		return CachingProxyRecordHttp{}, err
+	}
+
+	recordHttp := ret[0]
+	recordHttp.Cache, err = loadCachingProxyRecordHttpCache(profile, db)
+	if err != nil {
+		log.Println(err)
+		return recordHttp, err
+	}
+
+	// Postgres epoch returns seconds. This multiplies it into nanoseconds, which are the correct internal representation of time.Duration
+	recordHttp.TransactionActiveTimeoutIn *= time.Second
+	recordHttp.TransactionActiveTimeoutOut *= time.Second
+	recordHttp.TransactionNoActivityTimeoutIn *= time.Second
+	recordHttp.TransactionNoActivityTimeoutOut *= time.Second
+	return recordHttp, nil
+}
+
+func loadCachingProxyRecordLogData(profile string, logName string, db *sqlx.DB) (CachingProxyRecordLogData, error) {
+	ret := []CachingProxyRecordLogData{}
+	arg := CachingProxyRecordLogData{Profile: profile, Name: logName}
+	queryStr := `select profile, name, enabled, header, is_ascii from caching_proxy_record_data_log_data where profile=:profile and name=:name`
+	nstmt, err := db.PrepareNamed(queryStr)
+	err = nstmt.Select(&ret, arg)
+	if err != nil {
+		log.Println(err)
+		return CachingProxyRecordLogData{}, err
+	}
+	nstmt.Close()
+
+	if len(ret) != 1 {
+		log.Printf("loadCachingProxyRecordLogData expecting 1 record, query returned %d", len(ret))
+		return CachingProxyRecordLogData{}, err
+	}
+
+	logData := ret[0]
+	return logData, nil
+}
+
+func loadCachingProxyRecordLog(profile string, db *sqlx.DB) (CachingProxyRecordLog, error) {
+	ret := []CachingProxyRecordLog{}
+	arg := CachingProxyRecordLog{Profile: profile}
+	queryStr := `select profile, auto_delete_rolled_files, collation_host, collation_host_tagged, collation_port, extract(epoch from collation_retry) as collation_retry, collation_secret, custom_logs_enabled, hostname, logfile_dir, logfile_perm, logging_enabled, max_secs_per_buffer, max_space_mb_for_logs, max_space_mb_for_orphan_logs, max_space_mb_headroom, rolling_enabled, extract(epoch from rolling_interval) as rolling_interval, extract(epoch from rolling_offset) as rolling_offset, rolling_size_mb, sampling_frequency, separate_host_logs, separate_icp_logs, xml_config_file from caching_proxy_record_data_log where profile=:profile`
+	nstmt, err := db.PrepareNamed(queryStr)
+	err = nstmt.Select(&ret, arg)
+	if err != nil {
+		log.Println(err)
+		return CachingProxyRecordLog{}, err
+	}
+	nstmt.Close()
+
+	if len(ret) != 1 {
+		log.Printf("loadCachingProxyRecordLog expecting 1 record, query returned %d", len(ret))
+		return CachingProxyRecordLog{}, err
+	}
+
+	recordLog := ret[0]
+	// Postgres epoch returns seconds. This multiplies it into nanoseconds, which are the correct internal representation of time.Duration
+	recordLog.CollationRetry *= time.Second
+	recordLog.RollingInterval *= time.Second
+	recordLog.RollingOffset *= time.Second
+
+	recordLog.Squid, err = loadCachingProxyRecordLogData(profile, "squid", db)
+	if err != nil {
+		log.Println(err)
+		return CachingProxyRecordLog{}, err
+	}
+
+	recordLog.Common, err = loadCachingProxyRecordLogData(profile, "common", db)
+	if err != nil {
+		log.Println(err)
+		return CachingProxyRecordLog{}, err
+	}
+
+	recordLog.Extended2, err = loadCachingProxyRecordLogData(profile, "extended2", db)
+	if err != nil {
+		log.Println(err)
+		return CachingProxyRecordLog{}, err
+	}
+
+	recordLog.Extended, err = loadCachingProxyRecordLogData(profile, "extended", db)
+	if err != nil {
+		log.Println(err)
+		return CachingProxyRecordLog{}, err
+	}
+
+	return recordLog, nil
+}
+
+func loadCachingProxyRecord(profile string, db *sqlx.DB) (CachingProxyRecord, error) {
+	ret := []CachingProxyRecord{}
+	arg := CachingProxyRecord{Profile: profile}
+	queryStr := `select profile, accept_threads, admin_user, user_id, autoconf_port, number_config, alarm_abs_path, alarm_bin, alarm_email, allocator_debug_filter, allocator_enable_reclaim, allocator_huge_pages, allocator_max_overage, allocator_thread_freelist_size, body_factory_enable_customizations, body_factory_enable_logging, body_factory_response_suppression_mode, body_factory_template_sets_dir, enable_read_while_writer, cluster_configuration, cluster_cluster_port, cluster_ethernet_interface, cluster_log_bogus_mc_msgs, cluster_mc_group_addr, cluster_mc_ttl, cluster_mcport, cluster_rsport, config_dir, core_limit, diags_debug_enabled, diags_debug_tags, diags_show_location, dns_max_dns_in_flight, dns_nameservers, dns_resolv_conf, dns_round_robin_nameservers, dns_search_default_domains, dns_splitDNS_enabled, dns_url_expansions, dns_validate_query_name, dump_mem_info_frequency, env_prep, exec_thread_affinity, exec_thread_autoconfig, exec_thread_autoconfig_scale, exec_thread_limit, parse_no_host_url_redirect, icp_enabled, icp_interface, icp_port, icp_multicast_enabled, icp_query_timeout, mloc_enabled, net_connections_throttle, net_defer_accept, net_sock_recv_buffer_size_in, net_sock_recv_buffer_size_out, net_sock_send_buffer_size_in, net_sock_send_buffer_size_out, output_logfile, process_manager_management_port, proxy_binary_opts, proxy_name, reverse_proxy_enabled, snapshot_dir, stack_dump_enabled, syslog_facility, system_mmap_max, task_threads, temp_dir, update_concurrent_updates, update_enabled, update_force, update_retry_count, extract(epoch from update_retry_interval) as update_retry_interval,  url_remap_default_to_server_pac, url_remap_default_to_server_pac_port, url_remap_filename, url_remap_pristine_host_hdr, url_remap_remap_required, cron_ort_syncds_cdn, domain_name, health_connection_timeout, health_polling_url, health_threshold_available_bandwidth_kbps, health_threshold_load_average, health_threshold_query_time, history_count, cache_interim_storage, local_cluster_type, local_log_collation_mode, log_format_format, log_format_name, extract(epoch from max_reval_duration) as max_reval_duration, astats_path, qstring, astats_record_types, regex_revalidate, astats_library, traffic_server_chkconfig, crconfig_weight, parent_config_weight from caching_proxy_record_data where profile=:profile`
+	nstmt, err := db.PrepareNamed(queryStr)
+	err = nstmt.Select(&ret, arg)
+	if err != nil {
+		log.Println(err)
+		return CachingProxyRecord{}, err
+	}
+	nstmt.Close()
+
+	if len(ret) != 1 {
+		log.Printf("loadCachingProxyRecord expecting 1 record, query returned %d", len(ret))
+		return CachingProxyRecord{}, err
+	}
+
+	record := ret[0]
+
+	// Postgres epoch returns seconds. This multiplies it into nanoseconds, which are the correct internal representation of time.Duration
+	record.MaxRevalDuration *= time.Second
+	record.UpdateRetryInterval *= time.Second
+
+	record.Ssl, err = loadCachingProxyRecordSsl(profile, db)
+	if err != nil {
+		log.Println(err)
+		return record, err
+	}
+	record.HostDb, err = loadCachingProxyRecordHostDb(profile, db)
+	if err != nil {
+		log.Println(err)
+		return record, err
+	}
+
+	record.Cache, err = loadCachingProxyRecordCache(profile, db)
+	if err != nil {
+		log.Println(err)
+		return record, err
+	}
+
+	record.Http, err = loadCachingProxyRecordHttp(profile, db)
+	if err != nil {
+		log.Println(err)
+		return record, err
+	}
+
+	record.Log, err = loadCachingProxyRecordLog(profile, db)
+	if err != nil {
+		log.Println(err)
+		return record, err
+	}
+
+	return record, nil
+}
+
+// @Title getCachingProxyConfig
+// @Description retrieves the caching proxy configuration information for a certain profile
+// @Accept  application/json
+// @Param   profile              path    string     false        "The row id"
+// @Success 200 {object}    CachingProxyRecord
+// @Resource /api/2.0
+// @Router /api/2.0/caching_proxy_record/{profile} [get]
+func getCachingProxyConfig(profile string, db *sqlx.DB) (interface{}, error) {
+	r, err := loadCachingProxyRecord(profile, db)
+	return []CachingProxyRecord{r}, err
+}

--- a/traffic_ops/experimental/server/tools/db/relationalize-parameters/relationalize-parameters.go
+++ b/traffic_ops/experimental/server/tools/db/relationalize-parameters/relationalize-parameters.go
@@ -1,0 +1,1563 @@
+package main
+
+import (
+	"database/sql"
+	"strings"
+	"strconv"
+	"time"
+	_ "github.com/lib/pq"
+	"fmt"
+	"flag"
+	"log"
+	"github.com/Comcast/traffic_control/traffic_ops/experimental/server/api"
+)
+
+func createConnectionStringPostgres(server, database, user, pass string, port uint) (string, error) {
+	connString := fmt.Sprintf("dbname=%s user=%s password=%s sslmode=disable", database, user, pass)
+	if server != "" {
+		connString += fmt.Sprintf(" host=%s", server)
+	}
+	if server != "" {
+		connString += fmt.Sprintf(" port=%d", port)
+	}
+	return connString, nil
+}
+
+// Args encapsulates the command line arguments
+type Args struct {
+	Server   string
+	Port     uint
+	User     string
+	Pass     string
+	Database string
+}
+
+// getFlags parses and returns the command line arguments. The returned error
+// will be non-nil if any expected arg is missing.
+func getFlags() (Args, error) {
+	var args Args
+	flag.StringVar(&args.Server, "server", "localhost", "the PostgreSQL server")
+	flag.UintVar(&args.Port, "port", 5432, "the PostgreSQL port")
+	flag.StringVar(&args.User, "user", "", "the PostgreSQL user")
+	flag.StringVar(&args.Pass, "pass", "", "the PostgreSQL password")
+	flag.StringVar(&args.Database, "database", "", "the PostgreSQL database")
+	flag.Parse()
+	return args, nil
+}
+
+// getProfileParameters returns a map[parameter_id][profile_id]
+func getParameterProfiles(db *sql.DB) (map[int]int, error) {
+	rows, err := db.Query("select profile, parameter from profile_parameter;")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	parameterProfiles := make(map[int]int)
+	for rows.Next() {
+		var profile int
+		var parameter int
+		rows.Scan(&profile, &parameter)
+		parameterProfiles[parameter] = profile
+	}
+	return parameterProfiles, nil
+}
+
+type Profile struct {
+	Id int
+	Name string
+}
+
+// getProfileParameters returns a map[parameter_id][profile_id]
+func getProfiles(db *sql.DB) ([]Profile, error) {
+	rows, err := db.Query("select id, name from profile;")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var profiles []Profile
+	for rows.Next() {
+		var id int
+		var name string
+		rows.Scan(&id, &name)
+		profiles = append(profiles, Profile{Id: id, Name: name})
+	}
+	return profiles, nil
+}
+
+type Parameter struct {
+	Id int
+	Name string
+	ConfigFile string
+	Value string
+}
+
+func getParametersForProfile(db *sql.DB, profileId int) ([]Parameter, error)  {
+	rows, err := db.Query("select id, name, config_file, value from parameter where id in (select parameter from profile_parameter where profile = $1);", profileId)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var parameters []Parameter
+	for rows.Next() {
+		var id int
+		var name string
+		var configFile string
+		var value string
+		rows.Scan(&id, &name, &configFile, &value)
+		parameters = append(parameters, Parameter{Id: id, Name: name, ConfigFile: configFile, Value: value})
+	}
+	return parameters, nil
+}
+
+func processParameter(db *sql.DB, parameter Parameter, profileId int, record api.CachingProxyRecord) (api.CachingProxyRecord, error) {
+	switch parameter.ConfigFile {
+	case "records.config":
+//		fmt.Printf("%s\n", parameter.Name)
+		var err error
+		record, err = processParameterRecords(db, parameter, profileId, record)
+		if err != nil {
+			return record, err
+		}
+	// 	fmt.Printf("--record--\n")
+	// case "astats.config":
+	// 	fmt.Printf("##astats##\n")
+	// default:
+	// 	fmt.Printf("Profile %d - Param %d > %s | %s | %s\n", profileId, parameter.Id, parameter.Name, parameter.ConfigFile, parameter.Value)
+	}
+	return record, nil
+}
+
+
+// processParameterRecord adds the records.config parameter to the in-progres api.CachingProxyRecord struct.
+// `record` could be changed to a pointer, if performance mattered.
+func processParameterRecords(db *sql.DB, parameter Parameter, profileId int, r api.CachingProxyRecord) (api.CachingProxyRecord, error) {
+	getInt := func() (int, error) {
+		prefix := "INT "
+		if !strings.HasPrefix(parameter.Value, prefix) {
+			return 0, fmt.Errorf("Error parsing int parameter %s, missing prefix 'INT ': %s", parameter.Name, parameter.Value)
+		}
+		parameter.Value = parameter.Value[len(prefix):]
+
+		v, err := strconv.Atoi(parameter.Value)
+		if err != nil {
+			return 0, fmt.Errorf("Error parsing int parameter %s: %s", parameter.Name, err)
+		}
+		return v, nil
+	}
+	getFloat := func() (float64, error) {
+		prefix := "FLOAT "
+		if !strings.HasPrefix(parameter.Value, prefix) {
+			return 0, fmt.Errorf("Error parsing int parameter %s, missing prefix 'FLOAT ': %s", parameter.Name, parameter.Value)
+		}
+		parameter.Value = parameter.Value[len(prefix):]
+
+		v, err := strconv.ParseFloat(parameter.Value, 64)
+		if err != nil {
+			return 0, fmt.Errorf("Error parsing int parameter %s: %s", parameter.Name, err)
+		}
+		return v, nil
+	}
+	getBool := func() (bool, error) {
+		v, err := getInt()
+		if err != nil {
+			return false, fmt.Errorf("Error parsing bool parameter %s: %s", parameter.Name, err)
+		}
+		return v != 0, nil
+	}
+	getString := func() (string, error) {
+		prefix := "STRING "
+		if strings.HasPrefix(parameter.Value, prefix) {
+			parameter.Value = parameter.Value[len(prefix):]
+		}
+		return parameter.Value, nil
+	}
+	getDuration := func(unit time.Duration) (time.Duration, error) {
+		intVal, err := getInt()
+		if err != nil {
+			return time.Nanosecond, err
+		}
+		return unit * time.Duration(intVal), nil
+	}
+	getDurationSeconds := func() (time.Duration, error) {
+		return getDuration(time.Second)
+	}
+	getPorts := func() ([]api.CachingProxyRecordPort, error) {
+		// example; "STRING 80 80:ipv6 443:ssl 443:ipv6:ssl"
+		var ports []api.CachingProxyRecordPort
+
+		prefix := "STRING "
+		if len(parameter.Value) < len(prefix) {
+				return nil, fmt.Errorf("Error parsing ports %s: %s", parameter.Name, "missing prefix 'STRING '")
+		}
+		parameter.Value = parameter.Value[len(prefix):]
+
+		portStrs := strings.Split(parameter.Value, " ")
+		for _, portFullStr := range portStrs {
+			components := strings.Split(portFullStr, ":")
+			if len(components) < 1 {
+				return nil, fmt.Errorf("Error parsing ports %s: %s", parameter.Name, "no ports")
+			}
+			portStr := components[0]
+			port, err := strconv.Atoi(portStr)
+			if err != nil || port < 0 || port > 65535 {
+				return nil, fmt.Errorf("Error parsing ports %s: '%s' not a port", parameter.Name, port)
+			}
+			ipv6 := false
+			ssl := false
+			for i := 1; i < 3; i++ {
+				if len(components) <= i {
+					break
+				}
+				if components[i] == "ssl" {
+					ssl = true
+				} else if components[i] == "ipv6" {
+					ipv6 = true
+				} else if components[i] != "ipv4" {
+					return nil, fmt.Errorf("Error parsing ports %s: unexpected port string component '%s' (expecting ssl|ipv4|ipv6)", parameter.Name, components[i])
+				}
+			}
+
+			ports = append(ports, api.CachingProxyRecordPort{Port: uint(port), IPv6: ipv6, SSL: ssl})
+		}
+		return ports, nil
+	}
+
+	getSimplePorts := func() ([]uint, error) {
+		// example; "STRING 80 443"
+		var ports []uint
+
+		prefix := "STRING "
+		if len(parameter.Value) < len(prefix) {
+				return nil, fmt.Errorf("Error parsing ports %s: %s", parameter.Name, "missing prefix 'STRING '")
+		}
+		parameter.Value = parameter.Value[len(prefix):]
+
+		portStrs := strings.Split(parameter.Value, " ")
+		for _, portStr := range portStrs {
+			port, err := strconv.Atoi(portStr)
+			if err != nil {
+				return nil, fmt.Errorf("Error parsing ports %s: %s", parameter.Name, parameter.Value)
+			}
+			ports = append(ports, uint(port))
+		}
+		return ports, nil
+	}
+
+	// getDurationDays := func() (time.Duration, error) {
+	// 	return getDuration(time.Hour * 24)
+	// }
+
+	// fmt.Printf("Profile %d - Param %d > %s | %s | %s\n", profileId, parameter.Id, parameter.Name, parameter.ConfigFile, parameter.Value)
+
+	// getEnum takes a string 'int' number, e.g. `INT 0`, and returns the entry in enumVals for that index.
+	// If the given string doesn't contain an index of enumVals, the string is returned unmodified.
+	// This is designed to compose with `getString`, and s and err are returned unmodified if err != nil
+	getEnum := func(enumVals []string) (string, error) {
+		v, err := getInt()
+		if err != nil {
+			return strconv.Itoa(v), err
+		}
+		// this could be made efficient, if necessary
+		for i, enumVal := range enumVals {
+			if v == i {
+				return enumVal, nil
+			}
+		}
+		return strconv.Itoa(v), nil
+	}
+
+	var err error
+	switch parameter.Name {
+	case "location":
+		r.Location, err = getString()
+	case "CONFIG proxy.config.dns.lookup_timeout":
+		r.DnsLookupTimeout, err = getDurationSeconds()
+	case "CONFIG proxy.config.cache.ip_allow.filename":
+		r.IpAllowFilename, err = getString()
+	case "CONFIG proxy.config.accept_threads":
+		r.AcceptThreads, err = getInt()
+	case "CONFIG proxy.config.admin.admin_user":
+		r.AdminUser, err = getString()
+	case "CONFIG proxy.config.admin.user_id":
+		r.UserId, err = getString()
+	case "CONFIG proxy.config.admin.autoconf_port":
+		r.AutoconfPort, err = getInt()
+	case "CONFIG proxy.config.admin.number_config_bak":
+		fallthrough
+	case "CONFIG proxy.config.admin.number_config":
+		r.NumberConfig, err = getInt()
+	case "CONFIG proxy.config.alarm.abs_path":
+		r.AlarmAbsPath, err = getString()
+	case "CONFIG proxy.config.alarm.bin":
+		r.AlarmBin, err = getString()
+	case "CONFIG proxy.config.alarm_email":
+		r.AlarmEmail, err = getString()
+	case "CONFIG proxy.config.allocator.debug_filter":
+		r.AllocatorDebugFilter, err = getInt()
+	case "CONFIG proxy.config.allocator.enable_reclaim":
+		r.AllocatorEnableReclaim, err = getBool()
+	case "CONFIG proxy.config.allocator.hugepages":
+		r.AllocatorHugePages, err = getBool()
+	case "CONFIG proxy.config.allocator.max_overage":
+		r.AllocatorMaxOverage, err = getInt()
+	case "CONFIG proxy.config.allocator.thread_freelist_size":
+		r.AllocatorThreadFreelistSize, err = getInt()
+	case "CONFIG proxy.config.body_factory.enable_customizations":
+		r.BodyFactoryEnableCustomizations, err = getEnum([]string{"customizable response pages", "language-targetted response pages", "host-targetted response pages"})
+	case "CONFIG proxy.config.body_factory.enable_logging":
+		r.BodyFactoryEnableLogging, err = getBool()
+	case "CONFIG proxy.config.body_factory.response_suppression_mode":
+		r.BodyFactoryResponseSuppressionMode, err = getEnum([]string{"never", "always", "only intercepted traffic"})
+	case "CONFIG proxy.config.body_factory.template_sets_dir":
+		r.BodyFactoryTemplateSetsDir, err = getString()
+	case "CONFIG proxy.config.cache.control.filename":
+		r.Cache.ControlFilename, err = getString()
+	case "CONFIG proxy.config.cache.enable_read_while_writer":
+		r.EnableReadWhileWriter, err = getEnum([]string{"never", "always", "always_and_allow_range"})
+	case "CONFIG proxy.config.cache.hosting_filename":
+		r.Cache.HostingFilename, err = getString()
+	case "CONFIG proxy.config.cache.http.compatibility.4-2-0-fixup":
+		r.Cache.HttpCompatability420Fixup, err = getInt()
+	case "CONFIG proxy.config.cache.limits.http.max_alts":
+		r.Cache.LimitsHttpMaxAlts, err = getInt()
+	case "CONFIG proxy.config.cache.max_doc_size":
+		r.Cache.MaxDocSize, err = getInt()
+	case "CONFIG proxy.config.cache.min_average_object_size":
+		r.Cache.MinAverageObjectSize, err = getInt()
+	case "CONFIG proxy.config.cache.mutex_retry_delay":
+		r.Cache.MutexRetryDelay, err = getInt()
+	case "CONFIG proxy.config.cache.permit.pinning":
+		r.Cache.PermitPinning, err = getInt()
+	case "CONFIG proxy.config.cache.ram_cache.algorithm":
+		r.Cache.RamCacheAlgorithm, err = getInt()
+	case "CONFIG proxy.config.cache.ram_cache.compress":
+		r.Cache.RamCacheCompress, err = getInt()
+	case "CONFIG proxy.config.cache.ram_cache.size":
+		r.Cache.RamCacheSize, err = getInt()
+	case "CONFIG proxy.config.cache.ram_cache.use_seen_filter":
+		r.Cache.RamCacheUseSeenFilter, err = getBool()
+	case "CONFIG proxy.config.cache.ram_cache_cutoff":
+		r.Cache.RamCacheCutoff, err = getInt()
+	case "CONFIG proxy.config.cache.target_fragment_size":
+		r.Cache.TargetFragmentSize, err = getInt()
+	case "CONFIG proxy.config.cache.threads_per_disk":
+		r.Cache.ThreadsPerDisk, err = getInt()
+	case "CONFIG proxy.config.cluster.cluster_configuration ": // yes, the postfix space is intentional
+		fallthrough
+	case "CONFIG proxy.config.cluster.cluster_configuration":
+		r.ClusterConfiguration, err = getString()
+	case "CONFIG proxy.config.cluster.cluster_port":
+		r.ClusterClusterPort, err = getInt()
+	case "CONFIG proxy.config.cluster.ethernet_interface":
+		r.ClusterEthernetInterface, err = getString()
+	case "CONFIG proxy.config.cluster.log_bogus_mc_msgs":
+		r.ClusterLogBogusMcMsgs, err = getInt()
+	case "CONFIG proxy.config.cluster.mc_group_addr":
+		r.ClusterMcGroupAddr, err = getString()
+	case "CONFIG proxy.config.cluster.mc_ttl":
+		r.ClusterMcTtl, err = getInt()
+	case "CONFIG proxy.config.cluster.mcport":
+		r.ClusterMcport, err = getInt()
+	case "CONFIG proxy.config.cluster.rsport":
+		r.ClusterRsport, err = getInt()
+	case "CONFIG proxy.config.config_dir":
+		r.ConfigDir, err = getString()
+	case "CONFIG proxy.config.core_limit":
+		r.CoreLimit, err = getInt()
+	case "CONFIG proxy.config.diags.debug.enabled":
+		r.DiagsDebugEnabled, err = getBool()
+	case "CONFIG proxy.config.diags.debug.tags":
+		r.DiagsDebugTags, err = getString()
+	case "CONFIG proxy.config.diags.show_location":
+		r.DiagsShowLocation, err = getBool()
+	case "CONFIG proxy.config.dns.max_dns_in_flight":
+		r.DnsMaxDnsInFlight, err = getInt()
+	case "CONFIG proxy.config.dns.nameservers":
+		r.DnsNameservers, err = getString()
+	case "CONFIG proxy.config.dns.resolv_conf":
+		r.DnsResolvConf, err = getString()
+	case "CONFIG proxy.config.dns.round_robin_nameservers":
+		r.DnsRoundRobinNameservers, err = getBool()
+	case "CONFIG proxy.config.dns.search_default_domains":
+		r.DnsSearchDefaultDomains, err = getEnum([]string{"disable", "enable", "enable_restrain_splitting"})
+	case "CONFIG proxy.config.dns.splitDNS.enabled":
+		r.DnsSplitDnsEnabled, err = getBool()
+	case "CONFIG proxy.config.dns.url_expansions":
+		r.DnsUrlExpansions, err = getString()
+	case "CONFIG proxy.config.dns.validate_query_name":
+		r.DnsValidateQueryName, err = getBool()
+	case "CONFIG proxy.config.dump_mem_info_frequency":
+		r.DumpMemInfoFrequency, err = getInt()
+	case "CONFIG proxy.config.env_prep":
+		r.EnvPrep, err = getString()
+	case "CONFIG proxy.config.exec_thread.affinity":
+		r.ExecThreadAffinity, err = getEnum([]string{"machine", "numa", "sockets", "cores", "processing units"})
+	case "CONFIG proxy.config.exec_thread.autoconfig":
+		r.ExecThreadAutoconfig, err = getBool()
+	case "CONFIG proxy.config.exec_thread.autoconfig.scale":
+		r.ExecThreadAutoconfigScale, err = getFloat()
+	case "CONFIG proxy.config.exec_thread.limit":
+		r.ExecThreadLimit, err = getInt()
+	case "CONFIG proxy.config.header.parse.no_host_url_redirect":
+		r.ParseNoHostUrlRedirect, err = getString()
+	case "CONFIG proxy.config.hostdb.serve_stale_for":
+		r.HostDb.ServerStaleFor, err = getDurationSeconds()
+	case "CONFIG proxy.config.hostdb.size":
+		r.HostDb.Size, err = getInt()
+	case "CONFIG proxy.config.hostdb.storage_size":
+		r.HostDb.StorageSize, err = getInt()
+	case "CONFIG proxy.config.hostdb.strict_round_robin":
+		r.HostDb.StrictRoundRobin, err = getBool()
+	case "CONFIG proxy.config.hostdb.timeout":
+		r.HostDb.Timeout, err = getInt()
+	case "CONFIG proxy.config.hostdb.ttl_mode":
+		r.HostDb.TtlMode, err = getEnum([]string{"dns", "internal", "smaller", "larger"})
+	case "CONFIG proxy.config.http.accept_no_activity_timeout":
+		r.Http.AcceptNoActivityTimeout, err = getInt()
+	case "CONFIG proxy.config.http.anonymize_insert_client_ip":
+		r.Http.AnonymizeInsertClientIp, err = getInt()
+	case "CONFIG proxy.config.http.anonymize_other_header_list":
+		r.Http.AnonymizeOtherHeaderList, err = getString()
+	case "CONFIG proxy.config.http.anonymize_remove_client_ip":
+		r.Http.AnonymizeRemoveClientIp, err = getBool()
+	case "CONFIG proxy.config.http.anonymize_remove_cookie":
+		r.Http.AnonymizeRemoveCookie, err = getBool()
+	case "CONFIG proxy.config.http.anonymize_remove_from":
+		r.Http.AnonymizeRemoveFrom, err = getBool()
+	case "CONFIG proxy.config.http.anonymize_remove_referer":
+		r.Http.AnonymizeRemoveReferer, err = getBool()
+	case "CONFIG proxy.config.http.anonymize_remove_user_agent":
+		r.Http.AnonymizeRemoveUserAgent, err = getBool()
+	case "CONFIG proxy.config.http.background_fill_active_timeout":
+		r.Http.BackgroundFillActiveTimeout, err = getInt()
+	case "CONFIG proxy.config.http.background_fill_completed_threshold":
+		r.Http.BackgroundFillCompletedThreshold, err = getFloat()
+	case "CONFIG proxy.config.http.cache.allow_empty_doc":
+		r.Http.Cache.AllowEmptyDoc, err = getBool()
+	case "CONFIG proxy.config.http.cache.cache_responses_to_cookies":
+		r.Http.Cache.CacheResponsesToCookies, err = getEnum([]string{"no", "any", "only images", "except text"})
+	case "CONFIG proxy.config.http.cache.cache_urls_that_look_dynamic":
+		r.Http.Cache.CacheUrlsThatLookDynamic, err = getBool()
+	case "CONFIG proxy.config.http.cache.enable_default_vary_headers":
+		r.Http.Cache.EnableDefaultVaryHeaders, err = getBool()
+	case "CONFIG proxy.config.http.cache.fuzz.probability":
+		r.Http.Cache.FuzzProbability, err = getFloat()
+	case "CONFIG proxy.config.http.cache.fuzz.time":
+		r.Http.Cache.FuzzTime, err =  getDurationSeconds()
+	case "CONFIG proxy.config.http.cache.heuristic_lm_factor":
+		r.Http.Cache.HeuristicLmFactor, err = getFloat()
+	case "CONFIG proxy.config.http.cache.heuristic_max_lifetime":
+		r.Http.Cache.HeuristicMaxLifetime, err = getInt()
+	case "CONFIG proxy.config.http.cache.heuristic_min_lifetime":
+		r.Http.Cache.HeuristicMinLifetime, err = getInt()
+	case "CONFIG proxy.config.http.cache.http":
+		r.Http.Cache.Http, err = getBool()
+	case "CONFIG proxy.config.http.cache.ignore_accept_encoding_mismatch":
+		r.Http.Cache.IgnoreAcceptEncodingMismatch, err = getBool()
+	case "CONFIG proxy.config.http.cache.ignore_authentication":
+		r.Http.Cache.IgnoreAuthentication, err = getBool()
+	case "CONFIG proxy.config.http.cache.ignore_client_cc_max_age":
+		r.Http.Cache.IgnoreClientCcMaxAge, err = getInt()
+	case "CONFIG proxy.config.http.cache.ignore_client_no_cache":
+		r.Http.Cache.IgnoreClientNoCache, err = getBool()
+	case "CONFIG proxy.config.http.cache.ignore_server_no_cache":
+		r.Http.Cache.IgnoreServerNoCache, err = getBool()
+	case "CONFIG proxy.config.http.cache.ims_on_client_no_cache":
+		r.Http.Cache.ImsOnClientNoCache, err = getBool()
+	case "CONFIG proxy.config.http.cache.max_stale_age":
+		r.Http.Cache.MaxStaleAge, err = getInt()
+	case "CONFIG proxy.config.http.cache.range.lookup":
+		r.Http.Cache.RangeLookup, err = getBool()
+	case "CONFIG proxy.config.http.cache.required_headers":
+		r.Http.Cache.RequiredHeaders, err = getEnum([]string{"no", "implicit", "explicit"})
+	case "CONFIG proxy.config.http.cache.vary_default_images":
+		r.Http.Cache.VaryDefaultImages, err = getString()
+	case "CONFIG proxy.config.http.cache.vary_default_other":
+		r.Http.Cache.VaryDefaultOther, err = getString()
+	case "CONFIG proxy.config.http.cache.vary_default_text":
+		r.Http.Cache.VaryDefaultText, err = getString()
+	case "CONFIG proxy.config.http.cache.when_to_add_no_cache_to_msie_requests":
+		r.Http.Cache.WhenToAddNoCacheToMsieRequests, err = getInt()
+	case "CONFIG proxy.config.http.cache.when_to_revalidate":
+		r.Http.Cache.WhenToRevalidate, err = getEnum([]string{"directive or heuristic", "stale if heuristic", "always stale", "never stale", "directive or heuristic unless if-modified-since"})
+	case "CONFIG proxy.config.http.chunking_enabled":
+		r.Http.ChunkingEnabled, err = getEnum([]string{"never", "always", "if prior response HTTP/1.1", "if request and prior response HTTP/1.1"})
+	case "CONFIG proxy.config.http.congestion_control.enabled":
+		r.Http.CongestionControlEnabled, err = getBool()
+	case "CONFIG proxy.config.http.connect_attempts_max_retries":
+		r.Http.ConnectAttemptsMaxRetries, err = getInt()
+	case "CONFIG proxy.config.http.connect_attempts_max_retries_dead_server":
+		r.Http.ConnectAttemptsMaxRetriesDeadServer, err = getInt()
+	case "CONFIG proxy.config.http.connect_attempts_rr_retries":
+		r.Http.ConnectAttemptsRrRetries, err = getInt()
+	case "CONFIG proxy.config.http.connect_attempts_timeout":
+		r.Http.ConnectAttemptsTimeout, err = getInt()
+	case "CONFIG proxy.config.http.down_server.abort_threshold":
+		r.Http.DownServerAbortThreshold, err = getInt()
+	case "CONFIG proxy.config.http.down_server.cache_time":
+		r.Http.DownServerCacheTime, err = getInt()
+	case "CONFIG proxy.config.http.enable_http_stats":
+		r.Http.EnableHttpStats, err = getBool()
+	case "CONFIG proxy.config.http.enable_url_expandomatic":
+		r.Http.EnableUrlExpandomatic, err = getBool()
+	case "CONFIG proxy.config.http.forward.proxy_auth_to_parent":
+		r.Http.ForwardProxyAuthToParent, err = getBool()
+	case "CONFIG proxy.config.http.insert_age_in_response":
+		r.Http.InsertAgeInResponse, err = getBool()
+	case "CONFIG proxy.config.http.insert_request_via_str":
+		r.Http.InsertRequestViaStr, err = getEnum([]string{"no", "normal", "higher", "highest"})
+	case "CONFIG proxy.config.http.insert_response_via_str":
+		r.Http.InsertResponseViaStr, err = getEnum([]string{"no", "normal", "higher", "highest"})
+	case "CONFIG proxy.config.http.insert_squid_x_forwarded_for":
+		r.Http.InsertSquidXForwardedFor, err = getBool()
+	case "CONFIG proxy.config.http.keep_alive_enabled_in":
+		r.Http.KeepAliveEnabledIn, err = getBool()
+	case "CONFIG proxy.config.http.keep_alive_enabled_out":
+		r.Http.KeepAliveEnabledOut, err = getBool()
+	case "CONFIG proxy.config.http.keep_alive_no_activity_timeout_in":
+		r.Http.KeepAliveEnabledNoActivityTimeoutIn, err = getInt()
+	case "CONFIG proxy.config.http.keep_alive_no_activity_timeout_out":
+		r.Http.KeepAliveEnabledNoActivityTimeoutOut, err = getInt()
+	case "CONFIG proxy.config.http.negative_caching_enabled":
+		r.Http.NegativeCachingEnabled, err = getBool()
+	case "CONFIG proxy.config.http.negative_caching_lifetime":
+		r.Http.NegativeCachingLifetime, err = getInt()
+	case "CONFIG proxy.config.http.no_dns_just_forward_to_parent":
+		r.Http.NoDnsJustForwardToParent, err = getBool()
+	case "CONFIG proxy.config.http.normalize_ae_gzip":
+		r.Http.NormalizeAeGzip, err = getBool()
+	case "CONFIG proxy.config.http.origin_server_pipeline":
+		r.Http.OriginServerPipeline, err = getInt()
+	case "CONFIG proxy.config.http.parent_proxy.connect_attempts_timeout":
+		r.Http.ParentProxyConnectAttemptsTimeout, err = getInt()
+	case "CONFIG proxy.config.http.parent_proxy.fail_threshold":
+		r.Http.ParentProxyFailThreshold, err = getInt()
+	case "CONFIG proxy.config.http.parent_proxy.file":
+		r.Http.ParentProxyFile, err = getString()
+	case "CONFIG proxy.config.http.parent_proxy.per_parent_connect_attempts":
+		r.Http.ParentProxyPerParentConnectionAttempts, err = getInt()
+	case "CONFIG proxy.config.http.parent_proxy.retry_time":
+		r.Http.ParentProxyParentProxyRetryTime, err = getInt()
+	case "CONFIG proxy.config.http.parent_proxy.total_connect_attempts":
+		r.Http.ParentProxyParentProxyTotalConnectionAttempts, err = getInt()
+	case "CONFIG proxy.config.http.parent_proxy_routing_enable":
+		r.Http.ParentProxyParentProxyRoutingEnable, err = getBool()
+	case "CONFIG proxy.config.http.post_connect_attempts_timeout":
+		r.Http.PostConnectAttemptsTimeout, err = getInt()
+	case "CONFIG proxy.config.http.push_method_enabled":
+		r.Http.ParentPushMethodEnabled, err = getBool()
+	case "CONFIG proxy.config.http.referer_default_redirect":
+		r.Http.RefererDefaultRedirect, err = getString()
+	case "CONFIG proxy.config.http.referer_filter":
+		r.Http.RefererFilter, err = getInt()
+	case "CONFIG proxy.config.http.referer_format_redirect":
+		r.Http.RefererFormatRedirect, err = getInt()
+	case "CONFIG proxy.config.http.response_server_enabled":
+		r.Http.ResponseServerEnabled, err = getEnum([]string{"no", "add header", "add header if nonexistent"})
+	case "CONFIG proxy.config.http.send_http11_requests":
+		r.Http.SendHttp11Requests, err = getEnum([]string{"never", "always", "if prior response HTTP/1.1", "if request and prior response HTTP/1.1"})
+	case "CONFIG proxy.config.http.share_server_sessions":
+		r.Http.ShareServerSessions, err = getInt()
+	case "CONFIG proxy.config.http.slow.log.threshold":
+		r.Http.SlowLogThreshold, err = getInt()
+	case "CONFIG proxy.config.http.transaction_active_timeout_in":
+		r.Http.TransactionActiveTimeoutIn, err = getDurationSeconds()
+	case "CONFIG proxy.config.http.transaction_active_timeout_out":
+		r.Http.TransactionActiveTimeoutOut, err = getDurationSeconds()
+	case "CONFIG proxy.config.http.transaction_no_activity_timeout_in":
+		r.Http.TransactionNoActivityTimeoutIn, err = getDurationSeconds()
+	case "CONFIG proxy.config.http.transaction_no_activity_timeout_out":
+		r.Http.TransactionNoActivityTimeoutOut, err = getDurationSeconds()
+	case "CONFIG proxy.config.http.uncacheable_requests_bypass_parent":
+		r.Http.UncacheableRequestsBypassParent, err = getBool()
+	case "CONFIG proxy.config.http.user_agent_pipeline":
+		r.Http.UserAgentPipeline, err = getInt()
+	case "CONFIG proxy.config.icp.enabled":
+		r.IcpEnabled, err = getEnum([]string{"disabled", "receive", "send and receive"})
+	case "CONFIG proxy.config.icp.icp_interface":
+		r.IcpInterface, err = getString()
+	case "CONFIG proxy.config.icp.icp_port":
+		r.IcpPort, err = getInt()
+	case "CONFIG proxy.config.icp.multicast_enabled":
+		r.IcpMulticastEnabled, err = getInt()
+	case "CONFIG proxy.config.icp.query_timeout":
+		r.IcpQueryTimeout, err = getInt()
+	case "CONFIG proxy.config.log.auto_delete_rolled_files":
+		r.Log.AutoDeleteRolledFiles, err = getBool()
+	case "CONFIG proxy.config.log.collation_host":
+		r.Log.CollationHost, err = getString()
+	case "CONFIG proxy.config.log.collation_host_tagged":
+		r.Log.CollationHostTagged, err = getBool()
+	case "CONFIG proxy.config.log.collation_port":
+		r.Log.CollationPort, err = getInt()
+	case "CONFIG proxy.config.log.collation_retry_sec":
+		r.Log.CollationRetry, err = getDurationSeconds()
+	case "CONFIG proxy.config.log.collation_secret":
+		r.Log.CollationSecret, err = getString()
+	case "CONFIG proxy.config.log.common_log_enabled":
+		r.Log.Common.Enabled, err = getBool()
+	case "CONFIG proxy.config.log.common_log_header":
+		r.Log.Common.Header, err = getString()
+	case "CONFIG proxy.config.log.common_log_is_ascii":
+		r.Log.Common.IsAscii, err = getBool()
+	case "CONFIG proxy.config.log.common_log_name":
+		r.Log.Common.Name, err = getString()
+	case "CONFIG proxy.config.log.custom_logs_enabled":
+		r.Log.CustomLogsEnabled, err = getInt()
+	case "CONFIG proxy.config.log.extended2_log_enabled":
+		r.Log.Extended2.Enabled, err = getBool()
+	case "CONFIG proxy.config.log.extended2_log_header":
+		r.Log.Extended2.Header, err = getString()
+	case "CONFIG proxy.config.log.extended2_log_is_ascii":
+		r.Log.Extended2.IsAscii, err = getBool()
+	case "CONFIG proxy.config.log.extended2_log_name":
+		r.Log.Extended2.Name, err = getString()
+	case "CONFIG proxy.config.log.extended_log_enabled":
+		r.Log.Extended.Enabled, err = getBool()
+	case "CONFIG proxy.config.log.extended_log_header":
+		r.Log.Extended.Header, err = getString()
+	case "CONFIG proxy.config.log.extended_log_is_ascii":
+		r.Log.Extended.IsAscii, err = getBool()
+	case "CONFIG proxy.config.log.extended_log_name":
+		r.Log.Extended.Name, err = getString()
+	case "CONFIG proxy.config.log.hostname":
+		r.Log.Hostname, err = getString()
+	case "CONFIG proxy.config.log.logfile_dir":
+		r.Log.LogfileDir, err = getString()
+	case "CONFIG proxy.config.log.logfile_perm":
+		r.Log.LogfilePerm, err = getString()
+	case "CONFIG proxy.config.log.logging_enabled":
+		r.Log.LoggingEnabled, err = getEnum([]string{"disabled", "errors", "transactions", "all"})
+	case "CONFIG proxy.config.log.max_secs_per_buffer":
+		r.Log.MaxSecsPerBuffer, err = getInt()
+	case "CONFIG proxy.config.log.max_space_mb_for_logs":
+		r.Log.MaxSpaceMbForLogs, err = getInt()
+	case "CONFIG proxy.config.log.max_space_mb_for_orphan_logs":
+		r.Log.MaxSpaceMbForOrphanLogs, err = getInt()
+	case "CONFIG proxy.config.log.max_space_mb_headroom":
+		r.Log.MaxSpaceMbHeadroom, err = getInt()
+	case "CONFIG proxy.config.log.rolling_enabled":
+		r.Log.RollingEnabled, err = getEnum([]string{"disabled", "interval", "size", "either", "both"})
+	case "CONFIG proxy.config.log.rolling_interval_sec":
+		r.Log.RollingInterval, err = getDurationSeconds()
+	case "CONFIG proxy.config.log.rolling_offset_hr":
+		r.Log.RollingOffset, err = getDurationSeconds()
+	case "CONFIG proxy.config.log.rolling_size_mb":
+		r.Log.RollingSizeMb, err = getInt()
+	case "CONFIG proxy.config.log.sampling_frequency":
+		r.Log.SamplingFrequency, err = getInt()
+	case "CONFIG proxy.config.log.separate_host_logs":
+		r.Log.SeparateHostLogs, err = getInt()
+	case "CONFIG proxy.config.log.separate_icp_logs":
+		r.Log.SeparateIcpLogs, err = getInt()
+	case "CONFIG proxy.config.log.squid_log_enabled":
+		r.Log.Squid.Enabled, err = getBool()
+	case "CONFIG proxy.config.log.squid_log_header":
+		r.Log.Squid.Header, err = getString()
+	case "CONFIG proxy.config.log.squid_log_is_ascii":
+		r.Log.Squid.IsAscii, err = getBool()
+	case "CONFIG proxy.config.log.squid_log_name":
+		r.Log.Squid.Name, err = getString()
+	case "CONFIG proxy.config.log.xml_config_file":
+		r.Log.XmlConfigFile, err = getString()
+	case "CONFIG proxy.config.mlock_enabled":
+		r.MlocEnabled, err = getInt()
+	case "CONFIG proxy.config.net.connections_throttle":
+		r.NetConnectionsThrottle, err = getInt()
+	case "CONFIG proxy.config.net.defer_accept":
+		r.NetDeferAccept, err = getBool()
+	case "CONFIG proxy.config.net.sock_recv_buffer_size_in":
+		r.NetSockRecvBufferSizeIn, err = getInt()
+	case "CONFIG proxy.config.net.sock_recv_buffer_size_out":
+		r.NetSockRecvBufferSizeOut, err = getInt()
+	case "CONFIG proxy.config.net.sock_send_buffer_size_in":
+		r.NetSockSendBufferSizeIn, err = getInt()
+	case "CONFIG proxy.config.net.sock_send_buffer_size_out":
+		r.NetSockSendBufferSizeOut, err = getInt()
+	case "CONFIG proxy.config.output.logfile":
+		r.OutputLogfile, err = getString()
+	case "CONFIG proxy.config.process_manager.mgmt_port":
+		r.ProcessManagerManagementPort, err = getInt()
+	case "CONFIG proxy.config.proxy_binary_opts":
+		r.ProxyBinaryOpts, err = getString()
+	case "CONFIG proxy.config.proxy_name":
+		r.ProxyName, err = getString()
+	case "CONFIG proxy.config.reverse_proxy.enabled":
+		r.ReverseProxyEnabled, err = getBool()
+	case "CONFIG proxy.config.snapshot_dir":
+		r.SnapshotDir, err = getString()
+	case "CONFIG proxy.config.ssl.client.CA.cert.filename":
+		r.Ssl.ClientCaCertFilename, err = getString()
+	case "CONFIG proxy.config.ssl.CA.cert.filename":
+		r.Ssl.CaCertFilename, err = getString()
+	case "CONFIG proxy.config.ssl.CA.cert.path":
+		r.Ssl.CaCertPath, err = getString()
+	case "CONFIG proxy.config.ssl.client.CA.cert.path":
+		r.Ssl.ClientCaCertPath, err = getString()
+	case "CONFIG proxy.config.ssl.client.cert.filename":
+		r.Ssl.ClientCertFilename, err = getString()
+	case "CONFIG proxy.config.ssl.client.cert.path":
+		r.Ssl.ClientCertPath, err = getString()
+	case "CONFIG proxy.config.ssl.client.certification_level":
+		r.Ssl.ClientCertificationLevel, err = getInt()
+	case "CONFIG proxy.config.ssl.client.private_key.filename":
+		r.Ssl.ClientPrivateKeyFilename, err = getString()
+	case "CONFIG proxy.config.ssl.client.private_key.path":
+		r.Ssl.ClientPrivateKeyPath, err = getString()
+	case "CONFIG proxy.config.ssl.client.verify.server":
+		r.Ssl.ClientVerifyServer, err = getInt()
+	case "CONFIG proxy.config.ssl.compression":
+		r.Ssl.Compression, err = getInt()
+	case "CONFIG proxy.config.ssl.number.threads":
+		r.Ssl.NumberThreads, err = getInt()
+	case "CONFIG proxy.config.ssl.server.cert.path":
+		r.Ssl.ServerCertPath, err = getString()
+	case "CONFIG proxy.config.ssl.server.cert_chain.filename":
+		r.Ssl.ServerCertChainFilename, err = getString()
+	case "CONFIG proxy.config.ssl.server.cipher_suite":
+		r.Ssl.ServerCipherSuite, err = getString()
+	case "CONFIG proxy.config.ssl.server.honor_cipher_order":
+		r.Ssl.ServerHonorCipherOrder, err = getInt()
+	case "CONFIG proxy.config.ssl.server.multicert.filename":
+		r.Ssl.ServerMulticertFilename, err = getString()
+	case "CONFIG proxy.config.ssl.server.private_key.path":
+		r.Ssl.ServerPrivateKeyPath, err = getString()
+	case "CONFIG proxy.config.ssl.SSLv2":
+		r.Ssl.Sslv2, err = getBool()
+	case "CONFIG proxy.config.ssl.SSLv3":
+		r.Ssl.Sslv3, err = getBool()
+	case "CONFIG proxy.config.ssl.TLSv1":
+		r.Ssl.Tlsv1, err = getBool()
+	case "CONFIG proxy.config.stack_dump_enabled":
+		r.StackDumpEnabled, err = getInt()
+	case "CONFIG proxy.config.syslog_facility":
+		r.SyslogFacility, err = getString()
+	case "CONFIG proxy.config.system.mmap_max":
+		r.SystemMmapMax, err = getInt()
+	case "CONFIG proxy.config.task_threads":
+		r.TaskThreads, err = getInt()
+	case "CONFIG proxy.config.temp_dir":
+		r.TempDir, err = getString()
+	case "CONFIG proxy.config.update.concurrent_updates":
+		r.UpdateConcurrentUpdates, err = getInt()
+	case "CONFIG proxy.config.update.enabled":
+		r.UpdateEnabled, err = getInt()
+	case "CONFIG proxy.config.update.force":
+		r.UpdateForce, err = getInt()
+	case "CONFIG proxy.config.update.retry_count":
+		r.UpdateRetryCount, err = getInt()
+	case "CONFIG proxy.config.update.retry_interval":
+		r.UpdateRetryInterval, err = getDurationSeconds()
+	case "CONFIG proxy.config.url_remap.default_to_server_pac":
+		r.UrlRemapDefaultToServerPac, err = getInt()
+	case "CONFIG proxy.config.url_remap.default_to_server_pac_port":
+		var v int
+		v, err = getInt()
+		r.UrlRemapDefaultToServerPacPort = &v
+		if *r.UrlRemapDefaultToServerPacPort < 0 || *r.UrlRemapDefaultToServerPacPort > 65535 {
+			r.UrlRemapDefaultToServerPacPort = nil
+		}
+	case "CONFIG proxy.config.url_remap.filename":
+		r.UrlRemapFilename, err = getString()
+	case "CONFIG proxy.config.url_remap.pristine_host_hdr":
+		r.UrlRemapPristineHostHdr, err = getInt()
+	case "CONFIG proxy.config.url_remap.remap_required":
+		r.UrlRemapRemapRequired, err = getInt()
+	// \todo handle params not in records.config
+	// case "FOO":
+	// 	r.CronOrtSyncdsCdn, err = getString()
+	// case "FOO":
+	// 	r.DomainName, err = getString()
+	// case "BAR":
+	// 	r.HealthConnectionTimeout, err = getInt()
+	// case "FOO":
+	// 	r.HealthPollingUrl, err = getString()
+	// case "BAR":
+	// 	r.HealthThresholdAvailableBandwidthKbps, err = getInt()
+	// case "BAR":
+	// 	r.HealthThresholdLoadAverage, err = getInt()
+	// case "BAR":
+	// 	r.HealthThresholdQueryTime, err = getInt()
+	// case "BAR":
+	// 	r.HistoryCount, err = getInt()
+	case "LOCAL proxy.config.cache.interim.storage":
+		r.CacheInterimStorage, err = getString()
+	case "LOCAL proxy.local.cluster.type":
+		r.LocalClusterType, err = getInt()
+	case "LOCAL proxy.local.log.collation_mode":
+		r.LocalLogCollationMode, err = getInt()
+	// case "FOO":
+	// 	r.Log.FormatFormat, err = getString()
+	// case "FOO":
+	// 	r.Log.FormatName, err = getString()
+	// case "FOOTHREE":
+	// 	r.MaxRevalDuration, err = getDurationDays()
+	// case "FOO":
+	// 	r.AstatsPath, err = getString()
+	// case "FOO":
+	// 	r.Qstring, err = getString()
+	// case "BAR":
+	// 	r.Astatsapi.CachingProxyRecordTypes, err = getInt()
+	// case "FOO":
+	// 	r.RegexRevalidate, err = getString()
+	// case "FOO":
+	// 	r.AstatsLibrary, err = getString()
+	// case "FOO":
+	// 	r.TrafficServerChkconfig, err = getString()
+	// case "FOOTWO":
+	// 	r.CrconfigWeight, err = getFloat()
+	// case "FOOTWO":
+		// 	r.ParentConfigWeight, err = getFloat()
+	case "CONFIG proxy.config.http.server_ports":
+		r.ServerPorts, err = getPorts()
+	case "CONFIG proxy.config.http.connect_ports":
+		r.ConnectPorts, err = getSimplePorts()
+	default:
+		err = fmt.Errorf("Unmatched Parameter: Profile %d - Param %d > %s | %s | %s\n", profileId, parameter.Id, parameter.Name, parameter.ConfigFile, parameter.Value)
+	}
+	return r, err
+}
+
+// getAtsProfiles gets the profile IDs of all profiles assigned to an Edge or Mid in the database
+func getAtsProfileIds(db *sql.DB) ([]int, error) {
+	rows, err := db.Query("select distinct profile from server where type in (select id from type where name = 'EDGE' or name = 'MID');")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var profiles []int
+	for rows.Next() {
+		var id int
+		rows.Scan(&id)
+		profiles = append(profiles, id)
+	}
+	return profiles, nil
+}
+
+func getProfileName(db *sql.DB, profileId int) (string, error) {
+	var name string
+	err := db.QueryRow("select name from profiles where id = $1;", profileId).Scan(&name)
+	return name, err
+}
+
+// DEBUG: more target columns than expressios
+func saveRecord(db *sql.DB, r api.CachingProxyRecord) error {
+	// this could be built from db tags in the struct, via reflection
+
+	fmt.Println("DEBUG inserting record")
+	fmt.Printf("DEBUG UpdateRetryInterval: %v\n", r.UpdateRetryInterval.Seconds())
+	fmt.Printf("DEBUG MaxRevalDuration: %v\n", r.MaxRevalDuration.Seconds())
+
+	query := `INSERT INTO caching_proxy_record_data (
+profile,
+accept_threads,
+admin_user,
+user_id,
+autoconf_port,
+number_config,
+alarm_abs_path,
+alarm_bin,
+alarm_email,
+allocator_debug_filter,
+allocator_enable_reclaim,
+allocator_huge_pages,
+allocator_max_overage,
+allocator_thread_freelist_size,
+body_factory_enable_customizations,
+body_factory_enable_logging,
+body_factory_response_suppression_mode,
+body_factory_template_sets_dir,
+enable_read_while_writer,
+cluster_configuration,
+cluster_cluster_port,
+cluster_ethernet_interface,
+cluster_log_bogus_mc_msgs,
+cluster_mc_group_addr,
+cluster_mc_ttl,
+cluster_mcport,
+cluster_rsport,
+config_dir,
+core_limit,
+diags_debug_enabled,
+diags_debug_tags,
+diags_show_location,
+dns_max_dns_in_flight,
+dns_nameservers,
+dns_resolv_conf,
+dns_round_robin_nameservers,
+dns_search_default_domains,
+dns_splitDNS_enabled,
+dns_url_expansions,
+dns_validate_query_name,
+dump_mem_info_frequency,
+env_prep,
+exec_thread_affinity,
+exec_thread_autoconfig,
+exec_thread_autoconfig_scale,
+exec_thread_limit,
+parse_no_host_url_redirect,
+icp_enabled,
+icp_interface,
+icp_port,
+icp_multicast_enabled,
+icp_query_timeout,
+mloc_enabled,
+net_connections_throttle,
+net_defer_accept,
+net_sock_recv_buffer_size_in,
+net_sock_recv_buffer_size_out,
+net_sock_send_buffer_size_in,
+net_sock_send_buffer_size_out,
+output_logfile,
+process_manager_management_port,
+proxy_binary_opts,
+proxy_name,
+reverse_proxy_enabled,
+snapshot_dir,
+stack_dump_enabled,
+syslog_facility,
+system_mmap_max,
+task_threads,
+temp_dir,
+update_concurrent_updates,
+update_enabled,
+update_force,
+update_retry_count,
+update_retry_interval,
+url_remap_default_to_server_pac,
+url_remap_default_to_server_pac_port,
+url_remap_filename,
+url_remap_pristine_host_hdr,
+url_remap_remap_required,
+cron_ort_syncds_cdn,
+domain_name,
+health_connection_timeout,
+health_polling_url,
+health_threshold_available_bandwidth_kbps,
+health_threshold_load_average,
+health_threshold_query_time,
+history_count,
+cache_interim_storage,
+local_cluster_type,
+local_log_collation_mode,
+log_format_format,
+log_format_name,
+max_reval_duration,
+astats_path,
+qstring,
+astats_record_types,
+regex_revalidate,
+astats_library,
+traffic_server_chkconfig,
+crconfig_weight,
+parent_config_weight
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45::double precision, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63, $64, $65, $66, $67, $68, $69, $70, $71, $72, $73, $74, $75 * INTERVAL '1 second', $76, $77, $78, $79, $80, $81, $82, $83, $84, $85, $86, $87, $88, $89, $90, $91, $92, $93, $94 * INTERVAL '1 second', $95, $96, $97, $98, $99, $100, $101, $102);`
+	_, err := db.Exec(query,
+		r.Profile,
+		//		r.Location,
+		//		r.DnsLookupTimeout,
+		//		r.IpAllowFilename,
+		r.AcceptThreads,
+		r.AdminUser,
+		r.UserId,
+		r.AutoconfPort,
+		r.NumberConfig,
+		r.AlarmAbsPath,
+		r.AlarmBin,
+		r.AlarmEmail,
+		r.AllocatorDebugFilter,
+		r.AllocatorEnableReclaim,
+		r.AllocatorHugePages,
+		r.AllocatorMaxOverage,
+		r.AllocatorThreadFreelistSize,
+		r.BodyFactoryEnableCustomizations,
+		r.BodyFactoryEnableLogging,
+		r.BodyFactoryResponseSuppressionMode,
+		r.BodyFactoryTemplateSetsDir,
+		r.EnableReadWhileWriter,
+		r.ClusterConfiguration,
+		r.ClusterClusterPort,
+		r.ClusterEthernetInterface,
+		r.ClusterLogBogusMcMsgs,
+		r.ClusterMcGroupAddr,
+		r.ClusterMcTtl,
+		r.ClusterMcport,
+		r.ClusterRsport,
+		r.ConfigDir,
+		r.CoreLimit,
+		r.DiagsDebugEnabled,
+		r.DiagsDebugTags,
+		r.DiagsShowLocation,
+		r.DnsMaxDnsInFlight,
+		r.DnsNameservers,
+		r.DnsResolvConf,
+		r.DnsRoundRobinNameservers,
+		r.DnsSearchDefaultDomains,
+		r.DnsSplitDnsEnabled,
+		r.DnsUrlExpansions,
+		r.DnsValidateQueryName,
+		r.DumpMemInfoFrequency,
+		r.EnvPrep,
+		r.ExecThreadAffinity,
+		r.ExecThreadAutoconfig,
+		r.ExecThreadAutoconfigScale,
+		r.ExecThreadLimit,
+		r.ParseNoHostUrlRedirect,
+		r.IcpEnabled,
+		r.IcpInterface,
+		r.IcpPort,
+		r.IcpMulticastEnabled,
+		r.IcpQueryTimeout,
+		r.MlocEnabled,
+		r.NetConnectionsThrottle,
+		r.NetDeferAccept,
+		r.NetSockRecvBufferSizeIn,
+		r.NetSockRecvBufferSizeOut,
+		r.NetSockSendBufferSizeIn,
+		r.NetSockSendBufferSizeOut,
+		r.OutputLogfile,
+		r.ProcessManagerManagementPort,
+		r.ProxyBinaryOpts,
+		r.ProxyName,
+		r.ReverseProxyEnabled,
+		r.SnapshotDir,
+		r.StackDumpEnabled,
+		r.SyslogFacility,
+		r.SystemMmapMax,
+		r.TaskThreads,
+		r.TempDir,
+		r.UpdateConcurrentUpdates,
+		r.UpdateEnabled,
+		r.UpdateForce,
+		r.UpdateRetryCount,
+		r.UpdateRetryInterval.Seconds(),
+		r.UrlRemapDefaultToServerPac,
+		r.UrlRemapDefaultToServerPacPort,
+		r.UrlRemapFilename,
+		r.UrlRemapPristineHostHdr,
+		r.UrlRemapRemapRequired,
+		r.CronOrtSyncdsCdn,
+		r.DomainName,
+		r.HealthConnectionTimeout,
+		r.HealthPollingUrl,
+		r.HealthThresholdAvailableBandwidthKbps,
+		r.HealthThresholdLoadAverage,
+		r.HealthThresholdQueryTime,
+		r.HistoryCount,
+		r.CacheInterimStorage,
+		r.LocalClusterType,
+		r.LocalLogCollationMode,
+		r.LogFormatFormat,
+		r.LogFormatName,
+ 		r.MaxRevalDuration.Seconds(),
+ 		r.AstatsPath,
+ 		r.Qstring,
+ 		r.AstatsRecordTypes,
+		r.RegexRevalidate,
+ 		r.AstatsLibrary,
+ 		r.TrafficServerChkconfig,
+		r.CrconfigWeight,
+		r.ParentConfigWeight,
+	)
+
+	if err != nil {
+		fmt.Println("DEBUG RECORD DATA ERR")
+		return err
+	}
+
+	fmt.Println("DEBUG inserting ssl")
+
+	query = `INSERT INTO caching_proxy_record_data_ssl (
+profile,
+ca_cert_filename,
+ca_cert_path,
+client_ca_cert_filename,
+client_ca_cert_path,
+client_cert_filename,
+client_cert_path,
+client_certification_level,
+client_private_key_filename,
+client_private_key_path,
+client_verify_server,
+compression,
+number_threads,
+server_cert_path,
+server_cert_chain_filename,
+server_cipher_suite,
+server_honor_cipher_order,
+server_multicert_filename,
+server_private_key_path,
+SSLv2,
+SSLv3,
+TLSv1
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)`
+	_, err = db.Exec(query,
+		r.Profile,
+		r.Ssl.CaCertFilename,
+		r.Ssl.CaCertPath,
+		r.Ssl.ClientCaCertFilename,
+		r.Ssl.ClientCaCertPath,
+		r.Ssl.ClientCertFilename,
+		r.Ssl.ClientCertPath,
+		r.Ssl.ClientCertificationLevel,
+		r.Ssl.ClientPrivateKeyFilename,
+		r.Ssl.ClientPrivateKeyPath,
+		r.Ssl.ClientVerifyServer,
+		r.Ssl.Compression,
+		r.Ssl.NumberThreads,
+		r.Ssl.ServerCertPath,
+		r.Ssl.ServerCertChainFilename,
+		r.Ssl.ServerCipherSuite,
+		r.Ssl.ServerHonorCipherOrder,
+		r.Ssl.ServerMulticertFilename,
+		r.Ssl.ServerPrivateKeyPath,
+		r.Ssl.Sslv2,
+		r.Ssl.Sslv3,
+		r.Ssl.Tlsv1)
+
+	fmt.Println("DEBUG inserting hostdb")
+
+	query = `INSERT INTO caching_proxy_record_data_hostdb (
+profile,
+server_stale_for,
+size,
+storage_size,
+strict_round_robin,
+timeout,
+ttl_mode
+) VALUES ($1, $2 * INTERVAL '1 second', $3, $4, $5, $6, $7)`
+	_, err = db.Exec(query,
+		r.Profile,
+		r.HostDb.ServerStaleFor.Seconds(),
+		r.HostDb.Size,
+		r.HostDb.StorageSize,
+		r.HostDb.StrictRoundRobin,
+		r.HostDb.Timeout,
+		r.HostDb.TtlMode)
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("DEBUG inserting cache")
+
+	query = `INSERT INTO caching_proxy_cache (
+profile,
+filename,
+hosting_filename,
+http_compatability_420_fixup,
+limits_http_max_alts,
+max_doc_size,
+min_average_object_size,
+mutex_retry_delay,
+permit_pinning,
+ram_cache_algorithm,
+ram_cache_compress,
+ram_cache_size,
+ram_cache_use_seen_filter,
+ram_cache_cutoff,
+target_fragment_size,
+threads_per_disk
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`
+
+	_, err = db.Exec(query,
+		r.Profile,
+		r.Cache.ControlFilename,
+		r.Cache.HostingFilename,
+		r.Cache.HttpCompatability420Fixup,
+		r.Cache.LimitsHttpMaxAlts,
+		r.Cache.MaxDocSize,
+		r.Cache.MinAverageObjectSize,
+		r.Cache.MutexRetryDelay,
+		r.Cache.PermitPinning,
+		r.Cache.RamCacheAlgorithm,
+		r.Cache.RamCacheCompress,
+		r.Cache.RamCacheSize,
+		r.Cache.RamCacheUseSeenFilter,
+		r.Cache.RamCacheCutoff,
+		r.Cache.TargetFragmentSize,
+		r.Cache.ThreadsPerDisk)
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("DEBUG inserting http")
+
+	query = `INSERT INTO caching_proxy_record_data_http (
+profile,
+accept_no_activity_timeout,
+anonymize_insert_client_ip,
+anonymize_other_header_list,
+anonymize_remove_client_ip,
+anonymize_remove_cookie,
+anonymize_remove_from,
+anonymize_remove_referer,
+anonymize_remove_user_agent,
+background_fill_active_timeout,
+background_fill_completed_threshold,
+chunking_enabled,
+congestion_control_enabled,
+connect_attempts_max_retries,
+connect_attempts_max_retries_dead_server,
+connect_attempts_rr_retries,
+connect_attempts_timeout,
+down_server_abort_threshold,
+down_server_cache_time,
+enable_http_stats,
+enable_url_expandomatic,
+forward_proxy_auth_to_parent,
+insert_age_in_response,
+insert_request_via_str,
+insert_response_via_str,
+insert_squid_x_forwarded_for,
+keep_alive_enabled_in,
+keep_alive_enabled_out,
+keep_alive_enabled_no_activity_timeout_in,
+keep_alive_enabled_no_activity_timeout_out,
+negative_caching_enabled,
+negative_caching_lifetime,
+no_dns_just_forward_to_parent,
+normalize_ae_gzip,
+origin_server_pipeline,
+parent_proxy_connect_attempts_timeout,
+parent_proxy_fail_threshold,
+parent_proxy_file,
+parent_proxy_per_parent_connection_attempts,
+parent_proxy_parent_proxy_retry_time,
+parent_proxy_parent_proxy_total_connection_attempts,
+parent_proxy_parent_proxy_routing_enable,
+post_connect_attempts_timeout,
+parent_push_method_enabled,
+referer_default_redirect,
+referer_filter,
+referer_format_redirect,
+response_server_enabled,
+send_http11_requests,
+share_server_sessions,
+slow_log_threshold,
+transaction_active_timeout_in,
+transaction_active_timeout_out,
+transaction_no_activity_timeout_in,
+transaction_no_activity_timeout_out,
+uncacheable_requests_bypass_parent,
+user_agent_pipeline
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57)`
+
+	_, err = db.Exec(query,
+		r.Profile,
+		r.Http.AcceptNoActivityTimeout,
+		r.Http.AnonymizeInsertClientIp,
+		r.Http.AnonymizeOtherHeaderList,
+		r.Http.AnonymizeRemoveClientIp,
+		r.Http.AnonymizeRemoveCookie,
+		r.Http.AnonymizeRemoveFrom,
+		r.Http.AnonymizeRemoveReferer,
+		r.Http.AnonymizeRemoveUserAgent,
+		r.Http.BackgroundFillActiveTimeout,
+		r.Http.BackgroundFillCompletedThreshold,
+		r.Http.ChunkingEnabled,
+		r.Http.CongestionControlEnabled,
+		r.Http.ConnectAttemptsMaxRetries,
+		r.Http.ConnectAttemptsMaxRetriesDeadServer,
+		r.Http.ConnectAttemptsRrRetries,
+		r.Http.ConnectAttemptsTimeout,
+		r.Http.DownServerAbortThreshold,
+		r.Http.DownServerCacheTime,
+		r.Http.EnableHttpStats,
+		r.Http.EnableUrlExpandomatic,
+		r.Http.ForwardProxyAuthToParent,
+		r.Http.InsertAgeInResponse,
+		r.Http.InsertRequestViaStr,
+		r.Http.InsertResponseViaStr,
+		r.Http.InsertSquidXForwardedFor,
+		r.Http.KeepAliveEnabledIn,
+		r.Http.KeepAliveEnabledOut,
+		r.Http.KeepAliveEnabledNoActivityTimeoutIn,
+		r.Http.KeepAliveEnabledNoActivityTimeoutOut,
+		r.Http.NegativeCachingEnabled,
+		r.Http.NegativeCachingLifetime,
+		r.Http.NoDnsJustForwardToParent,
+		r.Http.NormalizeAeGzip,
+		r.Http.OriginServerPipeline,
+		r.Http.ParentProxyConnectAttemptsTimeout,
+		r.Http.ParentProxyFailThreshold,
+		r.Http.ParentProxyFile,
+		r.Http.ParentProxyPerParentConnectionAttempts,
+		r.Http.ParentProxyParentProxyRetryTime,
+		r.Http.ParentProxyParentProxyTotalConnectionAttempts,
+		r.Http.ParentProxyParentProxyRoutingEnable,
+		r.Http.PostConnectAttemptsTimeout,
+		r.Http.ParentPushMethodEnabled,
+		r.Http.RefererDefaultRedirect,
+		r.Http.RefererFilter,
+		r.Http.RefererFormatRedirect,
+		r.Http.ResponseServerEnabled,
+		r.Http.SendHttp11Requests,
+		r.Http.ShareServerSessions,
+		r.Http.SlowLogThreshold,
+		r.Http.TransactionActiveTimeoutIn.Seconds(),
+		r.Http.TransactionActiveTimeoutOut.Seconds(),
+		r.Http.TransactionNoActivityTimeoutIn.Seconds(),
+		r.Http.TransactionNoActivityTimeoutOut.Seconds(),
+		r.Http.UncacheableRequestsBypassParent,
+		r.Http.UserAgentPipeline)
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("DEBUG inserting http cache")
+
+	query = `INSERT INTO caching_proxy_record_data_http_cache (
+profile,
+allow_empty_doc,
+cache_responses_to_cookies,
+cache_urls_that_look_dynamic,
+enable_default_vary_headers,
+fuzz_probability,
+fuzz_time,
+heuristic_lm_factor,
+heuristic_max_lifetime,
+heuristic_min_lifetime,
+http,
+ignore_accept_encoding_mismatch,
+ignore_authentication,
+ignore_client_cc_max_age,
+ignore_client_no_cache,
+ignore_server_no_cache,
+ims_on_client_no_cache,
+max_stale_age,
+range_lookup,
+required_headers,
+vary_default_images,
+vary_default_other,
+vary_default_text,
+when_to_add_no_cache_to_msie_requests,
+when_to_revalidate
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25)`
+
+	_, err = db.Exec(query,
+		r.Profile,
+		r.Http.Cache.AllowEmptyDoc,
+		r.Http.Cache.CacheResponsesToCookies,
+		r.Http.Cache.CacheUrlsThatLookDynamic,
+		r.Http.Cache.EnableDefaultVaryHeaders,
+		r.Http.Cache.FuzzProbability,
+		r.Http.Cache.FuzzTime.Seconds(),
+		r.Http.Cache.HeuristicLmFactor,
+		r.Http.Cache.HeuristicMaxLifetime,
+		r.Http.Cache.HeuristicMinLifetime,
+		r.Http.Cache.Http,
+		r.Http.Cache.IgnoreAcceptEncodingMismatch,
+		r.Http.Cache.IgnoreAuthentication,
+		r.Http.Cache.IgnoreClientCcMaxAge,
+		r.Http.Cache.IgnoreClientNoCache,
+		r.Http.Cache.IgnoreServerNoCache,
+		r.Http.Cache.ImsOnClientNoCache,
+		r.Http.Cache.MaxStaleAge,
+		r.Http.Cache.RangeLookup,
+		r.Http.Cache.RequiredHeaders,
+		r.Http.Cache.VaryDefaultImages,
+		r.Http.Cache.VaryDefaultOther,
+		r.Http.Cache.VaryDefaultText,
+		r.Http.Cache.WhenToAddNoCacheToMsieRequests,
+		r.Http.Cache.WhenToRevalidate)
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("DEBUG inserting log")
+
+	query = `INSERT INTO caching_proxy_record_data_log (
+profile,
+auto_delete_rolled_files,
+collation_host,
+collation_host_tagged,
+collation_port,
+collation_retry,
+collation_secret,
+custom_logs_enabled,
+hostname,
+logfile_dir,
+logfile_perm,
+logging_enabled,
+max_secs_per_buffer,
+max_space_mb_for_logs,
+max_space_mb_for_orphan_logs,
+max_space_mb_headroom,
+rolling_enabled,
+rolling_interval,
+rolling_offset,
+rolling_size_mb,
+sampling_frequency,
+separate_host_logs,
+separate_icp_logs,
+xml_config_file
+)	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)`
+
+	_, err = db.Exec(query,
+		r.Profile,
+		r.Log.AutoDeleteRolledFiles,
+		r.Log.CollationHost,
+		r.Log.CollationHostTagged,
+		r.Log.CollationPort,
+		r.Log.CollationRetry.Seconds(),
+		r.Log.CollationSecret,
+		r.Log.CustomLogsEnabled,
+		r.Log.Hostname,
+		r.Log.LogfileDir,
+		r.Log.LogfilePerm,
+		r.Log.LoggingEnabled,
+		r.Log.MaxSecsPerBuffer,
+		r.Log.MaxSpaceMbForLogs,
+		r.Log.MaxSpaceMbForOrphanLogs,
+		r.Log.MaxSpaceMbHeadroom,
+		r.Log.RollingEnabled,
+		r.Log.RollingInterval.Seconds(),
+		r.Log.RollingOffset.Seconds(),
+		r.Log.RollingSizeMb,
+		r.Log.SamplingFrequency,
+		r.Log.SeparateHostLogs,
+		r.Log.SeparateIcpLogs,
+		r.Log.XmlConfigFile)
+
+	if err != nil {
+		return err
+	}
+
+
+	err = saveRecordLogData(db, r.Profile, r.Log.Squid)
+	if err != nil {
+		return err
+	}
+	err = saveRecordLogData(db, r.Profile, r.Log.Common)
+	if err != nil {
+		return err
+	}
+	err = saveRecordLogData(db, r.Profile, r.Log.Extended)
+	if err != nil {
+		return err
+	}
+	err = saveRecordLogData(db, r.Profile, r.Log.Extended2)
+	if err != nil {
+		return err
+	}
+
+	for _, p := range r.ServerPorts {
+		fmt.Println("DEBUG inserting server port")
+		query = `INSERT INTO caching_proxy_records_data_http_server_ports (
+profile,
+port,
+ipv6,
+ssl
+) VALUES ($1, $2, $3, $4)`
+		_, err = db.Exec(query,
+			r.Profile,
+			p.Port,
+			p.IPv6,
+			p.SSL)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, p := range r.ConnectPorts {
+		fmt.Println("DEBUG inserting connect port")
+		query := `INSERT INTO caching_proxy_records_data_http_connect_ports (
+profile,
+port
+) VALUES ($1, $2)`
+		_, err = db.Exec(query,
+			r.Profile,
+			p)
+		if err != nil {
+			return err
+		}
+	}
+
+	return err
+}
+
+func saveRecordLogData(db *sql.DB, profile string, r api.CachingProxyRecordLogData) error {
+	fmt.Println("DEBUG record data log " + profile)
+	query := `INSERT INTO caching_proxy_record_data_log_data (
+profile,
+name,
+enabled,
+header,
+is_ascii
+) VALUES ($1, $2, $3, $4, $5)`
+	_, err := db.Exec(query,
+		profile,
+		r.Name,
+		r.Enabled,
+		r.Header,
+		r.IsAscii)
+	return err
+}
+
+func main() {
+	args, err := getFlags()
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	if args.Server == "localhost" && args.Port == 5432 && args.User == "" && args.Pass == "" && args.Database == "" {
+		flag.Usage()
+		return
+	}
+
+	connStr, err := createConnectionStringPostgres(args.Server, args.Database, args.User, args.Pass, args.Port)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	profileIds, err := getAtsProfileIds(db)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	for _, profileId := range profileIds {
+		var record api.CachingProxyRecord
+		var err error
+		record.Profile, err = getProfileName(db, profileId)
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+		parameters, err := getParametersForProfile(db, profileId)
+		if err != nil {
+			log.Println(err)
+		}
+		for _, parameter := range parameters {
+			record, err = processParameter(db, parameter, profileId, record)
+			if err != nil {
+				log.Println(err)
+			}
+		}
+//		fmt.Println(record)
+		err = saveRecord(db, record)
+		if err != nil {
+			log.Println(err)
+		}
+
+//		fmt.Println("Processed:")
+//		fmt.Println(record)
+//		fmt.Printf("\n")
+	}
+}


### PR DESCRIPTION
Starting point for relational, typed ATS parameters.

Adds the ATS config SQL tables, Go structs and API endpoint, and a conversion script to convert old parameters from 1.x.

This adds considerable data safety. For example, it isn't possible to add a `proxy.config.cluster.cluster_port` value of `foo`, or anything that isn't a valid port. Currently, the only constraints are for ports and ATS enum values. But Postgres constraints are very powerful, including regex. For example, we can make a regex constraint for URI fields.

Again, this is only the first step. The next steps that need done are:

* adding all ATS config files and parameters in SQL and REST (currently it's mostly only record.config)

* an ORT-like script to run on the ATS client, and fetch the endpoint and transform it into ATS config files

* Web GUI components for viewing and editing

* A script to add a new column and re-generate the Go endpoint code
  * This will be less necessary if/when we add all ATS config options to the config files. But until then, it should be easy to add new config options when they're needed.