### PR TITLE
don't allow an empty string to be passed in as ip6_address in the API

### DIFF
--- a/traffic_ops/app/lib/API/Server.pm
+++ b/traffic_ops/app/lib/API/Server.pm
@@ -621,7 +621,6 @@ sub create {
 sub update {
     my ($params, $data, $err) = (undef, undef, undef);
     my $self = shift;
-
     my $json = $self->req->json;
     if ( !&is_oper($self) ) {
         return $self->alert("You must be an ADMIN or OPER to perform this operation!");
@@ -654,7 +653,7 @@ sub update {
                 ip_address       => defined($params->{'ip_address'}) ? $params->{'ip_address'} : $update->ip_address,
                 ip_netmask       => defined($params->{'ip_netmask'}) ? $params->{'ip_netmask'} : $update->ip_netmask,
                 ip_gateway       => defined($params->{'ip_gateway'}) ? $params->{'ip_gateway'} : $update->ip_gateway,
-                ip6_address      => defined($params->{'ip6_address'}) ? $params->{'ip6_address'} : $update->ip6_address,
+                ip6_address      => defined($params->{'ip6_address'}) && $params->{'ip6_address'} != "" ? $params->{'ip6_address'} : $update->ip6_address,
                 ip6_gateway      => defined($params->{'ip6_gateway'}) ? $params->{'ip6_gateway'} : $update->ip6_gateway,
                 interface_mtu    => defined($params->{'interface_mtu'}) ? $params->{'interface_mtu'} : $update->interface_mtu,
                 cachegroup       => defined($params->{'cachegroup'}) ? $params->{'cachegroup'} : $update->cachegroup->id,

--- a/traffic_ops/app/t/api/1.2/server.t
+++ b/traffic_ops/app/t/api/1.2/server.t
@@ -50,14 +50,6 @@ ok $t->get_ok('/api/1.2/servers/details.json')->status_is(400)->or( sub { diag $
 ok $t->get_ok('/api/1.2/servers/details.json?orderby=hostName')->status_is(400)->or( sub { diag $t->tx->res->content->asset->{content}; } ),
 	'Does the orderby work?';
 
-ok $t->get_ok('/logout')->status_is(302)->or( sub { diag $t->tx->res->content->asset->{content}; } );
-
-
-
-
-ok $t->post_ok( '/login', => form => { u => Test::TestHelper::ADMIN_USER, p => Test::TestHelper::ADMIN_USER_PASSWORD } )->status_is(302)
-  ->or( sub { diag $t->tx->res->content->asset->{content}; } ), 'Should login?';
-
 ok $t->get_ok('/api/1.2/servers.json?type=mid')->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } )
   ->json_is( "/response/0/hostName", "atlanta-mid-01" )
   ->json_is( "/response/0/domainName", "ga.atlanta.kabletown.net" )


### PR DESCRIPTION
If a client passes in an empty string for ip6_address, just ignore it.