### PR TITLE
Submit button for SSL Keys now shows correct text

### DIFF
--- a/traffic_ops/app/templates/ssl_keys/add.html.ep
+++ b/traffic_ops/app/templates/ssl_keys/add.html.ep
@@ -36,7 +36,8 @@
 			$('#sslkeysadd').hide();
 			$('#generate-section').show();
 			$(".error-section").show();
-			$(".flash-section").show()
+			$(".flash-section").show();
+			$("#generate-button").val('Generate Keys');
 		  }
 		  else if (action_selected.match(/^Paste/)) {
 			$('#sslkeysgenerate').hide();


### PR DESCRIPTION
The text for generating new keys is "Generate Keys", the text for pasting existing keys is "Load Keys".

This fixes #876