### PR TITLE
Traffic Router now logs TTLs in the access log

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/DNSAccessEventBuilder.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/DNSAccessEventBuilder.java
@@ -52,12 +52,11 @@ public class DNSAccessEventBuilder {
             rloc = decimalFormat.format(resultLocation.getLatitude()) + "," + decimalFormat.format(resultLocation.getLongitude());
         }
 
-
         final String routingInfo = "rtype=" + rType + " rloc=\"" + rloc +  "\" rdtl=" + rdtl + " rerr=\"-\"";
         String answer = "ans=\"-\"";
 
         if (dnsAccessRecord.getDnsMessage() != null) {
-            answer = createAnswer(dnsAccessRecord.getDnsMessage());
+            answer = createTTLandAnswer(dnsAccessRecord.getDnsMessage());
         }
         return event + " " + routingInfo + " " + answer;
     }
@@ -74,7 +73,7 @@ public class DNSAccessEventBuilder {
         final StringBuilder stringBuilder = new StringBuilder(timeString).append(" qtype=DNS").append(" chi=").append(addressString).append(" ttms=").append(ttmsString);
 
         if (dnsAccessRecord.getDnsMessage() == null) {
-            return stringBuilder.append(" xn=- fqdn=- type=- class=- ttl=- rcode=-").toString();
+            return stringBuilder.append(" xn=- fqdn=- type=- class=- rcode=-").toString();
         }
 
         final String messageHeader = createDnsMessageHeader(dnsAccessRecord.getDnsMessage());
@@ -88,18 +87,21 @@ public class DNSAccessEventBuilder {
         return new StringBuilder(queryHeader).append(query).append(rcode).toString();
     }
 
-    private static String createAnswer(final Message dnsMessage) {
+    private static String createTTLandAnswer(final Message dnsMessage) {
         if (dnsMessage.getSectionArray(Section.ANSWER) == null || dnsMessage.getSectionArray(Section.ANSWER).length == 0) {
-            return "ans=\"-\"";
+            return "ttl=\"-\" ans=\"-\"";
         }
 
         final StringBuilder answerStringBuilder = new StringBuilder();
+        final StringBuilder ttlStringBuilder = new StringBuilder();
         for (final Record record : dnsMessage.getSectionArray(Section.ANSWER)) {
             final String s = record.rdataToString() + " ";
+            final String ttl = record.getTTL() + " ";
             answerStringBuilder.append(s);
+            ttlStringBuilder.append(ttl);
         }
 
-        return "ans=\"" + answerStringBuilder.toString().trim() + "\"";
+        return "ttl=\"" + ttlStringBuilder.toString().trim() + "\" ans=\"" + answerStringBuilder.toString().trim() + "\"";
     }
 
     public static String create(final DNSAccessRecord dnsAccessRecord, final WireParseException wireParseException) {
@@ -112,6 +114,7 @@ public class DNSAccessEventBuilder {
                 .append(" rerr=\"")
                 .append(rerr)
                 .append("\"")
+                .append(" ttl=\"-\"")
                 .append(" ans=\"-\"")
                 .toString();
     }
@@ -130,6 +133,7 @@ public class DNSAccessEventBuilder {
                 .append(" rerr=\"")
                 .append(rerr)
                 .append("\"")
+                .append(" ttl=\"-\"")
                 .append(" ans=\"-\"").toString();
     }
 
@@ -138,13 +142,11 @@ public class DNSAccessEventBuilder {
             final String qname = query.getName().toString();
             final String qtype = Type.string(query.getType());
             final String qclass = DClass.string(query.getDClass());
-            final long ttl = query.getTTL();
 
             return new StringBuilder()
                     .append("fqdn=").append(qname)
                     .append(" type=").append(qtype)
                     .append(" class=").append(qclass)
-                    .append(" ttl=").append(ttl)
                     .toString();
         }
         return "";

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/DNSAccessEventBuilderTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/DNSAccessEventBuilderTest.java
@@ -63,8 +63,8 @@ public class DNSAccessEventBuilderTest {
         DNSAccessRecord dnsAccessRecord = new DNSAccessRecord.Builder(144140678000L, client).build();
 
         String dnsAccessEvent = DNSAccessEventBuilder.create(dnsAccessRecord, new WireParseException("invalid record length"));
-        assertThat(dnsAccessEvent, equalTo("144140678.000 qtype=DNS chi=192.168.10.11 ttms=789 xn=- fqdn=- type=- class=- ttl=- rcode=-" +
-                " rtype=- rloc=\"-\" rdtl=- rerr=\"Bad Request:WireParseException:invalid record length\" ans=\"-\""));
+        assertThat(dnsAccessEvent, equalTo("144140678.000 qtype=DNS chi=192.168.10.11 ttms=789 xn=- fqdn=- type=- class=- rcode=-" +
+                " rtype=- rloc=\"-\" rdtl=- rerr=\"Bad Request:WireParseException:invalid record length\" ttl=\"-\" ans=\"-\""));
     }
 
     @Test
@@ -80,10 +80,13 @@ public class DNSAccessEventBuilderTest {
 
         final Record record1 = mock(Record.class);
         when(record1.rdataToString()).thenReturn("foo");
+        when(record1.getTTL()).thenReturn(1L);
         final Record record2 = mock(Record.class);
         when(record2.rdataToString()).thenReturn("bar");
+        when(record2.getTTL()).thenReturn(2L);
         final Record record3 = mock(Record.class);
         when(record3.rdataToString()).thenReturn("baz");
+        when(record3.getTTL()).thenReturn(3L);
 
         Record[] records = new Record[] {record1, record2, record3};
         when(response.getSectionArray(Section.ANSWER)).thenReturn(records);
@@ -97,15 +100,15 @@ public class DNSAccessEventBuilderTest {
         String dnsAccessEvent = DNSAccessEventBuilder.create(dnsAccessRecord);
 
         assertThat(dnsAccessEvent, equalTo("144140678.000 qtype=DNS chi=192.168.10.11 ttms=789" +
-                " xn=65535 fqdn=www.example.com. type=A class=IN ttl=12345" +
-                " rcode=NOERROR rtype=- rloc=\"-\" rdtl=- rerr=\"-\" ans=\"foo bar baz\""));
+                " xn=65535 fqdn=www.example.com. type=A class=IN" +
+                " rcode=NOERROR rtype=- rloc=\"-\" rdtl=- rerr=\"-\" ttl=\"1 2 3\" ans=\"foo bar baz\""));
 
 
         dnsAccessEvent = DNSAccessEventBuilder.create(dnsAccessRecord);
 
         assertThat(dnsAccessEvent, equalTo("144140678.000 qtype=DNS chi=192.168.10.11 ttms=0" +
-                " xn=65535 fqdn=www.example.com. type=A class=IN ttl=12345" +
-                " rcode=NOERROR rtype=- rloc=\"-\" rdtl=- rerr=\"-\" ans=\"foo bar baz\""));
+                " xn=65535 fqdn=www.example.com. type=A class=IN" +
+                " rcode=NOERROR rtype=- rloc=\"-\" rdtl=- rerr=\"-\" ttl=\"1 2 3\" ans=\"foo bar baz\""));
     }
 
     @Test
@@ -116,8 +119,8 @@ public class DNSAccessEventBuilderTest {
         DNSAccessRecord dnsAccessRecord = new DNSAccessRecord.Builder(144140678000L, client).dnsMessage(query).build();
         String dnsAccessEvent = DNSAccessEventBuilder.create(dnsAccessRecord, new RuntimeException("boom it failed"));
         assertThat(dnsAccessEvent, equalTo("144140678.000 qtype=DNS chi=192.168.10.11 ttms=789" +
-                " xn=65535 fqdn=www.example.com. type=A class=IN ttl=12345" +
-                " rcode=SERVFAIL rtype=- rloc=\"-\" rdtl=- rerr=\"Server Error:RuntimeException:boom it failed\" ans=\"-\""));
+                " xn=65535 fqdn=www.example.com. type=A class=IN" +
+                " rcode=SERVFAIL rtype=- rloc=\"-\" rdtl=- rerr=\"Server Error:RuntimeException:boom it failed\" ttl=\"-\" ans=\"-\""));
     }
 
     @Test
@@ -132,10 +135,13 @@ public class DNSAccessEventBuilderTest {
 
         final Record record1 = mock(Record.class);
         when(record1.rdataToString()).thenReturn("foo");
+        when(record1.getTTL()).thenReturn(1L);
         final Record record2 = mock(Record.class);
         when(record2.rdataToString()).thenReturn("bar");
+        when(record2.getTTL()).thenReturn(2L);
         final Record record3 = mock(Record.class);
         when(record3.rdataToString()).thenReturn("baz");
+        when(record3.getTTL()).thenReturn(3L);
 
         Record[] records = new Record[] {record1, record2, record3};
         when(response.getSectionArray(Section.ANSWER)).thenReturn(records);
@@ -154,21 +160,21 @@ public class DNSAccessEventBuilderTest {
         String dnsAccessEvent = DNSAccessEventBuilder.create(dnsAccessRecord);
 
         assertThat(dnsAccessEvent, equalTo("144140678.000 qtype=DNS chi=192.168.10.11 ttms=789" +
-                " xn=65535 fqdn=www.example.com. type=A class=IN ttl=12345" +
-                " rcode=NOERROR rtype=CZ rloc=\"39.75,-104.99\" rdtl=- rerr=\"-\" ans=\"foo bar baz\""));
+                " xn=65535 fqdn=www.example.com. type=A class=IN" +
+                " rcode=NOERROR rtype=CZ rloc=\"39.75,-104.99\" rdtl=- rerr=\"-\" ttl=\"1 2 3\" ans=\"foo bar baz\""));
 
         dnsAccessRecord = builder.resultType(ResultType.GEO).build();
         dnsAccessEvent = DNSAccessEventBuilder.create(dnsAccessRecord);
 
         assertThat(dnsAccessEvent, equalTo("144140678.000 qtype=DNS chi=192.168.10.11 ttms=0" +
-                " xn=65535 fqdn=www.example.com. type=A class=IN ttl=12345" +
-                " rcode=NOERROR rtype=GEO rloc=\"39.75,-104.99\" rdtl=- rerr=\"-\" ans=\"foo bar baz\""));
+                " xn=65535 fqdn=www.example.com. type=A class=IN" +
+                " rcode=NOERROR rtype=GEO rloc=\"39.75,-104.99\" rdtl=- rerr=\"-\" ttl=\"1 2 3\" ans=\"foo bar baz\""));
 
         dnsAccessRecord = builder.resultType(ResultType.MISS).resultDetails(ResultDetails.DS_NOT_FOUND).build();
         dnsAccessEvent = DNSAccessEventBuilder.create(dnsAccessRecord);
 
         assertThat(dnsAccessEvent, equalTo("144140678.000 qtype=DNS chi=192.168.10.11 ttms=0" +
-                " xn=65535 fqdn=www.example.com. type=A class=IN ttl=12345" +
-                " rcode=NOERROR rtype=MISS rloc=\"39.75,-104.99\" rdtl=DS_NOT_FOUND rerr=\"-\" ans=\"foo bar baz\""));
+                " xn=65535 fqdn=www.example.com. type=A class=IN" +
+                " rcode=NOERROR rtype=MISS rloc=\"39.75,-104.99\" rdtl=DS_NOT_FOUND rerr=\"-\" ttl=\"1 2 3\" ans=\"foo bar baz\""));
     }
 }

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/protocol/AbstractProtocolTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/dns/protocol/AbstractProtocolTest.java
@@ -73,7 +73,7 @@ public class AbstractProtocolTest {
         header.setRcode(Rcode.NOERROR);
 
         Name name = Name.fromString("www.example.com.");
-        Record question = Record.newRecord(name, Type.A, DClass.IN, 12345L);
+        Record question = Record.newRecord(name, Type.A, DClass.IN, 0L);
         Message query = Message.newQuery(question);
 
         query.getHeader().getRcode();
@@ -84,7 +84,7 @@ public class AbstractProtocolTest {
 
         InetAddress resolvedAddress = Inet4Address.getByName("192.168.8.9");
 
-        Record answer = new ARecord(name, DClass.IN, 12345L, resolvedAddress);
+        Record answer = new ARecord(name, DClass.IN, 3600L, resolvedAddress);
         Record[] answers = new Record[] {answer};
 
         Message response = mock(Message.class);
@@ -100,7 +100,7 @@ public class AbstractProtocolTest {
 
         abstractProtocol.run();
 
-        verify(accessLogger).info("144140678.000 qtype=DNS chi=192.168.23.45 ttms=345 xn=65535 fqdn=www.example.com. type=A class=IN ttl=12345 rcode=NOERROR rtype=- rloc=\"-\" rdtl=- rerr=\"-\" ans=\"192.168.8.9\"");
+        verify(accessLogger).info("144140678.000 qtype=DNS chi=192.168.23.45 ttms=345 xn=65535 fqdn=www.example.com. type=A class=IN rcode=NOERROR rtype=- rloc=\"-\" rdtl=- rerr=\"-\" ttl=\"3600\" ans=\"192.168.8.9\"");
     }
 
     @Test
@@ -123,7 +123,7 @@ public class AbstractProtocolTest {
         abstractProtocol.setNameServer(nameServer);
         abstractProtocol.run();
 
-        verify(accessLogger).info("144140678.000 qtype=DNS chi=192.168.23.45 ttms=345 xn=65535 fqdn=John\\032Wayne. type=TYPE65530 class=CLASS43210 ttl=0 rcode=REFUSED rtype=- rloc=\"-\" rdtl=- rerr=\"-\" ans=\"-\"");
+        verify(accessLogger).info("144140678.000 qtype=DNS chi=192.168.23.45 ttms=345 xn=65535 fqdn=John\\032Wayne. type=TYPE65530 class=CLASS43210 rcode=REFUSED rtype=- rloc=\"-\" rdtl=- rerr=\"-\" ttl=\"-\" ans=\"-\"");
     }
 
     @Test
@@ -131,7 +131,7 @@ public class AbstractProtocolTest {
         FakeAbstractProtocol abstractProtocol = new FakeAbstractProtocol(client, new byte[] {1,2,3,4,5,6,7});
         abstractProtocol.setNameServer(nameServer);
         abstractProtocol.run();
-        verify(accessLogger).info("144140678.000 qtype=DNS chi=192.168.23.45 ttms=345 xn=- fqdn=- type=- class=- ttl=- rcode=- rtype=- rloc=\"-\" rdtl=- rerr=\"Bad Request:WireParseException:end of input\" ans=\"-\"");
+        verify(accessLogger).info("144140678.000 qtype=DNS chi=192.168.23.45 ttms=345 xn=- fqdn=- type=- class=- rcode=- rtype=- rloc=\"-\" rdtl=- rerr=\"Bad Request:WireParseException:end of input\" ttl=\"-\" ans=\"-\"");
     }
 
     @Test
@@ -154,7 +154,7 @@ public class AbstractProtocolTest {
         abstractProtocol.setNameServer(nameServer);
         abstractProtocol.run();
 
-        verify(accessLogger).info("144140678.000 qtype=DNS chi=192.168.23.45 ttms=345 xn=65535 fqdn=John\\032Wayne. type=TYPE65530 class=CLASS43210 ttl=0 rcode=SERVFAIL rtype=- rloc=\"-\" rdtl=- rerr=\"Server Error:RuntimeException:Aw snap!\" ans=\"-\"");
+        verify(accessLogger).info("144140678.000 qtype=DNS chi=192.168.23.45 ttms=345 xn=65535 fqdn=John\\032Wayne. type=TYPE65530 class=CLASS43210 rcode=SERVFAIL rtype=- rloc=\"-\" rdtl=- rerr=\"Server Error:RuntimeException:Aw snap!\" ttl=\"-\" ans=\"-\"");
 
     }
 


### PR DESCRIPTION
A TTL will be logged for each IP in the answer.  The TTL field was also moved to right before the answer. The answer will now look something like this:  
`1465230613.478 qtype=DNS chi=10.1.1.1 ttms=13 xn=44901 fqdn=edge.ds-01.mycdn.kabletown.net. type=A class=IN rcode=NOERROR rtype=CZ rloc="0,0" rdtl=- rerr="-" ttl="30 30" ans="192.168.1.2 192.168.1.1"`

This fixes #1489 