### PR TITLE
git short hash now has 8 characters instead of 9 in rpm names for TM and TR

### DIFF
--- a/traffic_monitor/pom.xml
+++ b/traffic_monitor/pom.xml
@@ -205,7 +205,7 @@
 					</execution>
 				</executions>
 				<configuration>
-					<shortRevisionLength>9</shortRevisionLength>
+					<shortRevisionLength>8</shortRevisionLength>
 					<doCheck>false</doCheck>
 					<doUpdate>false</doUpdate>
 					<timestampFormat>

--- a/traffic_router/build/pom.xml
+++ b/traffic_router/build/pom.xml
@@ -61,7 +61,7 @@
 					</execution>
 				</executions>
 				<configuration>
-					<shortRevisionLength>9</shortRevisionLength>
+					<shortRevisionLength>8</shortRevisionLength>
 					<doCheck>false</doCheck>
 					<doUpdate>false</doUpdate>
 					<timestampFormat>


### PR DESCRIPTION
This closes #1330 