### PR TITLE
TO now displays 'no data available in table' instead of hanging with message 'processing...'

### DIFF
--- a/traffic_ops/app/lib/UI/Cdn.pm
+++ b/traffic_ops/app/lib/UI/Cdn.pm
@@ -206,7 +206,7 @@ sub isValidCdn {
 
 sub aprofileparameter {
     my $self = shift;
-    my %data = ( "aaData" => undef );
+    my %data = ( "aaData" => [] );
 
     my $rs;
     if ( defined( $self->param('filter') ) ) {
@@ -249,7 +249,7 @@ sub aprofileparameter {
 
 sub aparameter {
     my $self = shift;
-    my %data = ( "aaData" => undef );
+    my %data = ( "aaData" => [] );
 
     my $col = undef;
     my $val = undef;
@@ -337,7 +337,7 @@ sub aparameter {
 sub aserver {
     my $self          = shift;
     my $server_select = shift;
-    my %data          = ( "aaData" => undef );
+    my %data          = ( "aaData" => [] );
     my $pparam =
         $self->db->resultset('ProfileParameter')
         ->search( { -and => [ 'parameter.name' => 'server_graph_url', 'profile.name' => 'GLOBAL' ] }, { prefetch => [ 'parameter', 'profile' ] } )
@@ -395,7 +395,7 @@ sub aserver {
 
 sub aasn {
     my $self = shift;
-    my %data = ( "aaData" => undef );
+    my %data = ( "aaData" => [] );
 
     my $rs = $self->db->resultset('Asn')->search( undef, { prefetch => [ { 'cachegroup' => 'cachegroups' }, ] } );
 
@@ -409,7 +409,7 @@ sub aasn {
 
 sub aphys_location {
     my $self = shift;
-    my %data = ( "aaData" => undef );
+    my %data = ( "aaData" => [] );
 
     my $rs = $self->db->resultset('PhysLocation')->search( undef, { prefetch => ['region'] } );
 
@@ -425,7 +425,7 @@ sub aphys_location {
 
 sub adeliveryservice {
     my $self       = shift;
-    my %data       = ( "aaData" => undef );
+    my %data       = ( "aaData" => [] );
     my %geo_limits = ( 0 => "none", 1 => "CZF", 2 => "CZF + Countries" );
     my %protocol   = ( 0 => "http", 1 => "https", 2 => "http/https" );
 
@@ -526,7 +526,7 @@ sub hwinfo {
 
 sub ajob {
     my $self = shift;
-    my %data = ( "aaData" => undef );
+    my %data = ( "aaData" => [] );
 
     my $rs = $self->db->resultset('Job')->search(
         undef, {
@@ -545,7 +545,7 @@ sub ajob {
 
 sub alog {
     my $self = shift;
-    my %data = ( "aaData" => undef );
+    my %data = ( "aaData" => [] );
 
     my $interval = "> now() - interval '30 day'";    # postgres
     if ( $self->db->storage->isa("DBIx::Class::Storage::DBI::mysql") ) {
@@ -578,7 +578,7 @@ sub alog {
 
 sub acdn {
     my $self = shift;
-    my %data = ( "aaData" => undef );
+    my %data = ( "aaData" => [] );
 
     my %id_to_name = ();
     my $rs         = $self->db->resultset('Cdn')->search(undef);
@@ -596,7 +596,7 @@ sub acdn {
 
 sub acachegroup {
     my $self = shift;
-    my %data = ( "aaData" => undef );
+    my %data = ( "aaData" => [] );
 
     my %id_to_name = ();
     my $rs = $self->db->resultset('Cachegroup')->search( undef, { prefetch => [ { 'type' => undef } ] } );
@@ -621,7 +621,7 @@ sub acachegroup {
 
 sub auser {
     my $self = shift;
-    my %data = ( "aaData" => undef );
+    my %data = ( "aaData" => [] );
 
     my $rs = $self->db->resultset('TmUser')->search( undef, { prefetch => [ { 'role' => undef } ] } );
 
@@ -639,7 +639,7 @@ sub auser {
 
 sub afederation {
     my $self = shift;
-    my %data = ( "aaData" => undef );
+    my %data = ( "aaData" => [] );
 
     my @line;
     my $feds = $self->db->resultset('Federation')->search(undef);
@@ -680,7 +680,7 @@ sub afederation {
 
 sub aprofile {
     my $self = shift;
-    my %data = ( "aaData" => undef );
+    my %data = ( "aaData" => [] );
 
     my $rs = $self->db->resultset('Profile')->search(undef);
 
@@ -694,7 +694,7 @@ sub aprofile {
 
 sub atype {
     my $self = shift;
-    my %data = ( "aaData" => undef );
+    my %data = ( "aaData" => [] );
 
     my $rs = $self->db->resultset('Type')->search(undef);
 
@@ -707,7 +707,7 @@ sub atype {
 
 sub adivision {
     my $self = shift;
-    my %data = ( "aaData" => undef );
+    my %data = ( "aaData" => [] );
 
     my $rs = $self->db->resultset('Division')->search(undef);
 
@@ -720,7 +720,7 @@ sub adivision {
 
 sub aregion {
     my $self = shift;
-    my %data = ( "aaData" => undef );
+    my %data = ( "aaData" => [] );
 
     my $rs = $self->db->resultset('Region')->search( undef, { prefetch => [ { 'division' => undef } ] } );
 


### PR DESCRIPTION
The DataTables java script library expects to get back an array at app/public/js/jquery.dataTables.js line 3284

We were sending back null which was blowing up javascript as evidenced in the javascript console in my browser