### PR TITLE
Ops now correctly sends cert from endpoint /api/1.2/cdns/name/<cdnname>/sslkeys.json

### DIFF
--- a/traffic_ops/app/lib/API/Cdn.pm
+++ b/traffic_ops/app/lib/API/Cdn.pm
@@ -1357,7 +1357,7 @@ sub ssl_keys {
 			push(@$keys, {
 				deliveryservice => $record->{deliveryservice},
 				certificate => {
-					crt => $record->{'certificate.key'},
+					crt => $record->{'certificate.crt'},
 					key => $record->{'certificate.key'},
 				}
 			});


### PR DESCRIPTION
fixed a typo