### PR TITLE
Added InfluxDb tools to RPM build

### DIFF
--- a/traffic_stats/build/traffic_stats.spec
+++ b/traffic_stats/build/traffic_stats.spec
@@ -51,6 +51,7 @@ go_get_version() {
    go get -v \
   )
 }
+
 # get traffic_ops client
 godir=src/github.com/Comcast/traffic_control/traffic_ops/client
 ( mkdir -p "$godir" && \
@@ -59,6 +60,7 @@ godir=src/github.com/Comcast/traffic_control/traffic_ops/client
   go get -v \
 ) || { echo "Could not build go program at $(pwd): $!"; exit 1; }
 
+#get traffic_stats client
 godir=src/github.com/Comcast/traffic_control/traffic_stats
 oldpwd=$(pwd)
 ( mkdir -p "$godir" && \
@@ -69,11 +71,21 @@ oldpwd=$(pwd)
   go install -v \
 ) || { echo "Could not build go program at $(pwd): $!"; exit 1; }
 
+#build influxdb_tools
+godir=src/github.com/Comcast/traffic_control/traffic_stats/influxdb_tools
+( mkdir -p "$godir" && \
+  cd "$godir" && \
+  cp -r "$TC_DIR"/traffic_stats/influxdb_tools/* . && \
+  go build sync_ts_databases.go
+  go build create_ts_databases.go
+) || { echo "Could not build go program at $(pwd): $!"; exit 1; }
+
 %install
 mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_stats
 mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_stats/bin
 mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_stats/conf
 mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_stats/backup
+mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_stats/influxdb_tools
 mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_stats/var/run
 mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_stats/var/log/traffic_stats
 mkdir -p "${RPM_BUILD_ROOT}"/etc/init.d
@@ -87,6 +99,9 @@ cp "$src"/traffic_stats_seelog.xml "${RPM_BUILD_ROOT}"/opt/traffic_stats/conf/tr
 cp "$src"/traffic_stats.init       "${RPM_BUILD_ROOT}"/etc/init.d/traffic_stats
 cp "$src"/traffic_stats.logrotate  "${RPM_BUILD_ROOT}"/etc/logrotate.d/traffic_stats
 cp "$src"/grafana/*.js             "${RPM_BUILD_ROOT}"/usr/share/grafana/public/dashboards/
+cp "$src"/influxdb_tools/sync_ts_databases	"${RPM_BUILD_ROOT}"/opt/traffic_stats/influxdb_tools/
+cp "$src"/influxdb_tools/create_ts_databases	"${RPM_BUILD_ROOT}"/opt/traffic_stats/influxdb_tools/
+
 
 %pre
 /usr/bin/getent group traffic_stats >/dev/null
@@ -140,11 +155,13 @@ fi
 %dir /opt/traffic_stats/var/run
 %dir /opt/traffic_stats/var/log/traffic_stats
 %dir /usr/share/grafana/public/dashboards
+%dir /opt/traffic_stats/influxdb_tools
 
 %attr(600, traffic_stats, traffic_stats) /opt/traffic_stats/conf/*
 %attr(755, traffic_stats, traffic_stats) /opt/traffic_stats/bin/*
 %attr(755, traffic_stats, traffic_stats) /etc/init.d/traffic_stats
 %attr(644, traffic_stats, traffic_stats) /usr/share/grafana/public/dashboards/*
+%attr(644, traffic_stats, traffic_stats) /opt/traffic_stats/influxdb_tools/*
 
 %preun
 # args for hooks: http://www.ibm.com/developerworks/library/l-rpm2/

--- a/traffic_stats/build/traffic_stats.spec
+++ b/traffic_stats/build/traffic_stats.spec
@@ -161,7 +161,7 @@ fi
 %attr(755, traffic_stats, traffic_stats) /opt/traffic_stats/bin/*
 %attr(755, traffic_stats, traffic_stats) /etc/init.d/traffic_stats
 %attr(644, traffic_stats, traffic_stats) /usr/share/grafana/public/dashboards/*
-%attr(644, traffic_stats, traffic_stats) /opt/traffic_stats/influxdb_tools/*
+%attr(755, traffic_stats, traffic_stats) /opt/traffic_stats/influxdb_tools/*
 
 %preun
 # args for hooks: http://www.ibm.com/developerworks/library/l-rpm2/

--- a/traffic_stats/influxdb_tools/create_ts_databases.go
+++ b/traffic_stats/influxdb_tools/create_ts_databases.go
@@ -37,12 +37,12 @@ func main() {
 		Addr: *influxURL,
 	})
 	if err != nil {
-		fmt.Printf("Error creating influx client: %v", err)
+		fmt.Printf("Error creating influx client: %v\n", err)
 		panic("could not create influx client")
 	}
 	_, _, err = client.Ping(10)
 	if err != nil {
-		fmt.Printf("Error creating influx client: %v", err)
+		fmt.Printf("Error creating influx client: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/traffic_stats/influxdb_tools/create_ts_databases.go
+++ b/traffic_stats/influxdb_tools/create_ts_databases.go
@@ -22,6 +22,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 
 	influx "github.com/influxdata/influxdb/client/v2"
 )
@@ -38,6 +39,11 @@ func main() {
 	if err != nil {
 		fmt.Printf("Error creating influx client: %v", err)
 		panic("could not create influx client")
+	}
+	_, _, err = client.Ping(10)
+	if err != nil {
+		fmt.Printf("Error creating influx client: %v", err)
+		os.Exit(1)
 	}
 
 	createCacheStats(client, replication)

--- a/traffic_stats/influxdb_tools/create_ts_databases.go
+++ b/traffic_stats/influxdb_tools/create_ts_databases.go
@@ -38,7 +38,7 @@ func main() {
 	})
 	if err != nil {
 		fmt.Printf("Error creating influx client: %v\n", err)
-		panic("could not create influx client")
+		os.Exit(1)
 	}
 	_, _, err = client.Ping(10)
 	if err != nil {

--- a/traffic_stats/influxdb_tools/sync_ts_databases.go
+++ b/traffic_stats/influxdb_tools/sync_ts_databases.go
@@ -64,9 +64,19 @@ func main() {
 		fmt.Printf("Error creating influx sourceClient: %v\n", err)
 		os.Exit(1)
 	}
+	_, _, err = sourceClient.Ping(10)
+	if err != nil {
+		fmt.Printf("Error creating influx sourceClient: %v\n", err)
+		os.Exit(1)
+	}
 	targetClient, err := influx.NewHTTPClient(influx.HTTPConfig{
 		Addr: *targetURL,
 	})
+	if err != nil {
+		fmt.Printf("Error creating influx targetClient: %v\n", err)
+		os.Exit(1)
+	}
+	_, _, err = targetClient.Ping(10)
 	if err != nil {
 		fmt.Printf("Error creating influx targetClient: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
This closes #1069 

create_ts_databases and sync_ts_databases are now included with the traffic stats build.  This gives users the ablilty to run them without having to have a golang dependency and without needing to checkout the code, build them, etc. 

Also fixed an issue where the tools were trying to continue when the client was not created successfully giving the appearance that they were successful when really they were not. 

