### PR TITLE
allows override of MOJO_MODE for kabletown sample data

### DIFF
--- a/traffic_ops/app/bin/db/setup_kabletown.pl
+++ b/traffic_ops/app/bin/db/setup_kabletown.pl
@@ -1,3 +1,5 @@
+#!/usr/bin/perl
+
 package main;
 #
 # Copyright 2015 Comcast Cable Communications Management, LLC
@@ -20,7 +22,8 @@ use Test::IntegrationTestHelper;
 use strict;
 use warnings;
 
-BEGIN { $ENV{MOJO_MODE} = "development" }
+# If MOJO_MODE not already defined, default to development
+BEGIN { $ENV{MOJO_MODE} //= "development" }
 my $schema = Schema->connect_to_database;
 my $t      = Test::Mojo->new('TrafficOps');
 


### PR DESCRIPTION
small change -- don't set MOJO_MODE if already set in environment.