### PR TITLE
#1730: Stop RGB File downloading when RGB func not use

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/config/ConfigHandler.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/config/ConfigHandler.java
@@ -442,7 +442,7 @@ public class ConfigHandler {
 
 		if (jo.has(deliveryServicesKey)) {
 			final JSONObject dss = jo.getJSONObject(deliveryServicesKey);
-			for (String ds : JSONObject.getNames(dss)) {
+			for (final String ds : JSONObject.getNames(dss)) {
 				if (dss.getJSONObject(ds).has("regionalGeoBlocking") &&
 						dss.getJSONObject(ds).getString("regionalGeoBlocking").equals("true")) {
 					final long interval = config.optLong("regional_geoblock.polling.interval");

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/config/ConfigHandler.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/config/ConfigHandler.java
@@ -60,6 +60,7 @@ public class ConfigHandler {
 
 	private static long lastSnapshotTimestamp = 0;
 	private static Object configSync = new Object();
+	private static String deliveryServicesKey = "deliveryServices";
 
 	private TrafficRouterManager trafficRouterManager;
 	private GeolocationDatabaseUpdater geolocationDatabaseUpdater;
@@ -114,14 +115,14 @@ public class ConfigHandler {
 			try {
 				parseGeolocationConfig(config);
 				parseCoverageZoneNetworkConfig(config);
-				parseRegionalGeoConfig(config);
+				parseRegionalGeoConfig(jo);
 
 				final CacheRegister cacheRegister = new CacheRegister();
 				cacheRegister.setTrafficRouters(jo.getJSONObject("contentRouters"));
 				cacheRegister.setConfig(config);
 				cacheRegister.setStats(stats);
 				parseTrafficOpsConfig(config, stats);
-				parseDeliveryServiceConfig(jo.getJSONObject("deliveryServices"), cacheRegister);
+				parseDeliveryServiceConfig(jo.getJSONObject(deliveryServicesKey), cacheRegister);
 				parseLocationConfig(jo.getJSONObject("edgeLocations"), cacheRegister);
 				parseCacheConfig(jo.getJSONObject("contentServers"), cacheRegister);
 				parseMonitorConfig(jo.getJSONObject("monitors"));
@@ -222,9 +223,9 @@ public class ConfigHandler {
 					LOGGER.warn(e+" : "+ip);
 				}
 
-				if(jo.has("deliveryServices")) {
+				if(jo.has(deliveryServicesKey)) {
 					final List<DeliveryServiceReference> references = new ArrayList<Cache.DeliveryServiceReference>();
-					final JSONObject dsJos = jo.optJSONObject("deliveryServices");
+					final JSONObject dsJos = jo.optJSONObject(deliveryServicesKey);
 					for (final String ds : JSONObject.getNames(dsJos)) {
 						/* technically this could be more than just a string or array,
 						 * but, as we only have had those two types, let's not worry about the future
@@ -429,7 +430,8 @@ public class ConfigHandler {
 			);
 	}
 
-	private void parseRegionalGeoConfig(final JSONObject config) {
+	private void parseRegionalGeoConfig(final JSONObject jo) throws JSONException {
+		final JSONObject config = jo.getJSONObject("config");
 		final String url = config.optString("regional_geoblock.polling.url", null);
 
 		if (url == null) {
@@ -438,8 +440,19 @@ public class ConfigHandler {
 			return;
 		}
 
-		final long interval = config.optLong("regional_geoblock.polling.interval");
-		getRegionalGeoUpdater().setDataBaseURL(url, interval);
+		if (jo.has(deliveryServicesKey)) {
+			final JSONObject dss = jo.getJSONObject(deliveryServicesKey);
+			for (String ds : JSONObject.getNames(dss)) {
+				if (dss.getJSONObject(ds).has("regionalGeoBlocking") &&
+						dss.getJSONObject(ds).getString("regionalGeoBlocking").equals("true")) {
+					final long interval = config.optLong("regional_geoblock.polling.interval");
+					getRegionalGeoUpdater().setDataBaseURL(url, interval);
+					return;
+				}
+			}
+		}
+
+		getRegionalGeoUpdater().cancelServiceUpdater();
 	}
 
 	/**

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
@@ -184,6 +184,12 @@ public abstract class AbstractServiceUpdater {
 		}
 	}
 
+	public void cancelServiceUpdater() {
+		this.stopServiceUpdater();
+		pollingInterval = 0;
+		dataBaseURL = null;
+	}
+
 	public void setDataBaseURL(final String url, final long refresh) {
 		if (refresh !=0 && refresh != pollingInterval) {
 


### PR DESCRIPTION
When there is no delivery service which use RGB function,  the downloading of RGB file should be stopped. 