### PR TITLE
If TM doesn't get a valid DataPoint value from peer then default to false instead of empty string

### DIFF
--- a/traffic_monitor/src/main/java/com/comcast/cdn/traffic_control/traffic_monitor/health/AbstractState.java
+++ b/traffic_monitor/src/main/java/com/comcast/cdn/traffic_control/traffic_monitor/health/AbstractState.java
@@ -209,7 +209,7 @@ abstract public class AbstractState {
 				 * relies on a null DataPoint value.  Because the JSON library
 				 * discards a key with a null value, let's handle it here. -jse
 				 */
-				final String value = (dp.getValue() == null) ? "" : dp.getValue();
+				final String value = (dp.getValue() == null) ? "false" : dp.getValue();
 				o.put("value", value);
 				o.put("span", dp.getSpan());
 				o.put("time", statisticsLog.getTime(dp));


### PR DESCRIPTION
If a server is set from REPORTED to OFFLINE (or deleted) and then CrConfig is snapshotted, the server is no longer in CrConfig or CrStates.  When this happens, peer states shows a value of "" for the server.  Instead of showing "" for the server, Traffic Monitor will now show "false".


This addresses #1535