### PR TITLE
Traffic Ops no longer submits queue update requests over and over

### DIFF
--- a/traffic_ops/app/lib/UI/Server.pm
+++ b/traffic_ops/app/lib/UI/Server.pm
@@ -1031,7 +1031,7 @@ sub postupdatequeue {
 		}
 	}
 
-	return;
+	$self->redirect_to('/tools/queue_updates');
 }
 
 1;


### PR DESCRIPTION
The issue was that the UI was not receiving a response from the controller so the UI kept submitting the request over and over again.  Adding a re-direct solves this issue.

This fixes #1570
