### PR TITLE
Fix TO postinstall profile check error message

### DIFF
--- a/traffic_ops/install/bin/postinstall
+++ b/traffic_ops/install/bin/postinstall
@@ -614,6 +614,7 @@ sleep(5);
 
 sub profiles_exist {
 		if ( -f $reconfigure_defaults ) {
+				print "Default profiles were previously created. Remove " . $reconfigure_defaults . " to create again.\n";
 				return 1;
 		}
 
@@ -646,7 +647,7 @@ sub profiles_exist {
 		my $resp = $ua->request($req);
 
 		if ( !$resp->is_success ) {
-				print "Error checking if profiles exist: $resp->code $resp->message\n";
+				print "Error checking if profiles exist: " . $resp->status_line . "\n";
 				return 1;    # return true, so we don't attempt to create profiles
 		}
 		my $message = $resp->decoded_content;


### PR DESCRIPTION
Fixes postinstall to print a useful error when checking if default
profiles exist fails.

Fixes postinstall to print an informative message when profile
defaults aren't created because the $reconfigure_defaults file
exists.

Fixes #1359