### PR TITLE
TO now allows editing delivery services in different cdn's with the same host regex

### DIFF
--- a/traffic_ops/app/lib/API/DeliveryService.pm
+++ b/traffic_ops/app/lib/API/DeliveryService.pm
@@ -30,6 +30,7 @@ use Common::ReturnCodes qw(SUCCESS ERROR);
 use JSON;
 use MojoPlugins::Response;
 use UI::DeliveryService;
+use Scalar::Util qw(looks_like_number);
 
 my $valid_server_types = {
 	edge => "EDGE",
@@ -64,6 +65,7 @@ sub delivery_services {
 			my $cdn_name  = defined( $row->cdn_id ) ? $row->cdn->name : "";
 			my $re_rs     = $row->deliveryservice_regexes;
 			my @matchlist = ();
+
 			while ( my $re_row = $re_rs->next ) {
 				push(
 					@matchlist, {
@@ -73,9 +75,11 @@ sub delivery_services {
 					}
 				);
 			}
-			my $cdn_domain = &UI::DeliveryService::get_cdn_domain( $self, $row->id );
+
+			my $cdn_domain = $self->get_cdn_domain_by_ds_id($row->id);
 			my $regexp_set = &UI::DeliveryService::get_regexp_set( $self, $row->id );
 			my @example_urls = &UI::DeliveryService::get_example_urls( $self, $row->id, $regexp_set, $row, $cdn_domain, $row->protocol );
+
 			push(
 				@data, {
 					"id"                       => $row->id,
@@ -435,14 +439,15 @@ sub create {
 
 	my ($transformed_params, $err) = (undef, undef);
 	($transformed_params, $err) = $self->check_params($params);
+
 	if ( defined($err) ) {
 		return $self->alert($err);
 	}
 
-        my $existing = $self->db->resultset('Deliveryservice')->search( { xml_id => $params->{xmlId} } )->get_column('xml_id')->single();
-        if ( $existing ) {
-                $self->alert("a delivery service with xmlId " . $params->{xmlId} . " already exists." );
-        }
+	my $existing = $self->db->resultset('Deliveryservice')->search( { xml_id => $params->{xmlId} } )->get_column('xml_id')->single();
+	if ( $existing ) {
+			$self->alert("a delivery service with xmlId " . $params->{xmlId} . " already exists." );
+	}
 
 	my $value=$self->new_value($params, $transformed_params);
 	my $insert = $self->db->resultset('Deliveryservice')->create($value);
@@ -572,26 +577,37 @@ sub assign_servers {
 sub check_params {
 	my $self = shift;
 	my $params = shift;
+	my $ds_id = shift;
 	my $transformed_params = undef;
 
 	if ( !defined($params) ) {
-		return (undef, "parameters should in json format, please check!");
+		return (undef, "parameters should be in json format, please check!");
 	}
 
 	if ( !defined($params->{xmlId}) ) {
 		return (undef, "parameter xmlId is must." );
 	}
 
-	if ( defined($params->{active}) ) {
-		if ( $params->{active} eq "true" || $params->{active} == 1 ) {
+	if (!defined($params->{active})) {
+		return (undef, "parameter active is must." );
+	}
+
+	if (looks_like_number($params->{active})) {
+		if ($params->{active} == 1) {
 			$transformed_params->{active} = 1;
-		} elsif ( $params->{active} eq "false" || $params->{active} == 0 ) {
+		} elsif ($params->{active} == 0) {
 			$transformed_params->{active} = 0;
 		} else {
-			return (undef, "active must be true|false." );
+			return (undef, "active must be 1|0");
 		}
 	} else {
-		return (undef, "parameter active is must." );
+		if ($params->{active} eq "true") {
+			$transformed_params->{active} = 1;
+		} elsif ($params->{active} eq "false") {
+			$transformed_params->{active} = 0;
+		} else {
+			return (undef, "active must be true|false");
+		}
 	}
 
 	if ( defined($params->{type}) ) {
@@ -634,8 +650,9 @@ sub check_params {
 		return (undef, "parameter profileName is must." );
 	}
 
+	my $cdn_id = undef;
 	if ( defined($params->{cdnName}) ) {
-		my $cdn_id = $self->db->resultset('Cdn')->search( { name => $params->{cdnName} } )->get_column('id')->single();
+		$cdn_id = $self->db->resultset('Cdn')->search( { name => $params->{cdnName} } )->get_column('id')->single();
 		if ( !defined $cdn_id ) {
 			return (undef, "cdnName (" . $params->{cdnName} . ") does not exists." );
 		} else {
@@ -646,10 +663,26 @@ sub check_params {
 	}
 
 	if ( defined($params->{matchList}) ) {
-		my $patterns     = $params->{matchList};
-		my $patterns_len = @$patterns;
-		if ( $patterns_len == 0 ) {
+		my $match_list = $params->{matchList};
+
+		if ((scalar $match_list) == 0) {
 			return (undef, "At least have 1 pattern in matchList.");
+		}
+
+		my $cdn_domain = undef;
+
+		if (defined($ds_id)) {
+			$cdn_domain = $self->get_cdn_domain_by_ds_id($ds_id);
+		} else {
+			my $profile_id = $self->get_profile_id_for_name($params->{profileName});
+			$cdn_domain = $self->get_cdn_domain_by_profile_id($profile_id);
+		}
+
+		foreach my $match_item (@$match_list) {
+			my $conflicting_regex = $self->find_existing_host_regex($match_item->{'type'}, $match_item->{'pattern'}, $cdn_domain, $cdn_id, $ds_id);
+			if (defined($conflicting_regex)) {
+				return(undef, "Another delivery service is already using host regex $conflicting_regex");
+			}
 		}
 	} else {
 		return (undef, "parameter matchList is must." );
@@ -836,7 +869,7 @@ sub update {
 	}
 
 	my ($transformed_params, $err) = (undef, undef);
-	($transformed_params, $err) = $self->check_params($params);
+	($transformed_params, $err) = $self->check_params($params, $id);
 	if ( defined($err) ) {
 		return $self->alert($err);
 	}

--- a/traffic_ops/app/lib/MojoPlugins/DeliveryService.pm
+++ b/traffic_ops/app/lib/MojoPlugins/DeliveryService.pm
@@ -28,6 +28,8 @@ use Common::ReturnCodes qw(SUCCESS ERROR);
 sub register {
 	my ( $self, $app, $conf ) = @_;
 
+	my $no_instance_message = "Call on an instance of MojoPlugins::DeliveryService!";
+	
 	$app->renderer->add_helper(
 
 		# ensure param returned as a scalar no matter the context,  and allow default value to be provided
@@ -62,7 +64,7 @@ sub register {
 
 	$app->renderer->add_helper(
 		is_delivery_service_assigned => sub {
-			my $self = shift || confess("Call on an instance of Utils::Helper");
+			my $self = shift || confess($no_instance_message);
 			my $id   = shift || confess("Please supply a delivery service ID");
 
 			my $user_id =
@@ -93,7 +95,7 @@ sub register {
 
 	$app->renderer->add_helper(
 		is_delivery_service_name_assigned => sub {
-			my $self    = shift || confess("Call on an instance of Utils::Helper");
+			my $self    = shift || confess($no_instance_message);
 			my $ds_name = shift || confess("Please supply a delivery service name (xml_id)");
 
 			my $user_id =
@@ -124,7 +126,7 @@ sub register {
 
 	$app->renderer->add_helper(
 		is_valid_delivery_service => sub {
-			my $self = shift || confess("Call on an instance of Utils::Helper");
+			my $self = shift || confess($no_instance_message);
 			my $id   = shift || confess("Please supply a delivery service ID");
 
 			my $result = $self->db->resultset("Deliveryservice")->find( { id => $id } );
@@ -140,7 +142,7 @@ sub register {
 
 	$app->renderer->add_helper(
 		is_valid_delivery_service_name => sub {
-			my $self = shift || confess("Call on an instance of Utils::Helper");
+			my $self = shift || confess($no_instance_message);
 			my $name = shift || confess("Please supply a delivery service 'name' (xml_id)");
 
 			my $result = $self->db->resultset("Deliveryservice")->find( { xml_id => $name } );
@@ -156,7 +158,7 @@ sub register {
 
 	$app->renderer->add_helper(
 		get_delivery_service_name => sub {
-			my $self = shift || confess("Call on an instance of Utils::Helper");
+			my $self = shift || confess($no_instance_message);
 			my $id   = shift || confess("Please supply a delivery service ID");
 
 			my $result = $self->db->resultset("Deliveryservice")->search( { id => $id } )->single();
@@ -170,6 +172,92 @@ sub register {
 		}
 	);
 
+	$app->renderer->add_helper(
+		find_existing_host_regex => sub {
+			my $self = shift || confess($no_instance_message);
+			my $regex_type = shift || confess("Please supply a regex type");
+			my $host_regex = shift || confess("Please supply a host regular expression");
+			my $cdn_domain = shift || confess("Please supply a cdn domain");
+			my $cdn_id = shift || confess("Please supply a cdn_name");
+			my $ds_id = shift;
+
+			if ($regex_type ne 'HOST_REGEXP') {
+				return undef;
+			}
+
+			my $new_regex = $host_regex . $cdn_domain;
+			my $rs = $self->db->resultset('DeliveryserviceRegex')->search(undef, {prefetch => [{regex => undef}, {deliveryservice => undef}]} );
+
+			while (my $row = $rs->next) {
+				my $other_cdn_id = $self->db->resultset('Deliveryservice')->search( { 'me.id' => $row->deliveryservice->id })->single->cdn_id;
+
+				if (defined($cdn_id) && $other_cdn_id != $cdn_id) {
+					next;
+				}
+
+				if (defined($ds_id) && $ds_id == $row->deliveryservice->id) {
+					next;
+				}
+
+				my $existing_regex = $row->regex->pattern . $cdn_domain;
+
+				if ($existing_regex eq $new_regex) {
+					return $existing_regex;
+				}
+			}
+
+			return undef;
+		}
+	);
+
+	$app->renderer->add_helper(
+		get_cdn_domain_by_ds_id => sub {
+			my $self = shift || confess($no_instance_message);
+			my $ds_id = shift || confess("Please supply a delivery service id!");
+
+			my $cdn_domain = $self->db->resultset('Parameter')->search(
+				{ -and => [ 'me.name' => 'domain_name', 'deliveryservices.id' => $ds_id ] },
+				{
+					join     => { profile_parameters => { profile => { deliveryservices => undef } } },
+					distinct => 1
+				}
+			)->get_column('value')->single();
+
+			return $cdn_domain;
+		}
+	);
+
+	$app->renderer->add_helper(
+		get_cdn_domain_by_profile_id => sub {
+			my $self = shift || confess($no_instance_message);
+			my $profile_id = shift || confess("Please Supply a profile id");
+
+			return $self->db->resultset('Parameter')->search(
+				{
+					'Name'                       => 'domain_name',
+					'Config_file'                => 'CRConfig.json',
+					'profile_parameters.profile' => $profile_id,
+				},
+				{ join => 'profile_parameters', }
+			)->get_column('value')->single();
+		}
+	);
+
+	$app->renderer->add_helper(
+		get_profile_id_for_name => sub {
+			my $self = shift || confess($no_instance_message);
+			my $profile_name = shift || confess("Please Supply a profile name");
+			return $self->db->resultset('Profile')->search({'me.name' => $profile_name})->single->id;
+		}
+	);
+
+	$app->renderer->add_helper(
+		get_id_for_cdn_name => sub {
+			my $self = shift || confess($no_instance_message);
+			my $cdn_name = shift || confess("Please Supply a CDN name");
+			return $self->db->resultset('Cdn')->search({'me.name' => $cdn_name})->single->id;
+		}
+	);
 }
 
 1;

--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -1263,8 +1263,7 @@ sub regex_revalidate_dot_config {
 	}
 
 	my %regex_time;
-	my $max_days =
-		$self->db->resultset('Parameter')->search( { name => "maxRevalDurationDays" }, { config_file => "regex_revalidate.config" } )->get_column('value')->first;
+	$max_days = $self->db->resultset('Parameter')->search( { name => "maxRevalDurationDays" }, { config_file => "regex_revalidate.config" } )->get_column('value')->first;
 	my $max_hours = $max_days * 24;
 	my $min_hours = 1;
 

--- a/traffic_ops/app/t/api/1.2/deliveryservice.t
+++ b/traffic_ops/app/t/api/1.2/deliveryservice.t
@@ -41,6 +41,20 @@ Test::TestHelper->load_core_data($schema);
 ok $t->post_ok( '/login', => form => { u => Test::TestHelper::ADMIN_USER, p => Test::TestHelper::ADMIN_USER_PASSWORD } )->status_is(302)
 	->or( sub { diag $t->tx->res->content->asset->{content}; } ), 'Should login?';
 
+# It gets existing delivery services
+ok $t->get_ok("/api/1.2/deliveryservices.json")->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content} } )
+		->json_is( "/response/0/xmlId", "test-ds1" )
+		->json_is( "/response/0/logsEnabled", 1 )
+		->json_is( "/response/0/ipv6RoutingEnabled", 1 )
+		->json_is( "/response/1/xmlId", "test-ds2" );
+
+ok $t->get_ok("/api/1.2/deliveryservices.json?logsEnabled=true")->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content} } )
+		->json_is( "/response/0/xmlId", "test-ds1" )
+		->json_is( "/response/0/logsEnabled", 1 )
+		->json_is( "/response/0/ipv6RoutingEnabled", 1 )
+		->json_is( "/response/1/xmlId", "test-ds4" );
+
+# It creates new delivery services
 ok $t->post_ok('/api/1.2/deliveryservices' => {Accept => 'application/json'} => json => {
         "xmlId" => "ds_1",
         "displayName" => "ds_displayname_1",
@@ -83,12 +97,97 @@ ok $t->post_ok('/api/1.2/deliveryservices' => {Accept => 'application/json'} => 
     ->json_is( "/response/matchList/1/pattern" => ".*\\.my_vod1\\..*")
             , 'Does the deliveryservice details return?';
 
+ok $t->post_ok('/api/1.2/deliveryservices' => {Accept => 'application/json'} => json => {
+        "xmlId" => "ds_2",
+        "displayName" => "ds_displayname_2",
+        "protocol" => "1",
+        "orgServerFqdn" => "http://10.75.168.91",
+        "cdnName" => "cdn1",
+        "profileName" => "CCR1",
+        "type" => "HTTP",
+        "multiSiteOrigin" => "0",
+        "regionalGeoBlocking" => "1",
+        "active" => "false",
+        "matchList" => [
+            {
+                "type" =>  "HOST_REGEXP",
+                "setNumber" =>  "0",
+                "pattern" => ".*\\.ds_2\\..*"
+            },
+            {
+                "type" =>  "HOST_REGEXP",
+                "setNumber" =>  "1",
+                "pattern" => ".*\\.my_vod2\\..*"
+            }
+        ]})
+    ->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } )
+    ->json_is( "/response/xmlId" => "ds_2")
+    ->json_is( "/response/displayName" => "ds_displayname_2")
+    ->json_is( "/response/orgServerFqdn" => "http://10.75.168.91")
+    ->json_is( "/response/cdnName" => "cdn1")
+    ->json_is( "/response/profileName" => "CCR1")
+    ->json_is( "/response/protocol" => "1")
+    ->json_is( "/response/type" => "HTTP")
+    ->json_is( "/response/multiSiteOrigin" => "0")
+    ->json_is( "/response/regionalGeoBlocking" => "1")
+    ->json_is( "/response/active" => "false")
+    ->json_is( "/response/matchList/0/type" => "HOST_REGEXP")
+    ->json_is( "/response/matchList/0/setNumber" => "0")
+    ->json_is( "/response/matchList/0/pattern" => ".*\\.ds_2\\..*")
+    ->json_is( "/response/matchList/1/type" => "HOST_REGEXP")
+    ->json_is( "/response/matchList/1/setNumber" => "1")
+    ->json_is( "/response/matchList/1/pattern" => ".*\\.my_vod2\\..*")
+            , 'Does the deliveryservice details return?';
+
+# It allows adding a delivery service to a different CDN with a matching regex in another CDN's delivery service
+ok $t->post_ok('/api/1.2/deliveryservices' => {Accept => 'application/json'} => json => {
+        "xmlId" => "ds_3",
+        "displayName" => "ds_displayname_1",
+        "protocol" => "1",
+        "orgServerFqdn" => "http://10.75.168.91",
+        "cdnName" => "cdn2",
+        "profileName" => "CCR1",
+        "type" => "HTTP",
+        "multiSiteOrigin" => "0",
+        "regionalGeoBlocking" => "1",
+        "active" => "false",
+        "matchList" => [
+            {
+                "type" =>  "HOST_REGEXP",
+                "setNumber" =>  "0",
+                "pattern" => ".*\\.ds_1\\..*"
+            },
+            {
+                "type" =>  "HOST_REGEXP",
+                "setNumber" =>  "1",
+                "pattern" => ".*\\.my_vod2\\..*"
+            }
+        ]})
+    ->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } )
+    ->json_is( "/response/xmlId" => "ds_3")
+    ->json_is( "/response/displayName" => "ds_displayname_1")
+    ->json_is( "/response/orgServerFqdn" => "http://10.75.168.91")
+    ->json_is( "/response/cdnName" => "cdn2")
+    ->json_is( "/response/profileName" => "CCR1")
+    ->json_is( "/response/protocol" => "1")
+    ->json_is( "/response/type" => "HTTP")
+    ->json_is( "/response/multiSiteOrigin" => "0")
+    ->json_is( "/response/regionalGeoBlocking" => "1")
+    ->json_is( "/response/active" => "false")
+    ->json_is( "/response/matchList/0/type" => "HOST_REGEXP")
+    ->json_is( "/response/matchList/0/setNumber" => "0")
+    ->json_is( "/response/matchList/0/pattern" => ".*\\.ds_1\\..*")
+    ->json_is( "/response/matchList/1/type" => "HOST_REGEXP")
+    ->json_is( "/response/matchList/1/setNumber" => "1")
+    ->json_is( "/response/matchList/1/pattern" => ".*\\.my_vod2\\..*")
+            , 'Does the deliveryservice details return?';
+
 my $ds_id = &get_ds_id('ds_1');
 
 ok $t->put_ok('/api/1.2/deliveryservices/' . $ds_id  => {Accept => 'application/json'} => json => {
         "xmlId" => "ds_1",
-        "displayName" => "ds_displayname_2",
-        "protocol" => "1",
+        "displayName" => "ds_displayname_11",
+        "protocol" => "2",
         "orgServerFqdn" => "http://10.75.168.91",
         "cdnName" => "cdn1",
         "profileName" => "CCR1",
@@ -100,29 +199,105 @@ ok $t->put_ok('/api/1.2/deliveryservices/' . $ds_id  => {Accept => 'application/
             {
                 "type" =>  "HOST_REGEXP",
                 "setNumber" =>  "0",
-                "pattern" => ".*\\.my_vod2\\..*"
+                "pattern" => ".*\\.my_vod1\\..*"
             }
         ]})
     ->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } )
     ->json_is( "/response/xmlId" => "ds_1")
-    ->json_is( "/response/displayName" => "ds_displayname_2")
+    ->json_is( "/response/displayName" => "ds_displayname_11")
     ->json_is( "/response/orgServerFqdn" => "http://10.75.168.91")
     ->json_is( "/response/cdnName" => "cdn1")
     ->json_is( "/response/profileName" => "CCR1")
-    ->json_is( "/response/protocol" => "1")
+    ->json_is( "/response/protocol" => "2")
     ->json_is( "/response/type" => "HTTP")
     ->json_is( "/response/multiSiteOrigin" => "0")
     ->json_is( "/response/regionalGeoBlocking" => "0")
     ->json_is( "/response/active" => "true")
     ->json_is( "/response/matchList/0/type" => "HOST_REGEXP")
     ->json_is( "/response/matchList/0/setNumber" => "0")
-    ->json_is( "/response/matchList/0/pattern" => ".*\\.my_vod2\\..*")
+    ->json_is( "/response/matchList/0/pattern" => ".*\\.my_vod1\\..*")
             , 'Does the deliveryservice details return?';
+
+
+# It allows updating a delivery service in a CDN with a matching regex in another CDN's delivery service
+
+$ds_id = &get_ds_id('ds_3');
+
+ok $t->put_ok('/api/1.2/deliveryservices/' . $ds_id  => {Accept => 'application/json'} => json => {
+		"xmlId" => "ds_3",
+		"displayName" => "ds_displayname_1",
+		"protocol" => "1",
+		"orgServerFqdn" => "http://10.75.168.91",
+		"cdnName" => "cdn2",
+		"profileName" => "CCR1",
+		"type" => "HTTP",
+		"multiSiteOrigin" => "0",
+		"regionalGeoBlocking" => "1",
+		"active" => "false",
+		"matchList" => [
+			{
+				"type" =>  "HOST_REGEXP",
+				"setNumber" =>  "0",
+				"pattern" => ".*\\.ds_1\\..*"
+			},
+			{
+				"type" =>  "HOST_REGEXP",
+				"setNumber" =>  "1",
+				"pattern" => ".*\\.my_vod1\\..*"
+			}
+		]})
+	->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } )
+		->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } )
+		->json_is( "/response/xmlId" => "ds_3")
+		->json_is( "/response/displayName" => "ds_displayname_1")
+		->json_is( "/response/orgServerFqdn" => "http://10.75.168.91")
+		->json_is( "/response/cdnName" => "cdn2")
+		->json_is( "/response/profileName" => "CCR1")
+		->json_is( "/response/protocol" => "1")
+		->json_is( "/response/type" => "HTTP")
+		->json_is( "/response/multiSiteOrigin" => "0")
+		->json_is( "/response/regionalGeoBlocking" => "1")
+		->json_is( "/response/active" => "false")
+		->json_is( "/response/matchList/0/type" => "HOST_REGEXP")
+		->json_is( "/response/matchList/0/setNumber" => "0")
+		->json_is( "/response/matchList/0/pattern" => ".*\\.ds_1\\..*")
+		->json_is( "/response/matchList/1/type" => "HOST_REGEXP")
+		->json_is( "/response/matchList/1/setNumber" => "1")
+		->json_is( "/response/matchList/1/pattern" => ".*\\.my_vod1\\..*")
+	, 'Does the deliveryservice details return?';
+
+# It does not allow changing a regex to be the same as an existing one in another DS in the same CDN
+$ds_id = &get_ds_id('ds_1');
+ok $t->put_ok('/api/1.2/deliveryservices/' . $ds_id  => {Accept => 'application/json'} => json => {
+			"xmlId" => "ds_1",
+			"displayName" => "ds_displayname_2",
+			"protocol" => "1",
+			"orgServerFqdn" => "http://10.75.168.91",
+			"cdnName" => "cdn1",
+			"profileName" => "CCR1",
+			"type" => "HTTP",
+			"multiSiteOrigin" => "0",
+			"regionalGeoBlocking" => "0",
+			"active" => "true",
+			"matchList" => [
+				{
+					"type" =>  "HOST_REGEXP",
+					"setNumber" =>  "0",
+					"pattern" => ".*\\.ds_2\\..*"
+				},
+				{
+					"type" =>  "HOST_REGEXP",
+					"setNumber" =>  "1",
+					"pattern" => ".*\\.my_vod2\\..*"
+				}
+			]})
+		->status_is(400)->or( sub { diag $t->tx->res->content->asset->{content}; } )
+	, 'Does the deliveryservice details return?';
 
 ok $t->delete_ok('/api/1.2/deliveryservices/' . $ds_id)->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content}; } );
 
 ok $t->put_ok('/api/1.2/deliveryservices/' . $ds_id  => {Accept => 'application/json'} => json => {
-        "xmlId" => "ds_3"
+        "xmlId" => "ds_1234"
 })
     ->status_is(404)->or( sub { diag $t->tx->res->content->asset->{content}; } );
 
@@ -134,13 +309,7 @@ ok $t->post_ok(
 	->json_is( "/response/serverNames/0" => "atlanta-edge-01" )->json_is( "/response/serverNames/1" => "atlanta-edge-02" ),
 	'Does the assigned servers return?';
 
-ok $t->get_ok("/api/1.2/deliveryservices.json")->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content} } )
-	->json_is( "/response/0/xmlId", "test-ds1" )->json_is( "/response/0/logsEnabled", 1 )->json_is( "/response/0/ipv6RoutingEnabled", 1 )
-	->json_is( "/response/1/xmlId", "test-ds2" );
 
-ok $t->get_ok("/api/1.2/deliveryservices.json?logsEnabled=true")->status_is(200)->or( sub { diag $t->tx->res->content->asset->{content} } )
-	->json_is( "/response/0/xmlId", "test-ds1" )->json_is( "/response/0/logsEnabled", 1 )->json_is( "/response/0/ipv6RoutingEnabled", 1 )
-	->json_is( "/response/1/xmlId", "test-ds4" );
 
 # Count the 'response number'
 my $count_response = sub {


### PR DESCRIPTION
Used to get a bogus error that I was trying to add a host regex that was already taken by another delivery service. However the other delivery service was not in the same cdn.