### PR TITLE
POC: use common LWP::UserAgent and LWP::ConnCache for RIAK

### DIFF
--- a/traffic_ops/app/lib/MojoPlugins/Riak.pm
+++ b/traffic_ops/app/lib/MojoPlugins/Riak.pm
@@ -22,10 +22,8 @@ use utf8;
 use Carp qw(cluck confess);
 use Net::Riak;
 use Data::Dumper;
-use Mojo::UserAgent;
 use JSON;
 use IO::Socket::SSL qw();
-use LWP::UserAgent qw();
 use Connection::RiakAdapter;
 use File::Slurp;
 


### PR DESCRIPTION
handing back to @PSUdaemon -- Alternative to #1305 -- LWP::ConnCache works with LWP::UserAgent, but not Mojo::UserAgent which is used most places in TO.     Instead,  limit this change to the Riak adapter which seems to be the bottleneck right now.

I'm not really sure how to effectively test this (unit and integration tests pass).