### PR TITLE
TO 2.0 API error return fixes

### DIFF
--- a/traffic_ops/experimental/server/api/server_byname.go
+++ b/traffic_ops/experimental/server/api/server_byname.go
@@ -24,17 +24,18 @@ import (
 )
 
 func GetServerByName(serverName string, db *sqlx.DB) (Server, error) {
-
 	ret := []Server{}
 	arg := Server{HostName: serverName}
 	nstmt, err := db.PrepareNamed(`select * from server where host_name=:host_name`)
 	err = nstmt.Select(&ret, arg)
 	if err != nil {
 		log.Println(err)
+		return Server{}, err
 	}
+	defer nstmt.Close()
+
 	if len(ret) != 1 {
-		err = errors.New("Host name " + serverName + " is not unique!")
+		return Server{}, errors.New("Host name " + serverName + " is not unique!")
 	}
-	nstmt.Close()
 	return ret[0], err
 }

--- a/traffic_ops/experimental/server/api/tm_user_byname.go
+++ b/traffic_ops/experimental/server/api/tm_user_byname.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"gopkg.in/guregu/null.v3"
 	"log"
-	"github.com/jmoiron/sqlx"		
+	"github.com/jmoiron/sqlx"
 )
 
 // This is not in the tm_user.go file because that gets (re) generated still
@@ -55,8 +55,7 @@ func GetTmUserByName(username string, db *sqlx.DB) (TmUser, error) {
 		return TmUser{}, err
 	}
 	if len(ret) != 1 {
-		err = errors.New("Username " + username + " is not unique!")
-		return TmUser{}, err
+		return TmUser{}, errors.New("Username " + username + " is not unique!")
 	}
 
 	return ret[0], err

--- a/traffic_ops/experimental/server/crconfig/crconfig.go
+++ b/traffic_ops/experimental/server/crconfig/crconfig.go
@@ -338,7 +338,7 @@ func contentRoutersSection(cdnName string, db *sqlx.DB) (map[string]ContentRoute
 	return retMap, nil
 }
 
-func monitorSecttion(cdnName string, db *sqlx.DB) (map[string]Monitor, error) {
+func monitorSection(cdnName string, db *sqlx.DB) (map[string]Monitor, error) {
 	mQuery := "select * from monitors where cdnname='" + cdnName + "'"
 	ms := []Monitor{}
 	err := db.Select(&ms, mQuery)
@@ -612,13 +612,36 @@ func statsSection(cdnName string) (Stats, error) {
 
 func GetCRConfig(cdnName string, db *sqlx.DB) (interface{}, error) {
 	crs, err := contentRoutersSection(cdnName, db)
-	ms, err := monitorSecttion(cdnName, db)
+	if err != nil {
+		log.Println(err)
+		return nil, err
+	}
+	ms, err := monitorSection(cdnName, db)
+	if err != nil {
+		log.Println(err)
+		return nil, err
+	}
 	edges, err := edgeLocationSection(cdnName, db)
+	if err != nil {
+		log.Println(err)
+		return nil, err
+	}
 	cfg, pmap, err := configSection(cdnName, db)
+	if err != nil {
+		log.Println(err)
+		return nil, err
+	}
 	dsMap, err := deliveryServicesSection(cdnName, pmap, db)
+	if err != nil {
+		log.Println(err)
+		return nil, err
+	}
 	cServermap, err := contentServersSection(cdnName, pmap["domain_name"], db)
+	if err != nil {
+		log.Println(err)
+		return nil, err
+	}
 	stats, err := statsSection(cdnName)
-
 	if err != nil {
 		log.Println(err)
 		return nil, err

--- a/traffic_ops/experimental/server/routes/routes.go
+++ b/traffic_ops/experimental/server/routes/routes.go
@@ -119,9 +119,15 @@ func getHandleCRConfigFunc(db *sqlx.DB) http.HandlerFunc {
 		setHeaders(w, []api.ApiMethod{api.GET})
 		vars := mux.Vars(r)
 		cdn := vars["cdn"]
-		resp, _ := crconfig.GetCRConfig(cdn, db)
+		resp, err := crconfig.GetCRConfig(cdn, db)
 		enc := json.NewEncoder(w)
-		enc.Encode(resp)
+		if err != nil {
+			enc.Encode(struct {
+				Error string `json:"error"`
+			}{Error: err.Error()})
+		} else {
+			enc.Encode(resp)
+		}
 	}
 }
 
@@ -132,8 +138,14 @@ func getHandleCSConfigFunc(db *sqlx.DB) http.HandlerFunc {
 		setHeaders(w, []api.ApiMethod{api.GET})
 		vars := mux.Vars(r)
 		hostName := vars["hostname"]
-		resp, _ := csconfig.GetCSConfig(hostName, db)
+		resp, err := csconfig.GetCSConfig(hostName, db)
 		enc := json.NewEncoder(w)
-		enc.Encode(resp)
+		if err != nil {
+			enc.Encode(struct {
+				Error string `json:"error"`
+			}{Error: err.Error()})
+		} else {
+			enc.Encode(resp)
+		}
 	}
 }


### PR DESCRIPTION
This fixes several error return issues.

`GetServerByName` was logging errors, but continuing anyway and trying to index the nil slice.
`GetCRConfig` was only checking and returning the last error, not every error for every function called.
Routes for both the `crconfig` and `csconfig` were ignoring errors and returning the value anyway. This fixes to return a JSON object with an `error` key, with the error string.