### PR TITLE
Traffic Router now logs INFO for all modules

### DIFF
--- a/traffic_router/core/src/main/conf/log4j.properties
+++ b/traffic_router/core/src/main/conf/log4j.properties
@@ -42,16 +42,7 @@ log4j.appender.A1.threshold=ALL
 log4j.rootLogger=WARN, A1
 
 # Set application logger levels
-log4j.logger.com.comcast.cdn.traffic_control.traffic_router.core=INFO
-
-log4j.logger.com.comcast.cdn.traffic_control.traffic_router.core.cache=INFO
-log4j.logger.com.comcast.cdn.traffic_control.traffic_router.core.config=INFO
-log4j.logger.com.comcast.cdn.traffic_control.traffic_router.core.ds=INFO
-log4j.logger.com.comcast.cdn.traffic_control.traffic_router.core.loc=INFO
-log4j.logger.com.comcast.cdn.traffic_control.traffic_router.core.router=INFO
-log4j.logger.com.comcast.cdn.traffic_control.traffic_router.core.xmpp=INFO
-
-log4j.logger.com.comcast.cdn.traffic_control.traffic_router.core.http=INFO
+log4j.logger.com.comcast.cdn.traffic_control.traffic_router=INFO
 
 log4j.logger.com.comcast.cdn.traffic_control.traffic_router.core.access=INFO, ACCESS
 log4j.additivity.com.comcast.cdn.traffic_control.traffic_router.core.access=false


### PR DESCRIPTION
Traffic Router now logs at the INFO level for any packages and classes under the  com.comcast.cdn.traffic_control.traffic_router package.  Since we are logging info for all classes under the traffic_router package we no longer need the individual package config.

This fixes #1498