### PR TITLE
traffic portal rpm cleanup

### DIFF
--- a/traffic_portal/build/README.md
+++ b/traffic_portal/build/README.md
@@ -23,11 +23,6 @@
     $ vagrant ssh
     ```  
 
-* [OPTIONAL] Set RPM variables
-
-  * BRANCH (enter version (i.e. 1.6.0) or leave default (master))
-  * BUILD_NUMBER (defaults to number of git commits)
-
 * Build the RPM
 
     ```
@@ -41,7 +36,7 @@
 
     ```
     $ cd /vagrant/traffic_control/dist
-    $ sudo yum install -y traffic_portal-$BRANCH-$BUILD_NUMBER.x86_64.rpm
+    $ sudo yum install -y traffic_portal-$VERSION-$BUILD_NUMBER.x86_64.rpm
     ```
 
 ### 3. Configure


### PR DESCRIPTION
no longer can you pass in build_no and version - also, renamed $branch to $version and also adds sha to rpm name.

related to issue #1636 