### PR TITLE
Fix consistent hashing in Traffic Router

### DIFF
--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/hash/ConsistentHasher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/hash/ConsistentHasher.java
@@ -1,18 +1,16 @@
 package com.comcast.cdn.traffic_control.traffic_router.core.hash;
 
 import com.comcast.cdn.traffic_control.traffic_router.core.ds.Dispersion;
-import org.apache.log4j.Logger;
+//import org.apache.log4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
 public class ConsistentHasher {
-	private static final Logger LOGGER = Logger.getLogger(ConsistentHasher.class);
+//	private static final Logger LOGGER = Logger.getLogger(ConsistentHasher.class);
 
 	final private MD5HashFunction hashFunction = new MD5HashFunction();
 

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/hash/ConsistentHasher.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/hash/ConsistentHasher.java
@@ -1,5 +1,6 @@
 package com.comcast.cdn.traffic_control.traffic_router.core.hash;
 
+import com.comcast.cdn.traffic_control.traffic_router.core.ds.Dispersion;
 import org.apache.log4j.Logger;
 
 import java.util.ArrayList;
@@ -15,44 +16,27 @@ public class ConsistentHasher {
 
 	final private MD5HashFunction hashFunction = new MD5HashFunction();
 
-	public <T extends Hashable> T selectHashable(final List<T> hashables, final String s, final boolean shuffle) {
-		if (hashables.isEmpty()) {
-			LOGGER.warn("Cannot select a hashable from an empty list!");
-			return null;
-		}
-
-		if (shuffle) {
-			return hashables.get(new Random(System.currentTimeMillis()).nextInt(hashables.size()));
-		}
-
-		final Collection<T> values = sortHashables(hashables, s).values();
-
-		if (values.isEmpty()) {
-			LOGGER.warn("Failed to generate sorted hashables from given hashables list of size " + hashables.size());
-			return null;
-		}
-
-		return values.iterator().next();
+	public <T extends Hashable> T selectHashable(final List<T> hashables, final Dispersion dispersion, final String s) {
+		return selectHashables(hashables, dispersion, s).get(0);
 	}
 
-	public <T extends Hashable> List<T> selectHashables(final List<T> hashables, final int limit, final String s, final boolean shuffle) {
-		if (shuffle) {
-			Collections.shuffle(hashables);
-			return (limit <= hashables.size()) ? hashables.subList(0, limit) : hashables;
-		}
+	public <T extends Hashable> List<T> selectHashables(final List<T> hashables, final Dispersion dispersion, final String s) {
 
 		final SortedMap<Double, T> sortedHashables = sortHashables(hashables, s);
 		final List<T> selectedHashables = new ArrayList<T>();
 
 		for (final T hashable : sortedHashables.values()) {
-			if (selectedHashables.size() >= limit) {
+			if (selectedHashables.size() >= dispersion.getLimit()) {
 				break;
 			}
 
 			selectedHashables.add(hashable);
 		}
+		if (dispersion.isShuffled()) {
+			Collections.shuffle(selectedHashables);
+		}
 
-		return selectedHashables;
+		return (dispersion.getLimit() <= selectedHashables.size()) ? selectedHashables.subList(0, dispersion.getLimit()) : selectedHashables;
 	}
 
 	private <T extends Hashable> SortedMap<Double, T> sortHashables(final List<T> hashables, final String s) {

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
@@ -367,8 +367,7 @@ public class TrafficRouter {
 		List<Cache> selectedCaches;
 
 		if (maxDnsIps > 0 && isConsistentDNSRouting()) { // only consistent hash if we must
-			final Dispersion dispersion = ds.getDispersion();
-			selectedCaches = (List<Cache>) consistentHasher.selectHashables(caches, dispersion.getLimit(), request.getHostname(), dispersion.getLimit() > 1 && dispersion.isShuffled());
+			selectedCaches = (List<Cache>) consistentHasher.selectHashables(caches, ds.getDispersion(), request.getHostname());
 		} else if (maxDnsIps > 0) {
 			/*
 			 * We also shuffle in NameServer when adding Records to the Message prior
@@ -474,9 +473,7 @@ public class TrafficRouter {
 			routeResult.setUrl(deliveryService.getFailureHttpResponse(request, track));
 			return routeResult;
 		}
-
-		final boolean isShuffled = deliveryService.getDispersion().getLimit() > 1 && deliveryService.getDispersion().isShuffled();
-		final Cache cache = consistentHasher.selectHashable(caches, request.getPath(), isShuffled);
+		final Cache cache = consistentHasher.selectHashable(caches, deliveryService.getDispersion(), request.getPath());
 
 		if (deliveryService.isRegionalGeoEnabled()) {
 			RegionalGeo.enforce(this, request, deliveryService, cache, routeResult, track);
@@ -570,7 +567,7 @@ public class TrafficRouter {
 			return null;
 		}
 
-		return consistentHasher.selectHashable(caches, requestPath, deliveryService.getDispersion().getLimit() > 1 && deliveryService.getDispersion().isShuffled());
+		return consistentHasher.selectHashable(caches, deliveryService.getDispersion(), requestPath);
 	}
 
 	public Cache consistentHashForGeolocation(final String ip, final String deliveryServiceId, final String requestPath) {
@@ -598,7 +595,7 @@ public class TrafficRouter {
 			return null;
 		}
 
-		return consistentHasher.selectHashable(caches, requestPath, deliveryService.getDispersion().getLimit() > 1 && deliveryService.getDispersion().isShuffled());
+		return consistentHasher.selectHashable(caches, deliveryService.getDispersion(), requestPath);
 	}
 
 	public DeliveryService consistentHashDeliveryService(final String deliveryServiceId, final String requestPath) {
@@ -625,7 +622,7 @@ public class TrafficRouter {
 			return cacheRegister.getDeliveryService(bypassDeliveryServiceId);
 		}
 
-		final SteeringTarget steeringTarget = consistentHasher.selectHashable(steering.getTargets(), requestPath, false);
+		final SteeringTarget steeringTarget = consistentHasher.selectHashable(steering.getTargets(), deliveryService.getDispersion(), requestPath);
 		return cacheRegister.getDeliveryService(steeringTarget.getDeliveryService());
 	}
 
@@ -659,7 +656,7 @@ public class TrafficRouter {
 		return null;
 	}
 
-	/**
+	/*
 	 * Selects a {@link Cache} from the {@link CacheLocation} provided.
 	 * 
 	 * @param location

--- a/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
+++ b/traffic_router/core/src/main/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouter.java
@@ -51,7 +51,6 @@ import com.comcast.cdn.traffic_control.traffic_router.core.cache.InetRecord;
 import com.comcast.cdn.traffic_control.traffic_router.core.dns.ZoneManager;
 import com.comcast.cdn.traffic_control.traffic_router.core.dns.DNSAccessRecord;
 import com.comcast.cdn.traffic_control.traffic_router.core.ds.DeliveryService;
-import com.comcast.cdn.traffic_control.traffic_router.core.ds.Dispersion;
 import com.comcast.cdn.traffic_control.traffic_router.core.loc.FederationRegistry;
 import com.comcast.cdn.traffic_control.traffic_router.geolocation.Geolocation;
 import com.comcast.cdn.traffic_control.traffic_router.geolocation.GeolocationException;

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/hashing/ConsistentHasherTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/hashing/ConsistentHasherTest.java
@@ -12,10 +12,10 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Random;
 
 import static org.hamcrest.Matchers.greaterThan;
@@ -69,25 +69,29 @@ public class ConsistentHasherTest {
 
 	@Test
 	public void itHashesMoreThanOne() throws Exception {
-		JSONObject jo = new JSONObject("dispersion: {\n" +
+		JSONObject jo = new JSONObject("{dispersion: {\n" +
 				"limit: 2,\n" +
 				"shuffled: \"true\"\n" +
-				"}");
+				"}}");
 		Dispersion dispersion = new Dispersion(jo);
 
 		List<DefaultHashable> results = consistentHasher.selectHashables(hashables, dispersion, "some-string");
 		assertThat(results.size(), equalTo(2));
 		assertThat(results.get(0), anyOf(equalTo(hashable1), equalTo(hashable2), equalTo(hashable3)));
 		assertThat(results.get(1), anyOf(equalTo(hashable1), equalTo(hashable2), equalTo(hashable3)));
+		List<DefaultHashable> results2 = consistentHasher.selectHashables(hashables, dispersion, "some-string");
+		assert(results.containsAll(results2));
 
-		assertThat(consistentHasher.selectHashables(hashables, dispersion, "some-string"), equalTo(results));
-		JSONObject jo2 = new JSONObject("dispersion: {\n" +
+		JSONObject jo2 = new JSONObject("{dispersion: {\n" +
 				"limit: 2000000000,\n" +
 				"shuffled: \"true\"\n" +
-				"}");
+				"}}");
 		Dispersion disp2 = new Dispersion(jo2);
-		assertThat(consistentHasher.selectHashables(hashables, disp2, "some-string"), equalTo(hashables));
+		List <DefaultHashable> res3 = consistentHasher.selectHashables(hashables, disp2, "some-string");
+		assert(res3.containsAll(hashables));
+
 	}
+
 
 	@Test
 	public void itemsMigrateFromSmallerToLargerBucket() {

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/hashing/ConsistentHasherTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/hashing/ConsistentHasherTest.java
@@ -1,10 +1,12 @@
 package com.comcast.cdn.traffic_control.traffic_router.core.hashing;
 
+import com.comcast.cdn.traffic_control.traffic_router.core.ds.Dispersion;
 import com.comcast.cdn.traffic_control.traffic_router.core.hash.ConsistentHasher;
 import com.comcast.cdn.traffic_control.traffic_router.core.hash.DefaultHashable;
 import com.comcast.cdn.traffic_control.traffic_router.core.hash.Hashable;
 import com.comcast.cdn.traffic_control.traffic_router.core.hash.MD5HashFunction;
 import com.comcast.cdn.traffic_control.traffic_router.core.hash.NumberSearcher;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -59,21 +61,32 @@ public class ConsistentHasherTest {
 
 	@Test
 	public void itHashes() throws Exception {
-		DefaultHashable hashable = consistentHasher.selectHashable(hashables, "some-string", false);
+		DefaultHashable hashable = consistentHasher.selectHashable(hashables, new Dispersion(new JSONObject()), "some-string");
 		assertThat(hashable, anyOf(equalTo(hashable1), equalTo(hashable2), equalTo(hashable3)));
-		DefaultHashable nextHashable = consistentHasher.selectHashable(hashables, "some-string", false);
+		DefaultHashable nextHashable = consistentHasher.selectHashable(hashables, new Dispersion(new JSONObject()),"some-string");
 		assertThat(nextHashable, equalTo(hashable));
 	}
 
 	@Test
 	public void itHashesMoreThanOne() throws Exception {
-		List<DefaultHashable> results = consistentHasher.selectHashables(hashables, 2, "some-string", false);
+		JSONObject jo = new JSONObject("dispersion: {\n" +
+				"limit: 2,\n" +
+				"shuffled: \"true\"\n" +
+				"}");
+		Dispersion dispersion = new Dispersion(jo);
+
+		List<DefaultHashable> results = consistentHasher.selectHashables(hashables, dispersion, "some-string");
 		assertThat(results.size(), equalTo(2));
 		assertThat(results.get(0), anyOf(equalTo(hashable1), equalTo(hashable2), equalTo(hashable3)));
 		assertThat(results.get(1), anyOf(equalTo(hashable1), equalTo(hashable2), equalTo(hashable3)));
 
-		assertThat(consistentHasher.selectHashables(hashables, 2, "some-string", false), equalTo(results));
-		assertThat(consistentHasher.selectHashables(hashables, 2000000000, "some-string", true), equalTo(hashables));
+		assertThat(consistentHasher.selectHashables(hashables, dispersion, "some-string"), equalTo(results));
+		JSONObject jo2 = new JSONObject("dispersion: {\n" +
+				"limit: 2000000000,\n" +
+				"shuffled: \"true\"\n" +
+				"}");
+		Dispersion disp2 = new Dispersion(jo2);
+		assertThat(consistentHasher.selectHashables(hashables, disp2, "some-string"), equalTo(hashables));
 	}
 
 	@Test
@@ -96,7 +109,7 @@ public class ConsistentHasherTest {
 		hashedPaths.put(largerBucket, new ArrayList<String>());
 
 		for (String randomPath : randomPaths) {
-			Hashable hashable = consistentHasher.selectHashable(buckets, randomPath, false);
+			Hashable hashable = consistentHasher.selectHashable(buckets, new Dispersion(new JSONObject()), randomPath);
 			hashedPaths.get(hashable).add(randomPath);
 		}
 
@@ -112,7 +125,7 @@ public class ConsistentHasherTest {
 		rehashedPaths.put(shrunkBucket, new ArrayList<String>());
 
 		for (String randomPath : randomPaths) {
-			Hashable hashable = consistentHasher.selectHashable(changedBuckets, randomPath, false);
+			Hashable hashable = consistentHasher.selectHashable(changedBuckets, new Dispersion(new JSONObject()), randomPath);
 			rehashedPaths.get(hashable).add(randomPath);
 		}
 

--- a/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouterTest.java
+++ b/traffic_router/core/src/test/java/com/comcast/cdn/traffic_control/traffic_router/core/router/TrafficRouterTest.java
@@ -148,8 +148,6 @@ public class TrafficRouterTest {
         when(trafficRouter.getCacheRegister()).thenReturn(cacheRegister);
         when(trafficRouter.orderCacheLocations(any(List.class), any(Geolocation.class))).thenCallRealMethod();
 
-        when(consistentHasher.selectHashable(any(List.class),any(Dispersion.class),anyString())).thenReturn(cache);
-
         HTTPRouteResult httpRouteResult = trafficRouter.route(httpRequest, track);
 
         assertThat(httpRouteResult.getUrl().toString(), equalTo("http://atscache.kabletown.net/index.html"));


### PR DESCRIPTION
Traffic Router now correctly performs consistent hashing or dispersion. 

This fixes #1767 in master, will need to be cherry picked to 1.6.0.