### PR TITLE
Change telegraf queries to use regex so they work

### DIFF
--- a/traffic_stats/grafana/traffic_ops_server.js
+++ b/traffic_stats/grafana/traffic_ops_server.js
@@ -227,8 +227,8 @@ dashboard.refresh = "30s";
               "tags": [
                 {
                   "key": "host",
-                  "operator": "=",
-                  "value": which
+                  "operator": "=~",
+                  "value": "/" + which + "/"
                 }
               ],
               "groupBy": [
@@ -380,8 +380,8 @@ dashboard.refresh = "30s";
               "tags": [
                 {
                   "key": "host",
-                  "operator": "=",
-                  "value": which
+                  "operator": "=~",
+                  "value": "/" + which + "/"
                 }
               ],
               "groupBy": [
@@ -505,8 +505,8 @@ dashboard.refresh = "30s";
               "tags": [
                 {
                   "key": "host",
-                  "operator": "=",
-                  "value": which
+                  "operator": "=~",
+                  "value": "/" + which + "/"
                 }
               ],
               "groupBy": [
@@ -658,8 +658,8 @@ dashboard.refresh = "30s";
               "tags": [
                 {
                   "key": "host",
-                  "operator": "=",
-                  "value": which
+                  "operator": "=~",
+                  "value": "/" + which + "/"
                 }
               ],
               "groupBy": [


### PR DESCRIPTION
This fixes an issue found in 1.6.0 where telegraf data was not showing up on the server scripted dashboard because the query needed to use a regex.