### PR TITLE
move go requirement down into subsystems requiring it

### DIFF
--- a/build/functions.sh
+++ b/build/functions.sh
@@ -89,8 +89,8 @@ function checkEnvironment {
 
 	mkdir -p "$DIST" || { echo "Could not create $DIST: $?"; exit 1; }
 
-	# verify required tools available in path
-	for pgm in git go rpmbuild; do
+	# verify required tools available in path -- extra tools required by subsystem are passed in
+	for pgm in git rpmbuild "$@"; do
 		type $pgm 2>/dev/null || { echo "$pgm not found in PATH"; exit 1; }
 	done
 	# verify git version

--- a/traffic_ops/build/build_rpm.sh
+++ b/traffic_ops/build/build_rpm.sh
@@ -60,6 +60,6 @@ function initBuildArea() {
 
 # ---------------------------------------
 importFunctions
-checkEnvironment
+checkEnvironment go
 initBuildArea
 buildRpm traffic_ops traffic_ops_ort

--- a/traffic_stats/build/build_rpm.sh
+++ b/traffic_stats/build/build_rpm.sh
@@ -54,6 +54,6 @@ function initBuildArea() {
 # ---------------------------------------
 
 importFunctions
-checkEnvironment
+checkEnvironment go
 initBuildArea
 buildRpm traffic_stats


### PR DESCRIPTION
traffic_monitor, traffic_router, traffic_portal don't require go:  not required when only one of these is being built