### PR TITLE
Fix TO duplicate PRE_PROD on new install

### DIFF
--- a/traffic_ops/install/data/json/status.json
+++ b/traffic_ops/install/data/json/status.json
@@ -3,4 +3,3 @@
 {"name":"REPORTED","description":"Edge: Puts server in CCR config file in this state, and CCR will adhere to the health protocol. Mid: N/A for now"}
 {"name":"ADMIN_DOWN","description":"Temporary down. Edge: XMPP client will send status OFFLINE to CCR, otherwise similar to REPORTED. Mid: Server will not be included in parent.config files for its edge caches"}
 {"name":"CCR_IGNORE","description":"Edge: Traffic Ops will not include caches in this state in CCR config files. Mid: N/A for now"}
-{"name":"PRE_PROD","description":"Pre Production. Not active in any configuration."}


### PR DESCRIPTION
The PRE_PROD status was being added by both `dataload.go` via `status.json`, and a Goose migration. Since the migration will always run on both new installs and upgrades, removing it from `dataload` seems like the right solution.

I looked into letting both dataload and the migration insert it with `insert ignore` (so `status.json` could sort of act as documentation of the statuses), but the PK is an ID, not the name, so there's no way to do that without a nontrivial query or schema modification.

Fixes #950