### PR TITLE
Add TO2.0 API Url Rewriter Dockerfile

### DIFF
--- a/traffic_ops/experimental/url-rewriter-nginx/Url_Rewriter_Dockerfile
+++ b/traffic_ops/experimental/url-rewriter-nginx/Url_Rewriter_Dockerfile
@@ -1,0 +1,40 @@
+############################################################
+# Dockerfile to build Traffic Ops 1.4 container images
+# Based on CentOS 6.6
+############################################################
+
+# Example Build and Run:
+# docker build --file Url_Rewriter_Dockerfile --rm --tag traffic_ops_url_rewriter:0.1 .
+# docker run --add-host="localhost:10.0.2.2" -p 9008:9008 --name my-tour --hostname my-tour --detach traffic_ops_url_rewriter:0.1
+
+FROM nginx:1.9
+MAINTAINER Robert Butts
+
+RUN printf '\
+server {\n\
+	listen       9008;\n\
+	server_name  localhost;\n\
+\n\
+	location /successful-return-prefix {\n\
+		return 200 '\''{"result":'\'';\n\
+		add_header Content-Type text/plain;\n\
+	}\n\
+\n\
+	location /successful-return-postfix {\n\
+		return 200 '\''}'\'';\n\
+		add_header Content-Type text/plain;\n\
+	}\n\
+\n\
+	location ~* ^/api/2.0/profile/(.*)$ {\n\
+		add_before_body /successful-return-prefix;\n\
+		add_after_body /successful-return-postfix;\n\
+		addition_types *;\n\
+		rewrite ^/api/2.0/profile/(.*)$ "/profile_parameter?profile=eq.$1&select=parameter{*}" break;\n\
+		proxy_pass http://localhost:42421;\n\
+		proxy_set_header Accept-Encoding "";\n\
+		proxy_intercept_errors on;\n\
+	}\n\
+}\n\
+' > /etc/nginx/conf.d/traffic_ops.conf
+
+EXPOSE 9008


### PR DESCRIPTION
This Dockerfile creates a Docker image with NGINX configured to
rewrite requests of a format we want, to that expected by PostgREST.