### PR TITLE
add perl-core to dependencies to get Test::More

### DIFF
--- a/traffic_ops/build/traffic_ops.spec
+++ b/traffic_ops/build/traffic_ops.spec
@@ -33,7 +33,7 @@ URL:	          https://github.com/Comcast/traffic_control/
 Vendor:	          Comcast
 Packager:         daniel_kirkwood at Cable dot Comcast dot com
 AutoReqProv:      no
-Requires:         expat-devel, mod_ssl, mkisofs, libpcap-devel mysql, mysql-server, openssl, perl-DBI, perl-DBD-MySQL, perl-Digest-SHA1, perl-WWW-Curl, perl-libwww-perl
+Requires:         expat-devel, mod_ssl, mkisofs, libpcap-devel mysql, mysql-server, openssl, perl-core, perl-DBI, perl-DBD-MySQL, perl-Digest-SHA1, perl-WWW-Curl, perl-libwww-perl
 Requires(pre):    /usr/sbin/useradd, /usr/bin/getent
 Requires(postun): /usr/sbin/userdel
 


### PR DESCRIPTION
install of YAML module requires Test::More,  which is in perl-core module.   That needs to be installed for a clean install from scratch.  Now installed by yum/rpm as dependency for traffic_ops