### PR TITLE
Fix issue where /api/1.2/parameter/profile requests were failing if .json was on the URL

### DIFF
--- a/traffic_ops/app/lib/TrafficOpsRoutes.pm
+++ b/traffic_ops/app/lib/TrafficOpsRoutes.pm
@@ -519,8 +519,6 @@ sub api_routes {
 	$r->get( "/api/$version/parameters" => [ format => [qw(json)] ] )->over( authenticated => 1 )->to( 'Parameter#index', namespace => $namespace );
 	$r->get( "/api/$version/parameters/profile/:name" => [ format => [qw(json)] ] )->over( authenticated => 1 )
 		->to( 'Parameter#profile', namespace => $namespace );
-	$r->get( "/api/$version/parameters/profile/#name" )->over( authenticated => 1 )
-		->to( 'Parameter#profile', namespace => $namespace );
 
 	# -- PHYS_LOCATION #NEW
 	# Supports ?orderby=key

--- a/traffic_ops/app/lib/TrafficOpsRoutes.pm
+++ b/traffic_ops/app/lib/TrafficOpsRoutes.pm
@@ -161,7 +161,7 @@ sub ui_routes {
 	# -- Keys - SSL Key management
 	$r->get('/ds/:id/urlsigkeys/add')->to( 'UrlSigKeys#add', namespace => $namespace );
 
-	# -- Steering DS assignment 
+	# -- Steering DS assignment
 	$r->get('/ds/:id/steering')->to( 'Steering#index', namespace => $namespace );
 	$r->post('/ds/:id/steering/update')->over( authenticated => 1 )->to( 'Steering#update', namespace => $namespace );
 
@@ -517,6 +517,8 @@ sub api_routes {
 	# -- PARAMETER #NEW
 	# Supports ?orderby=key
 	$r->get( "/api/$version/parameters" => [ format => [qw(json)] ] )->over( authenticated => 1 )->to( 'Parameter#index', namespace => $namespace );
+	$r->get( "/api/$version/parameters/profile/:name" => [ format => [qw(json)] ] )->over( authenticated => 1 )
+		->to( 'Parameter#profile', namespace => $namespace );
 	$r->get( "/api/$version/parameters/profile/#name" )->over( authenticated => 1 )
 		->to( 'Parameter#profile', namespace => $namespace );
 


### PR DESCRIPTION
I added back in the original endpoint in addition to the changed one. This should now allow you to send a request ending in .json or not. 
I would like to understand the original issue this was trying to fix with spaces not being allowed in profile names, I did some curl for a profile with a space in the name and as long as you escape the profile name (with %20) it works....