### PR TITLE
Fix TR download invalid db issue -- version2

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/ds/SteeringRegistry.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/ds/SteeringRegistry.java
@@ -62,6 +62,18 @@ public class SteeringRegistry {
 		}
 	}
 
+	public boolean verify(final String json) {
+		try {
+			final ObjectMapper mapper = new ObjectMapper(new JsonFactory());
+			mapper.readValue(json, new TypeReference<HashMap<String, List<Steering>>>() { });
+		} catch (IOException e) {
+			LOGGER.error("Failed consuming Json data to populate steering registry while verifying:" + e.getMessage());
+			return false;
+		}
+
+		return true;
+	}
+
 	public boolean has(final String steeringId) {
 		return registry.containsKey(steeringId);
 	}

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/ds/SteeringWatcher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/ds/SteeringWatcher.java
@@ -64,6 +64,17 @@ public class SteeringWatcher extends AbstractResourceWatcher {
 	}
 
 	@Override
+	protected boolean verifyData(final String data) {
+		try {
+			return steeringRegistry.verify(data);
+		} catch (Exception e) {
+			LOGGER.warn("Failed to build steering data while verifying");
+		}
+
+		return false;
+	}
+
+	@Override
 	public String getWatcherConfigPrefix() {
 		return "steeringmapping";
 	}

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationsWatcher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/FederationsWatcher.java
@@ -40,6 +40,18 @@ public class FederationsWatcher extends AbstractResourceWatcher {
         return false;
     }
 
+    @Override
+    protected boolean verifyData(final String data) {
+        try {
+            new FederationsBuilder().fromJSON(data);
+            return true;
+        } catch (Exception e) {
+            LOGGER.warn("Failed to build federations data from " + dataBaseURL);
+        }
+
+        return false;
+    }
+
     public void setFederationRegistry(final FederationRegistry federationRegistry) {
         this.federationRegistry = federationRegistry;
     }

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/MaxmindGeolocationService.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/MaxmindGeolocationService.java
@@ -78,6 +78,20 @@ public class MaxmindGeolocationService implements GeolocationService {
 	}
 
 	@Override
+	public void reloadDatabase(final File dbFile) throws IOException {
+		if (databaseReader != null) {
+			databaseReader.close();
+		}
+
+		if (dbFile != null) {
+			final DatabaseReader reader = createDatabaseReader(dbFile);
+			if (reader != null) {
+				initialized = true;
+			}
+		}
+	}
+
+	@Override
 	public boolean verifyDatabase(final File databaseFile) throws IOException {
 		return createDatabaseReader(databaseFile) != null;
 	}

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/MaxmindGeolocationService.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/MaxmindGeolocationService.java
@@ -78,20 +78,6 @@ public class MaxmindGeolocationService implements GeolocationService {
 	}
 
 	@Override
-	public void reloadDatabase(final File dbFile) throws IOException {
-		if (databaseReader != null) {
-			databaseReader.close();
-		}
-
-		if (dbFile != null) {
-			final DatabaseReader reader = createDatabaseReader(dbFile);
-			if (reader != null) {
-				initialized = true;
-			}
-		}
-	}
-
-	@Override
 	public boolean verifyDatabase(final File databaseFile) throws IOException {
 		return createDatabaseReader(databaseFile) != null;
 	}

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/NetworkNode.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/NetworkNode.java
@@ -63,12 +63,12 @@ public class NetworkNode implements Comparable<NetworkNode> {
         return instance;
     }
 
-    public static NetworkNode generateTree(final File f) throws NetworkNodeException, FileNotFoundException, JSONException  {
-        return generateTree(new JSONObject(new JSONTokener(new FileReader(f))));
+    public static NetworkNode generateTree(final File f, final boolean verifyOnly) throws NetworkNodeException, FileNotFoundException, JSONException  {
+        return generateTree(new JSONObject(new JSONTokener(new FileReader(f))), verifyOnly);
     }
 
     @SuppressWarnings("PMD.CyclomaticComplexity")
-    public static NetworkNode generateTree(final JSONObject json) {
+    public static NetworkNode generateTree(final JSONObject json, final boolean verifyOnly) {
         try {
             final JSONObject coverageZones = json.getJSONObject("coverageZones");
 
@@ -95,6 +95,7 @@ public class NetworkNode implements Comparable<NetworkNode> {
                             root.add6(new NetworkNode(ip, loc, geolocation));
                         } catch (NetworkNodeException ex) {
                             LOGGER.error(ex, ex);
+                            return null;
                         }
                     }
                 } catch (JSONException ex) {
@@ -111,6 +112,7 @@ public class NetworkNode implements Comparable<NetworkNode> {
                             root.add(new NetworkNode(ip, loc, geolocation));
                         } catch (NetworkNodeException ex) {
                             LOGGER.error(ex, ex);
+                            return null;
                         }
                     }
                 } catch (JSONException ex) {
@@ -118,7 +120,9 @@ public class NetworkNode implements Comparable<NetworkNode> {
                 }
             }
 
-            instance = root;
+            if (!verifyOnly) {
+                instance = root;
+            }
 
             return root;
         } catch (JSONException e) {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/NetworkUpdater.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/NetworkUpdater.java
@@ -29,6 +29,7 @@ public class NetworkUpdater extends AbstractServiceUpdater {
 		tmpSuffix = ".json";
 	}
 
+	@Override
 	public boolean loadDatabase() throws IOException, JSONException {
 		final File existingDB = databasesDirectory.resolve(databaseName).toFile();
 
@@ -36,7 +37,16 @@ public class NetworkUpdater extends AbstractServiceUpdater {
 			return false;
 		}
 
-		NetworkNode.generateTree(existingDB);
-		return true;
+		return NetworkNode.generateTree(existingDB, false) != null;
 	}
+
+	@Override
+	public boolean verifyDatabase(final File dbFile) throws IOException, JSONException {
+		if (!dbFile.exists() || !dbFile.canRead()) {
+			return false;
+		}
+
+		return NetworkNode.generateTree(dbFile, true) != null;
+	}
+
 }

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/RegionalGeo.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/RegionalGeo.java
@@ -233,7 +233,7 @@ public final class RegionalGeo {
         return null;
     }
 
-    public static boolean parseConfigFile(final File f) {
+    public static boolean parseConfigFile(final File f, final boolean verifyOnly) {
         JSONObject json = null;
         try {
             json = new JSONObject(new JSONTokener(new FileReader(f)));
@@ -249,7 +249,10 @@ public final class RegionalGeo {
             return false;
         }
         
-        currentConfig = regionalGeo; // point to the new parsed object
+        if (!verifyOnly) {
+            currentConfig = regionalGeo; // point to the new parsed object
+        }
+
         currentConfig.setFallback(false);
         LOGGER.debug("RegionalGeo: create instance from new json");
         return true;

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/RegionalGeoUpdater.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/RegionalGeoUpdater.java
@@ -30,11 +30,16 @@ public class RegionalGeoUpdater extends AbstractServiceUpdater {
         tmpPrefix = "regionalgeo";
         tmpSuffix = ".json";
     }
-
+    
+    @Override
     public boolean loadDatabase() throws IOException {
         final File existingDB = databasesDirectory.resolve(databaseName).toFile();
-        RegionalGeo.parseConfigFile(existingDB);
-        return true;
+        return RegionalGeo.parseConfigFile(existingDB, false);
+    }
+
+    @Override
+    public boolean verifyDatabase(final File dbFile) throws IOException {
+        return RegionalGeo.parseConfigFile(dbFile, true);
     }
 }
 

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/util/AbstractResourceWatcher.java
@@ -87,6 +87,8 @@ public abstract class AbstractResourceWatcher extends AbstractServiceUpdater {
 		return true;
 	}
 
+	abstract protected boolean verifyData(final String data);
+
 	@Override
 	public boolean loadDatabase() throws IOException, org.apache.wicket.ajax.json.JSONException {
 		final File existingDB = databasesDirectory.resolve(databaseName).toFile();
@@ -106,6 +108,25 @@ public abstract class AbstractResourceWatcher extends AbstractServiceUpdater {
 
 		return useData(new String(jsonData));
 	}
+
+	@Override
+	public boolean verifyDatabase(final File dbFile) throws IOException {
+		if (!dbFile.exists() || !dbFile.canRead()) {
+			return false;
+		}
+
+		final char[] jsonData = new char[(int) dbFile.length()];
+		final FileReader reader = new FileReader(dbFile);
+
+		try {
+			reader.read(jsonData);
+		} finally {
+			reader.close();
+		}
+
+		return verifyData(new String(jsonData));
+	}
+
 
 	@Override
 	protected File downloadDatabase(final String url, final File existingDb) {

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/NetworkNodeTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/NetworkNodeTest.java
@@ -48,7 +48,7 @@ public class NetworkNodeTest {
 	@Before
 	public void setUp() throws Exception {
 		final File file = new File(getClass().getClassLoader().getResource("czmap.json").toURI());
-		root = NetworkNode.generateTree(file);
+		root = NetworkNode.generateTree(file, false);
 
 		final JSONObject json = new JSONObject(new JSONTokener(new FileReader(file)));
 		final JSONObject coverageZones = json.getJSONObject("coverageZones");

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/NetworkNodeUnitTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/NetworkNodeUnitTest.java
@@ -102,7 +102,7 @@ public class NetworkNodeUnitTest {
 
         JSONTokener jsonTokener = new JSONTokener(czmapString);
         final JSONObject json = new JSONObject(jsonTokener);
-        NetworkNode networkNode = NetworkNode.generateTree(json);
+        NetworkNode networkNode = NetworkNode.generateTree(json, false);
         NetworkNode foundNetworkNode = networkNode.getNetwork("1234:5678::1");
 
         assertThat(foundNetworkNode.getLoc(), equalTo("us-co-denver"));
@@ -149,9 +149,45 @@ public class NetworkNodeUnitTest {
 
         JSONTokener jsonTokener = new JSONTokener(czmapString);
         final JSONObject json = new JSONObject(jsonTokener);
-        NetworkNode networkNode = NetworkNode.generateTree(json);
+        NetworkNode networkNode = NetworkNode.generateTree(json, false);
         NetworkNode foundNetworkNode = networkNode.getNetwork("192.168.55.2");
 
         assertThat(foundNetworkNode.getLoc(), equalTo("us-co-denver"));
+    }
+
+    @Test
+    public void itRejectsInvalidIpV4Network() throws Exception {
+        String czmapString = "{" +
+            "\"revision\": \"Mon Dec 21 15:04:01 2015\"," +
+            "\"customerName\": \"Kabletown\"," +
+            "\"coverageZones\": {" +
+            "\"us-co-denver\": {" +
+            "\"network\": [\"192.168.55.258/24\",\"192.168.6.0/24\",\"192.168.0.0/16\"]," +
+            "\"network6\": [\"1234:5678::/64\",\"1234:5679::/64\"]" +
+            "}" +
+            "}" +
+            "}";
+
+        JSONTokener jsonTokener = new JSONTokener(czmapString);
+        final JSONObject json = new JSONObject(jsonTokener);
+        assertThat(NetworkNode.generateTree(json, false), equalTo(null));
+    }
+
+    @Test
+    public void itRejectsInvalidIpV6Network() throws Exception {
+        String czmapString = "{" +
+            "\"revision\": \"Mon Dec 21 15:04:01 2015\"," +
+            "\"customerName\": \"Kabletown\"," +
+            "\"coverageZones\": {" +
+            "\"us-co-denver\": {" +
+            "\"network\": [\"192.168.55.0/24\",\"192.168.6.0/24\",\"192.168.0.0/16\"]," +
+            "\"network6\": [\"1234:5678::/64\",\"zyx:5679::/64\"]" +
+            "}" +
+            "}" +
+            "}";
+
+        JSONTokener jsonTokener = new JSONTokener(czmapString);
+        final JSONObject json = new JSONObject(jsonTokener);
+        assertThat(NetworkNode.generateTree(json, false), equalTo(null));
     }
 }

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/RegionalGeoTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/loc/RegionalGeoTest.java
@@ -38,7 +38,7 @@ public class RegionalGeoTest {
     @Before
     public void setUp() throws Exception {
         final File dbFile = new File("src/test/resources/regional_geoblock.json");
-        RegionalGeo.parseConfigFile(dbFile);
+        RegionalGeo.parseConfigFile(dbFile, false);
     }
 
     @Test


### PR DESCRIPTION
@dneuman64 @trevorackerman Please help to review this revised version, thanks.
To fix TR download invalid db issue #1449. And this is a revised version for the old PR #1541.

This time, I am implementing the verifyDatabase() for all subclasses of AbstractServiceUpdater. If it fails, do not copy the downloaded DB.

I have tested it on NetworkUpdater, RegionalGeo, and GeolocationDatabase, but not on SteeringWatcher and FederationsWatcher.
