### PR TITLE
Change TM2 name strings to types

### DIFF
--- a/traffic_monitor/experimental/traffic_monitor/deliveryservice/stat.go
+++ b/traffic_monitor/experimental/traffic_monitor/deliveryservice/stat.go
@@ -32,17 +32,17 @@ func NewStats() Stats {
 	return Stats{DeliveryService: map[enum.DeliveryServiceName]dsdata.Stat{}}
 }
 
-func setStaticData(dsStats Stats, dsServers map[string][]string) Stats {
+func setStaticData(dsStats Stats, dsServers map[enum.DeliveryServiceName][]enum.CacheName) Stats {
 	for ds, stat := range dsStats.DeliveryService {
-		stat.Common.CachesConfigured.Value = int64(len(dsServers[string(ds)]))
+		stat.Common.CachesConfigured.Value = int64(len(dsServers[ds]))
 		dsStats.DeliveryService[ds] = stat // TODO consider changing dsStats.DeliveryService[ds] to a pointer so this kind of thing isn't necessary; possibly more performant, as well
 	}
 	return dsStats
 }
 
-func addAvailableData(dsStats Stats, crStates peer.Crstates, serverCachegroups map[enum.CacheName]enum.CacheGroupName, serverDs map[string][]string, serverTypes map[enum.CacheName]enum.CacheType, statHistory map[enum.CacheName][]cache.Result) (Stats, error) {
+func addAvailableData(dsStats Stats, crStates peer.Crstates, serverCachegroups map[enum.CacheName]enum.CacheGroupName, serverDs map[enum.CacheName][]enum.DeliveryServiceName, serverTypes map[enum.CacheName]enum.CacheType, statHistory map[enum.CacheName][]cache.Result) (Stats, error) {
 	for cache, available := range crStates.Caches {
-		cacheGroup, ok := serverCachegroups[enum.CacheName(cache)]
+		cacheGroup, ok := serverCachegroups[cache]
 		if !ok {
 			log.Warnf("CreateStats not adding availability data for '%s': not found in Cachegroups\n", cache)
 			continue

--- a/traffic_monitor/experimental/traffic_monitor/health/cache_health.go
+++ b/traffic_monitor/experimental/traffic_monitor/health/cache_health.go
@@ -88,14 +88,14 @@ func GetVitals(newResult *cache.Result, prevResult *cache.Result, mc *traffic_op
 	// inf.speed -- value looks like "10000" (without the quotes) so it is in Mbps.
 	// TODO JvD: Should we really be running this code every second for every cache polled????? I don't think so.
 	interfaceBandwidth := newResult.Astats.System.InfSpeed
-	newResult.Vitals.MaxKbpsOut = int64(interfaceBandwidth)*1000 - mc.Profile[mc.TrafficServer[newResult.Id].Profile].Parameters.MinFreeKbps
+	newResult.Vitals.MaxKbpsOut = int64(interfaceBandwidth)*1000 - mc.Profile[mc.TrafficServer[string(newResult.Id)].Profile].Parameters.MinFreeKbps
 
 	// log.Infoln(newResult.Id, "BytesOut", newResult.Vitals.BytesOut, "BytesIn", newResult.Vitals.BytesIn, "Kbps", newResult.Vitals.KbpsOut, "max", newResult.Vitals.MaxKbpsOut)
 }
 
 // EvalCache returns whether the given cache should be marked available, and a string describing why
 func EvalCache(result cache.Result, mc *traffic_ops.TrafficMonitorConfigMap) (bool, string) {
-	status := mc.TrafficServer[result.Id].Status
+	status := mc.TrafficServer[string(result.Id)].Status
 	switch {
 	case status == "ADMIN_DOWN":
 		return false, "set to ADMIN_DOWN"
@@ -103,8 +103,8 @@ func EvalCache(result cache.Result, mc *traffic_ops.TrafficMonitorConfigMap) (bo
 		return false, "set to OFFLINE"
 	case status == "ONLINE":
 		return true, "set to ONLINE"
-	case result.Vitals.LoadAvg > mc.Profile[mc.TrafficServer[result.Id].Profile].Parameters.HealthThresholdLoadAvg:
-		return false, fmt.Sprintf("load average %f exceeds threshold %f", result.Vitals.LoadAvg, mc.Profile[mc.TrafficServer[result.Id].Profile].Parameters.HealthThresholdLoadAvg)
+	case result.Vitals.LoadAvg > mc.Profile[mc.TrafficServer[string(result.Id)].Profile].Parameters.HealthThresholdLoadAvg:
+		return false, fmt.Sprintf("load average %f exceeds threshold %f", result.Vitals.LoadAvg, mc.Profile[mc.TrafficServer[string(result.Id)].Profile].Parameters.HealthThresholdLoadAvg)
 	case result.Vitals.MaxKbpsOut < result.Vitals.KbpsOut:
 		return false, fmt.Sprintf("%dkbps exceeds max %dkbps", result.Vitals.KbpsOut, result.Vitals.MaxKbpsOut)
 	default:

--- a/traffic_monitor/experimental/traffic_monitor/manager/datarequest.go
+++ b/traffic_monitor/experimental/traffic_monitor/manager/datarequest.go
@@ -168,7 +168,7 @@ func dataRequestManagerListen(dr <-chan http_server.DataRequest, opsConfig OpsCo
 	}
 }
 
-func createCacheStatuses(cacheTypes map[enum.CacheName]enum.CacheType, statHistory map[enum.CacheName][]cache.Result, lastHealthDurations map[enum.CacheName]time.Duration, cacheStates map[string]peer.IsAvailable, lastKbpsStats ds.StatsLastKbps, localCacheStatusThreadsafe CacheAvailableStatusThreadsafe) map[enum.CacheName]CacheStatus {
+func createCacheStatuses(cacheTypes map[enum.CacheName]enum.CacheType, statHistory map[enum.CacheName][]cache.Result, lastHealthDurations map[enum.CacheName]time.Duration, cacheStates map[enum.CacheName]peer.IsAvailable, lastKbpsStats ds.StatsLastKbps, localCacheStatusThreadsafe CacheAvailableStatusThreadsafe) map[enum.CacheName]CacheStatus {
 	conns := createCacheConnections(statHistory)
 	statii := map[enum.CacheName]CacheStatus{}
 	localCacheStatus := localCacheStatusThreadsafe.Get()
@@ -269,7 +269,7 @@ func createCacheConnections(statHistory map[enum.CacheName][]cache.Result) map[e
 	return conns
 }
 
-func cacheDownCount(caches map[string]peer.IsAvailable) int {
+func cacheDownCount(caches map[enum.CacheName]peer.IsAvailable) int {
 	count := 0
 	for _, available := range caches {
 		if !available.IsAvailable {
@@ -279,11 +279,11 @@ func cacheDownCount(caches map[string]peer.IsAvailable) int {
 	return count
 }
 
-func cacheAvailableCount(caches map[string]peer.IsAvailable) int {
+func cacheAvailableCount(caches map[enum.CacheName]peer.IsAvailable) int {
 	return len(caches) - cacheDownCount(caches)
 }
 
-func createApiPeerStates(peerStates map[string]peer.Crstates) ApiPeerStates {
+func createApiPeerStates(peerStates map[enum.TrafficMonitorName]peer.Crstates) ApiPeerStates {
 	apiPeerStates := ApiPeerStates{Peers: map[enum.TrafficMonitorName]map[enum.CacheName][]CacheState{}}
 
 	for peer, state := range peerStates {

--- a/traffic_monitor/experimental/traffic_monitor/manager/events.go
+++ b/traffic_monitor/experimental/traffic_monitor/manager/events.go
@@ -2,16 +2,18 @@ package manager
 
 import (
 	"sync"
+
+	"github.com/Comcast/traffic_control/traffic_monitor/experimental/traffic_monitor/enum"
 )
 
 type Event struct {
-	Index       uint64 `json:"index"`
-	Time        int64  `json:"time"`
-	Description string `json:"description"`
-	Name        string `json:"name"`
-	Hostname    string `json:"hostname"`
-	Type        string `json:"type"`
-	Available   bool   `json:"isAvailable"`
+	Index       uint64         `json:"index"`
+	Time        int64          `json:"time"`
+	Description string         `json:"description"`
+	Name        enum.CacheName `json:"name"`
+	Hostname    enum.CacheName `json:"hostname"`
+	Type        string         `json:"type"`
+	Available   bool           `json:"isAvailable"`
 }
 
 const maxEvents = 200 // TODO make config?

--- a/traffic_monitor/experimental/traffic_monitor/peer/peer.go
+++ b/traffic_monitor/experimental/traffic_monitor/peer/peer.go
@@ -3,6 +3,8 @@ package peer
 import (
 	"encoding/json"
 	"io"
+
+	"github.com/Comcast/traffic_control/traffic_monitor/experimental/traffic_monitor/enum"
 )
 
 type Handler struct {
@@ -15,7 +17,7 @@ func NewHandler() Handler {
 }
 
 type Result struct {
-	Id           string
+	Id           enum.TrafficMonitorName
 	Available    bool
 	Errors       []error
 	PeerStats    Crstates
@@ -31,7 +33,7 @@ const (
 
 func (handler Handler) Handle(id string, r io.Reader, err error, pollId uint64, pollFinished chan<- uint64) {
 	result := Result{
-		Id:           id,
+		Id:           enum.TrafficMonitorName(id),
 		Available:    false,
 		Errors:       []error{},
 		PollID:       pollId,

--- a/traffic_monitor/experimental/traffic_monitor/trafficopsdata/trafficopsdata.go
+++ b/traffic_monitor/experimental/traffic_monitor/trafficopsdata/trafficopsdata.go
@@ -1,7 +1,5 @@
 package trafficopsdata
 
-// TODO move to its own package?
-
 import (
 	"encoding/json"
 	"fmt"
@@ -48,20 +46,20 @@ func NewRegexes() Regexes {
 }
 
 type TOData struct {
-	DeliveryServiceServers map[string][]string
-	ServerDeliveryServices map[string][]string
+	DeliveryServiceServers map[enum.DeliveryServiceName][]enum.CacheName
+	ServerDeliveryServices map[enum.CacheName][]enum.DeliveryServiceName
 	ServerTypes            map[enum.CacheName]enum.CacheType
-	DeliveryServiceTypes   map[string]enum.DSType
+	DeliveryServiceTypes   map[enum.DeliveryServiceName]enum.DSType
 	DeliveryServiceRegexes Regexes
 	ServerCachegroups      map[enum.CacheName]enum.CacheGroupName
 }
 
 func New() *TOData {
 	return &TOData{
-		DeliveryServiceServers: map[string][]string{},
-		ServerDeliveryServices: map[string][]string{},
+		DeliveryServiceServers: map[enum.DeliveryServiceName][]enum.CacheName{},
+		ServerDeliveryServices: map[enum.CacheName][]enum.DeliveryServiceName{},
 		ServerTypes:            map[enum.CacheName]enum.CacheType{},
-		DeliveryServiceTypes:   map[string]enum.DSType{},
+		DeliveryServiceTypes:   map[enum.DeliveryServiceName]enum.DSType{},
 		DeliveryServiceRegexes: NewRegexes(),
 		ServerCachegroups:      map[enum.CacheName]enum.CacheGroupName{},
 	}
@@ -94,13 +92,14 @@ func (d TODataThreadsafe) set(newTOData TOData) {
 }
 
 // CRConfig is the CrConfig data needed by TOData. Note this is not all data in the CRConfig.
+// TODO change strings to type?
 type CRConfig struct {
-	ContentServers map[string]struct {
-		DeliveryServices map[string][]string `json:"deliveryServices"`
-		CacheGroup       string              `json:"cacheGroup"`
-		Type             string              `json:"type"`
+	ContentServers map[enum.CacheName]struct {
+		DeliveryServices map[enum.DeliveryServiceName][]string `json:"deliveryServices"`
+		CacheGroup       string                                `json:"cacheGroup"`
+		Type             string                                `json:"type"`
 	} `json:"contentServers"`
-	DeliveryServices map[string]struct {
+	DeliveryServices map[enum.DeliveryServiceName]struct {
 		Matchsets []struct {
 			Protocol  string `json:"protocol"`
 			MatchList []struct {
@@ -155,10 +154,9 @@ func (d TODataThreadsafe) Fetch(to towrap.ITrafficOpsSession, cdn string) error 
 }
 
 // getDeliveryServiceServers gets the servers on each delivery services, for the given CDN, from Traffic Ops.
-// Returns a map[deliveryService][]server, and a map[server]deliveryService
-func getDeliveryServiceServers(crc CRConfig) (map[string][]string, map[string][]string, error) {
-	dsServers := map[string][]string{}
-	serverDses := map[string][]string{}
+func getDeliveryServiceServers(crc CRConfig) (map[enum.DeliveryServiceName][]enum.CacheName, map[enum.CacheName][]enum.DeliveryServiceName, error) {
+	dsServers := map[enum.DeliveryServiceName][]enum.CacheName{}
+	serverDses := map[enum.CacheName][]enum.DeliveryServiceName{}
 
 	for serverName, serverData := range crc.ContentServers {
 		for deliveryServiceName, _ := range serverData.DeliveryServices {
@@ -172,7 +170,7 @@ func getDeliveryServiceServers(crc CRConfig) (map[string][]string, map[string][]
 // getDeliveryServiceRegexes gets the regexes of each delivery service, for the given CDN, from Traffic Ops.
 // Returns a map[deliveryService][]regex.
 func getDeliveryServiceRegexes(crc CRConfig) (Regexes, error) {
-	dsRegexes := map[string][]string{}
+	dsRegexes := map[enum.DeliveryServiceName][]string{}
 
 	for dsName, dsData := range crc.DeliveryServices {
 		if len(dsData.Matchsets) < 1 {
@@ -190,15 +188,14 @@ func getDeliveryServiceRegexes(crc CRConfig) (Regexes, error) {
 }
 
 // TODO precompute, move to TOData; call when we get new delivery services, instead of every time we create new stats
-func createRegexes(dsToRegex map[string][]string) (Regexes, error) {
+func createRegexes(dsToRegex map[enum.DeliveryServiceName][]string) (Regexes, error) {
 	dsRegexes := Regexes{
 		DirectMatches:                      map[string]enum.DeliveryServiceName{},
 		DotStartSlashDotFooSlashDotDotStar: map[string]enum.DeliveryServiceName{},
 		RegexMatch:                         map[*regexp.Regexp]enum.DeliveryServiceName{},
 	}
 
-	for dsStr, regexStrs := range dsToRegex {
-		ds := enum.DeliveryServiceName(dsStr)
+	for ds, regexStrs := range dsToRegex {
 		for _, regexStr := range regexStrs {
 			prefix := `.*\.`
 			suffix := `\..*`
@@ -234,7 +231,7 @@ func getServerCachegroups(crc CRConfig) (map[enum.CacheName]enum.CacheGroupName,
 	serverCachegroups := map[enum.CacheName]enum.CacheGroupName{}
 
 	for server, serverData := range crc.ContentServers {
-		serverCachegroups[enum.CacheName(server)] = enum.CacheGroupName(serverData.CacheGroup)
+		serverCachegroups[server] = enum.CacheGroupName(serverData.CacheGroup)
 	}
 	return serverCachegroups, nil
 }
@@ -248,13 +245,13 @@ func getServerTypes(crc CRConfig) (map[enum.CacheName]enum.CacheType, error) {
 		if t == enum.CacheTypeInvalid {
 			return nil, fmt.Errorf("getServerTypes CRConfig unknown type for '%s': '%s'", server, serverData.Type)
 		}
-		serverTypes[enum.CacheName(server)] = t
+		serverTypes[server] = t
 	}
 	return serverTypes, nil
 }
 
-func getDeliveryServiceTypes(crc CRConfig) (map[string]enum.DSType, error) {
-	dsTypes := map[string]enum.DSType{}
+func getDeliveryServiceTypes(crc CRConfig) (map[enum.DeliveryServiceName]enum.DSType, error) {
+	dsTypes := map[enum.DeliveryServiceName]enum.DSType{}
 
 	for dsName, dsData := range crc.DeliveryServices {
 		if len(dsData.Matchsets) < 1 {


### PR DESCRIPTION
Changes strings which refer to names to be the proper type, e.g.
CacheName, DeliveryServiceName. (This aids readability, knowing what
a string is; its biggest benefit is in maps, e.g. `map[CacheName]int`
instead of `map[string]int`.)

Fixes #1853