### PR TITLE
Fix TO remap rules for nonstandard ports

### DIFF
--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -230,7 +230,11 @@ sub ds_data {
 				$re =~ s/\\//g;
 				$re =~ s/\.\*//g;
 				my $hname = $ds_type =~ /^DNS/ ? "edge" : "ccr";
-				my $map_from = "http://" . $hname . $re . $ds_domain . "/";
+				my $portstr = "";
+				if ( $hname eq "ccr" && $server->tcp_port > 0 && $server->tcp_port != 80 ) {
+					$portstr = ":" . $server->tcp_port;
+				}
+				my $map_from = "http://" . $hname . $re . $ds_domain . $portstr . "/";
 				if ( $protocol == 0 ) {
 					$dsinfo->{dslist}->[$j]->{"remap_line"}->{$map_from} = $map_to;
 				}


### PR DESCRIPTION
Fixes Traffic Ops remap.config generation to add the port to HTTP
delivery service remap rules, if it's nonstandard. This fixes the Host
headers generated by ATS to conform to RFC 2616, and fixes the CDN to
work with edges with nonstandard ports.

Fixes #1134