### PR TITLE
Modified two routes to use relaxed placeholders to fix issue #1598.

### DIFF
--- a/traffic_ops/app/lib/TrafficOpsRoutes.pm
+++ b/traffic_ops/app/lib/TrafficOpsRoutes.pm
@@ -91,7 +91,7 @@ sub ui_routes {
 
 	# Cdn - Special JSON format for datatables widget
 	$r->get('/aadata/:table')->over( authenticated => 1 )->to( 'Cdn#aadata', namespace => $namespace );
-	$r->get('/aadata/:table/:filter/:value')->over( authenticated => 1 )->to( 'Cdn#aadata', namespace => $namespace );
+	$r->get('/aadata/:table/:filter/#value')->over( authenticated => 1 )->to( 'Cdn#aadata', namespace => $namespace );
 
 	# -- Changelog
 	$r->get('/log')->over( authenticated => 1 )->to( 'ChangeLog#changelog', namespace => $namespace );
@@ -254,7 +254,7 @@ sub ui_routes {
 	$r->get('/parameter/:id/delete')->over( authenticated => 1 )->to( 'Parameter#delete', namespace => $namespace );
 	$r->post('/parameter/:id/update')->over( authenticated => 1 )->to( 'Parameter#update', namespace => $namespace );
 	$r->get('/parameters')->over( authenticated => 1 )->to( 'Parameter#index', namespace => $namespace );
-	$r->get('/parameters/:filter/:byvalue')->over( authenticated => 1 )->to( 'Parameter#index', namespace => $namespace );
+	$r->get('/parameters/:filter/#byvalue')->over( authenticated => 1 )->to( 'Parameter#index', namespace => $namespace );
 	$r->get('/parameter/add')->over( authenticated => 1 )->to( 'Parameter#add', namespace => $namespace );
 	$r->route('/parameter/:id')->via('GET')->over( authenticated => 1 )->to( 'Parameter#view', namespace => $namespace );
 


### PR DESCRIPTION
This is due to the way Mojolicious parses placeholders. The standard placeholders match on the period which causes the placeholder's value to be truncated at the period. Using the relaxed method is less greedy and allows one to use periods in a placeholder.