### PR TITLE
Centos7 ort integration.

### DIFF
--- a/traffic_ops/bin/traffic_ops_ort.pl
+++ b/traffic_ops/bin/traffic_ops_ort.pl
@@ -100,6 +100,9 @@ my $ERROR = 2;
 my $FATAL = 1;
 my $NONE  = 0;
 
+my $RELEASE = &os_version();
+( $log_level >> $DEBUG ) && print "DEBUG OS release is $RELEASE.\n";
+
 my $script_mode = &check_script_mode();
 &check_run_user();
 &check_only_copy_running();
@@ -193,6 +196,7 @@ if ( $script_mode == $BADASS || $script_mode == $INTERACTIVE || $script_mode == 
 my $header_comment = &get_header_comment($traffic_ops_host);
 
 &process_packages( $hostname_short, $traffic_ops_host );
+
 &process_chkconfig( $hostname_short, $traffic_ops_host );
 
 #### First time
@@ -239,6 +243,12 @@ if ( $script_mode != $REPORT ) {
 ####-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-####
 #### Subroutines
 ####-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-####
+
+sub os_version {
+        my @release = split(/\./, `/bin/uname -r`);
+        return uc $release[3];
+}
+
 sub usage {
 	print "====-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-====\n";
 	print "Usage: ./traffic_ops_ort.pl <Mode> <Log_Level> <Traffic_Ops_URL> <Traffic_Ops_Login> [optional flags]\n";
@@ -326,9 +336,73 @@ sub process_cfg_file {
 	return $return_code;
 }
 
+sub systemd_service_set {
+	my $systemd_service = shift;
+	my $systemd_service_enable = shift;
+
+	my $command = "/bin/systemctl $systemd_service_enable $systemd_service";
+	`$command 2>/dev/null`;
+	if ($? == 0) {
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
+sub systemd_service_chk {
+	my $service = shift;
+
+	my $status = "disabled";
+	open(FH, "/bin/systemctl list-unit-files ${service}.service|") or die ("/bin/systemctl: $!");
+	while(<FH>) {
+		chomp($_);
+		if ($_ =~ m/$service\.service\s(\w+)/) {
+			$status = $1;
+		}
+	}
+	close(FH);
+	return $status;
+}
+
+sub systemd_service_status {
+	my $pkg_name = shift;
+	my $running_string;
+	my $running = 0;
+	my $pid;
+	my $prog;
+
+	open(FH, "/bin/systemctl status $pkg_name|") or die ("/bin/systemctl $!");
+	while(<FH>) {
+		chomp ($_);
+		if ($_ =~ m/\s+Active:\s+active\s\(running\)/) {
+			$running = 1;
+		}
+		if ($_ =~ m/\s+Main\sPID:\s(\d+)\s+\((\w+)\)/) {
+			$pid = $1;
+			$prog = $2
+		}
+	}
+	close(FH);
+	if ($running) {
+		$running_string = "$prog (pid $pid) is running...";
+	} else {
+		$running_string = "$pkg_name is stopped";
+	}
+
+	return $running_string;
+}
+
 sub start_service {
 	my $pkg_name = shift;
-	( my $pkg_running ) = `/sbin/service $pkg_name status`;
+
+	( $log_level >> $ERROR ) && print "ERROR start_service called for $pkg_name.\n";
+
+	my $pkg_running;
+	if ($RELEASE eq "EL7") {
+		$pkg_running = &systemd_service_status($pkg_name);
+	} else {
+		$pkg_running  = `/sbin/service $pkg_name status`;
+	}
 	my $running_string = "";
 	if ( $pkg_name eq "trafficserver" ) {
 		$running_string = "traffic_cop";
@@ -345,11 +419,18 @@ sub start_service {
 			elsif ( $script_mode == $BADASS ) {
 				( $log_level >> $ERROR ) && print "ERROR $pkg_name needs started. Trying to do that now.\n";
 				my $pkg_start_output = `/sbin/service $pkg_name start`;
-				( my @output_lines ) = split( /\n/, $pkg_start_output );
 				my $pkg_started = 0;
-				foreach my $ol (@output_lines) {
-					if ( $ol =~ m/\[.*\]/ && $ol =~ m/OK/ ) {
+				if ($RELEASE eq "EL7") {
+					my $_st = &systemd_service_status($pkg_name);
+					if ($_st =~ m/\(pid\s+(\d+)\) is running.../) {
 						$pkg_started++;
+					}
+				} else {
+					( my @output_lines ) = split( /\n/, $pkg_start_output );
+					foreach my $ol (@output_lines) {
+						if ( $ol =~ m/\[.*\]/ && $ol =~ m/OK/ ) {
+							$pkg_started++;
+						}
 					}
 				}
 				if ($pkg_started) {
@@ -371,11 +452,18 @@ sub start_service {
 				if ( $select =~ m/Y/ ) {
 					( $log_level >> $ERROR ) && print "ERROR $pkg_name needs started. Trying to do that now.\n";
 					my $pkg_start_output = `/sbin/service $pkg_name start`;
-					( my @output_lines ) = split( /\n/, $pkg_start_output );
 					my $pkg_started = 0;
-					foreach my $ol (@output_lines) {
-						if ( $ol =~ m/\[.*\]/ && $ol =~ m/OK/ ) {
+					if ($RELEASE eq "EL7") {
+						my $_st = &systemd_service_status($pkg_name);
+						if ($_st =~ m/\(pid\s+(\d+)\) is running.../) {
 							$pkg_started++;
+						}
+					} else {
+						( my @output_lines ) = split( /\n/, $pkg_start_output );
+						foreach my $ol (@output_lines) {
+							if ( $ol =~ m/\[.*\]/ && $ol =~ m/OK/ ) {
+								$pkg_started++;
+							}
 						}
 					}
 					if ($pkg_started) {
@@ -391,7 +479,7 @@ sub start_service {
 			}
 		}
 		else {
-			( $log_level >> $DEBUG ) && print "DEBUG $pkg_name is running.\n";
+			( $log_level >> $ERROR ) && print "ERROR $pkg_name is running.\n";
 			$pkg_running = $ALREADY_RUNNING;
 		}
 	}
@@ -403,7 +491,13 @@ sub start_service {
 
 sub restart_service {
 	my $pkg_name = $_[0];
-	( my $pkg_running ) = `/sbin/service $pkg_name status`;
+
+	my $pkg_running;
+	if ($RELEASE eq "EL7") {
+		$pkg_running = &systemd_service_status($pkg_name);
+	} else {
+		$pkg_running  = `/sbin/service $pkg_name status`;
+	}
 	my $running_string = "";
 	if ( $pkg_name eq "trafficserver" ) {
 		$running_string = "traffic_cop";
@@ -656,7 +750,7 @@ sub check_syncds_state {
 			exit 0;
 		}
 		else {
-			( $log_level >> $DEBUG ) && print "DEBUG Traffic Ops is signaling that no update is waiting to be applied.\n";
+			( $log_level >> $ERROR ) && print "ERROR Traffic Ops is signaling that no update is waiting to be applied.\n";
 		}
 
 		my $stj = &lwp_get("$traffic_ops_host\/datastatus");
@@ -1325,7 +1419,15 @@ sub check_log_level {
 }
 
 sub set_domainname {
-	my $hostname = `cat /etc/sysconfig/network | grep HOSTNAME`;
+	my $hostname;
+	if ($RELEASE eq "EL7") {
+		$hostname = `cat /etc/hostname`;
+		chomp($hostname);
+	} else {
+		$hostname = `cat /etc/sysconfig/network | grep HOSTNAME`;
+		chomp($hostname);
+		$hostname =~ s/HOSTNAME\=//g;
+	}
 	chomp($hostname);
 	$hostname =~ s/HOSTNAME\=//g;
 	my $domainname;
@@ -1735,25 +1837,50 @@ sub chkconfig_matches {
 
 	( $log_level >> $TRACE ) && print "TRACE Checking whether ${service}'s chkconfig output matches $service_settings.\n";
 
-	my $command = "/sbin/chkconfig --list $service";
-	my $output  = `$command 2>&1`;
-	chomp($output);
+	# systemd check.
+	# This will work for now as  it trys to map from chkconfig run level settings to systemd enabled/disabled state.
+	# I think that a new generic endpoint should be added to traffic opts for chkconfig and systemd state settings and that functions
+	# here in the ort script should abstract the checking of chkconfig/systemd states with traffic ops.
+	if ($RELEASE eq "EL7") {
+		my $service_state = systemd_service_chk($service);
+		if ($service_state eq "enabled") {
+			if ($service_settings =~ m/on/) {
+				( $log_level >> $INFO ) && print "INFO chkconfig output for $service matches $service_settings.\n";
+				return 1;
+			} else {
+				( $log_level >> $ERROR ) && print "ERROR chkconfig output for $service does not match what we expect...\n";
+				return 0;
+			}
+		} else {
+			if ($service_settings =~ m/on/) {
+				( $log_level >> $ERROR ) && print "ERROR chkconfig output for $service does not match what we expect...\n";
+				return 0;
+			} else {
+				( $log_level >> $INFO ) && print "INFO chkconfig output for $service matches $service_settings.\n";
+				return 1;
+			}
+		}
+	} else {
+		my $command = "/sbin/chkconfig --list $service";
+		my $output  = `$command 2>&1`;
+		chomp($output);
 
-	if ( $? == 0 ) {
-		if ( $output =~ m/^$service\s+$service_settings$/ ) {
-			( $log_level >> $INFO ) && print "INFO chkconfig output for $service matches $service_settings.\n";
-			return (1);
+		if ( $? == 0 ) {
+			if ( $output =~ m/^$service\s+$service_settings$/ ) {
+				( $log_level >> $INFO ) && print "INFO chkconfig output for $service matches $service_settings.\n";
+				return (1);
+			}
+			else {
+				( $log_level >> $ERROR ) && print "ERROR chkconfig output for $service does not match what we expect...\n";
+				( $log_level >> $TRACE ) && print "TRACE $output != $service_settings.\n";
+				return (0);
+			}
 		}
 		else {
-			( $log_level >> $ERROR ) && print "ERROR chkconfig output for $service does not match what we expect...\n";
-			( $log_level >> $TRACE ) && print "TRACE $output != $service_settings.\n";
+			( $log_level >> $ERROR ) && print "ERROR $command returned non-zero ($?), output: $output.\n";
+
 			return (0);
 		}
-	}
-	else {
-		( $log_level >> $ERROR ) && print "ERROR $command returned non-zero ($?), output: $output.\n";
-
-		return (0);
 	}
 }
 
@@ -1784,35 +1911,48 @@ sub process_chkconfig {
 						}
 
 						if ($fixit) {
-							my (@levels) = split( /\s+/, $chkconfig->{"value"} );
+							#use systemd commands by mapping chkconfig runlrvrld to either enable or disable.
+							if ($RELEASE eq "EL7") {
+								my $systemd_service_enable = "disable";
+								if ($chkconfig->{"value"} =~ m/on/) {
+									$systemd_service_enable = "enable";
+								}
+								if (&systemd_service_set($chkconfig->{"name"}, $systemd_service_enable)) {
+									( $log_level >> $ERROR ) && print "ERROR $chkconfig->{name}: has been set to $systemd_service_enable\n";
+								} else {
+									( $log_level >> $ERROR ) && print "ERROR failed to set the systemd service for $chkconfig->{name} to $systemd_service_enable\n";
+								}
+							} else {
+								my (@levels) = split( /\s+/, $chkconfig->{"value"} );
 
-							if ( scalar(@levels) == 7 ) {
-								( $log_level >> $TRACE ) && print "TRACE $chkconfig->{name}: Split chkconfig into " . join( ", ", @levels ) . "\n";
+								if ( scalar(@levels) == 7 ) {
+									( $log_level >> $TRACE ) && print "TRACE $chkconfig->{name}: Split chkconfig into " . join( ", ", @levels ) . "\n";
 
-								for my $level (@levels) {
-									my ( $run_level, $setting ) = split( /:/, $level );
+									for my $level (@levels) {
+										my ( $run_level, $setting ) = split( /:/, $level );
 
-									if ( defined($run_level) && defined($setting) ) {
-										( $log_level >> $TRACE ) && print "TRACE $chkconfig->{name}: Setting run level $run_level to $setting\n";
+										if ( defined($run_level) && defined($setting) ) {
+											( $log_level >> $TRACE ) && print "TRACE $chkconfig->{name}: Setting run level $run_level to $setting\n";
 
-										if ( !set_chkconfig( $chkconfig->{"name"}, $run_level, $setting ) ) {
-											( $log_level >> $ERROR ) && print "ERROR $chkconfig->{name}: Unable to set run level $run_level to $setting!\n";
+											if ( !set_chkconfig( $chkconfig->{"name"}, $run_level, $setting ) ) {
+												( $log_level >> $ERROR ) && print "ERROR $chkconfig->{name}: Unable to set run level $run_level to $setting!\n";
+											}
+										}
+										else {
+											( $log_level >> $ERROR ) && print "ERROR $chkconfig->{name}: $level is not what we expected!\n";
 										}
 									}
+
+									if ( chkconfig_matches( $chkconfig->{"name"}, $chkconfig->{"value"} ) ) {
+										( $log_level >> $INFO ) && print "INFO Successfully set chkconfig for $chkconfig->{name}.\n";
+									}
 									else {
-										( $log_level >> $ERROR ) && print "ERROR $chkconfig->{name}: $level is not what we expected!\n";
+										( $log_level >> $ERROR ) && print "FATAL Unable to set chkconfig values for $chkconfig->{name}!\n";
 									}
 								}
-
-								if ( chkconfig_matches( $chkconfig->{"name"}, $chkconfig->{"value"} ) ) {
-									( $log_level >> $INFO ) && print "INFO Successfully set chkconfig for $chkconfig->{name}.\n";
-								}
 								else {
-									( $log_level >> $ERROR ) && print "FATAL Unable to set chkconfig values for $chkconfig->{name}!\n";
+									( $log_level >> $ERROR ) && print "ERROR $chkconfig->{name}: $chkconfig->{value} is not what we expected!\n";
 								}
-							}
-							else {
-								( $log_level >> $ERROR ) && print "ERROR $chkconfig->{name}: $chkconfig->{value} is not what we expected!\n";
 							}
 						}
 					}
@@ -2409,7 +2549,7 @@ sub setup_lwp {
 	my $browser = LWP::UserAgent->new( keep_alive => 100, ssl_opts => { verify_hostname => 0, SSL_verify_mode => 0x00 } );
 
 	my $lwp_cc = $browser->conn_cache(LWP::ConnCache->new());
-	$browser->timeout(5);
+	$browser->timeout(15);
 
 	return $browser;
 }


### PR DESCRIPTION
This pull request contains changes to traffic_ops_ort.pl following integration testing on a CentOS 7 machine.  Changes are principally around the system V init script commands service and chkconfig and the systemd commands used in centos 7.  These changes were made to fix centos 7 integration issues.  I think that the traffic ops chkconfig endpoint needs to be generalized to support both chkconfig and systemd.  Following this, these changes should be refactored to better abstract systemd and chkconfig differences.

NOTE:  Centos 6 regression testing is in progress.  I'll update this PR with regression test results.
