### PR TITLE
Traffic Stats now correctly calculates daily stats

### DIFF
--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -48,7 +48,7 @@ const (
 
 const (
 	defaultPollingInterval             = 10
-	defaultDailySummaryPollingInterval = 30
+	defaultDailySummaryPollingInterval = 60
 	defaultConfigInterval              = 300
 	defaultPublishingInterval          = 30
 	defaultMaxPublishSize              = 10000


### PR DESCRIPTION
Traffic Stats now uses continuous queries to calculate daily stats.  This is to address an issue where daily stats, specifically daily_bytesserved, was not correctly calculated once our CDN got to be > 1000 caches.  

This fixes #1669