### PR TITLE
Fix TO postinstall to retry failed openssl calls

### DIFF
--- a/traffic_ops/install/bin/generateCert
+++ b/traffic_ops/install/bin/generateCert
@@ -97,48 +97,56 @@ InstallUtils::execCommand( "/usr/bin/tput", "clear" );
 print $msg;
 InstallUtils::promptUser( "Hit Enter when you are ready to continue", "" );
 
-print "Postinstall SSL Certificate Creation.\n\nGenerating an RSA Private Server Key.\n\n";
-my $result = InstallUtils::execCommand( "openssl", "genrsa", "-des3", "-out", "server.key", "2048" );
+print "Postinstall SSL Certificate Creation.\n\n";
 
-if ( $result != 0 ) {
-	print "Key generation failed.\n";
+# execOpenssl takes a description of the command being done, and an array of arguments to OpenSSL,
+# and tries to execute the command, on failure prompting the user to retry.
+# The description should be capitalized, but not terminated with punctuation.
+# Returns the OpenSSL exit code.
+sub execOpenssl {
+	my ( $description, @args ) = @_;
+	print $description . ".\n\n";
+	my $result = 1;
+	while ( $result != 0 ) {
+		$result = InstallUtils::execCommand( "openssl", @args );
+		if ( $result != 0 ) {
+			my $ans = "";
+			while ( $ans !~ /^[yY]/ && $ans !~ /^[nN]/) {
+				$ans = InstallUtils::promptUser( $description . " failed. Try again (y/n)", "y" );
+			}
+			if ( $ans =~ /^[nN]/ ) {
+				return $result
+			}
+		}
+	}
+	return $result;
+}
+
+if ( execOpenssl( "Generating an RSA Private Server Key", "genrsa", "-des3", "-out", "server.key", "1024" ) != 0 ) {
 	exit 1;
 }
+print "\nThe server key has been generated.\n\n";
 
-print "\nThe server key has been generated.\n\nCreating a Certificate Signing Request (CSR)\n\n";
-
-$result = InstallUtils::execCommand( "openssl", "req", "-new", "-key", "server.key", "-out", "server.csr" );
-
-if ( $result != 0 ) {
-	print "CSR generation failed.\n";
+if ( execOpenssl( "Creating a Certificate Signing Request (CSR)", "req", "-new", "-key", "server.key", "-out", "server.csr" ) != 0 ) {
+	exit 1;
 }
-
 print "\nThe Certificate Signing Request has been generated.\n";
-print "Removing the pass phrase from the server key.\n";
 
 InstallUtils::execCommand( "/bin/mv", "server.key", "server.key.orig" );
 
-$result = InstallUtils::execCommand( "openssl", "rsa", "-in", "server.key.orig", "-out", "server.key" );
-
-if ( $result != 0 ) {
-	print "Failed to remove the server key pass phrase.\n";
-	exit 2;
+if ( execOpenssl( "Removing the pass phrase from the server key", "rsa", "-in", "server.key.orig", "-out", "server.key" ) != 0 ) {
+	exit 1;
 }
-
 print "\nThe pass phrase has been removed from the server key.\n";
 
-print "\nGenerating a Self-signed certificate.\n";
-
-$result = InstallUtils::execCommand( "openssl", "x509", "-req", "-days", "365", "-in", "server.csr", "-signkey", "server.key", "-out", "server.crt" );
-
-if ( $result != 0 ) {
-	print "Failed to generate a self signed certificate.\n";
+if ( execOpenssl( "Generating a Self-signed certificate", "x509", "-req", "-days", "365", "-in", "server.csr", "-signkey", "server.key", "-out", "server.crt" ) != 0 ) {
+	exit 1;
 }
-
 print "\nA server key and self signed certificate has been generated.\n";
+
 print "\nInstalling the server key and server certificate.\n";
 
-$result = InstallUtils::execCommand( "/bin/cp", "server.key", "$key" );
+my $result = InstallUtils::execCommand( "/bin/cp", "server.key", "$key" );
 if ( $result != 0 ) {
 	print "Failed to install the private server key.\n";
 	exit 3;


### PR DESCRIPTION
This changes postinstall (generateCerts) to prompt the user if openssl
fails, whether they want to retry.

Ideally, we would immediately inform and retry mismatched passes, but
that isn't possible while calling openssl as an external app.

We would also ideally always retry, except exit if the user hit
ctrl+c. But openssl doesn't return different exit codes for SIGINT
versus failures. Thus, asking seems like the most reasonable option.

Fixes #1063