### PR TITLE
Update dependencies upon delivery service protocol 'http to https'

### DIFF
--- a/traffic_ops/app/lib/UI/ConfigFiles.pm
+++ b/traffic_ops/app/lib/UI/ConfigFiles.pm
@@ -254,7 +254,7 @@ sub ds_data {
 				if ( $protocol == 0 ) {
 					$dsinfo->{dslist}->[$j]->{"remap_line"}->{$map_from} = $map_to;
 				}
-				elsif ( $protocol == 1 ) {
+				elsif ( $protocol == 1 || $protocol == 3) {
 					$map_from = "https://" . $host_re . "/";
 					$dsinfo->{dslist}->[$j]->{"remap_line"}->{$map_from} = $map_to;
 				}

--- a/traffic_ops/app/lib/UI/DeliveryService.pm
+++ b/traffic_ops/app/lib/UI/DeliveryService.pm
@@ -99,7 +99,7 @@ sub get_example_urls {
 	elsif ( $protocol eq '1' ) {
 		$scheme = 'https';
 	}
-	elsif ( $protocol eq '2' ) {
+	elsif ( $protocol eq '2' || $protocol eq '3' ) {
 		$scheme  = 'http';
 		$scheme2 = 'https';
 	}


### PR DESCRIPTION
I searched for 'protocol' on the project and these seemed to be the obvious items left out that depend on adding the http to https option for delivery service 'protocol'
