### PR TITLE
Fix Traffic Monitor 2.0 Bandwidth Capacity, Add GUI Bandwidth Commas

### DIFF
--- a/traffic_monitor/experimental/traffic_monitor/cache/cache.go
+++ b/traffic_monitor/experimental/traffic_monitor/cache/cache.go
@@ -38,7 +38,7 @@ func (h Handler) Precompute() bool {
 type PrecomputedData struct {
 	DeliveryServiceStats map[enum.DeliveryServiceName]dsdata.Stat
 	OutBytes             int64
-	MaxBytes             int64
+	MaxKbps              int64
 	Errors               []error
 	Reporting            bool
 }
@@ -207,7 +207,8 @@ func (handler Handler) precompute(result Result) Result {
 		log.Errorf("addkbps %s handle precomputing outbytes '%v'\n", result.Id, err)
 	}
 
-	result.PrecomputedData.MaxBytes = int64(result.Astats.System.InfSpeed)
+	kbpsInMbps := int64(1000)
+	result.PrecomputedData.MaxKbps = int64(result.Astats.System.InfSpeed) * kbpsInMbps
 
 	for stat, value := range result.Astats.Ats {
 		var err error

--- a/traffic_monitor/experimental/traffic_monitor/http_server/http_server.go
+++ b/traffic_monitor/experimental/traffic_monitor/http_server/http_server.go
@@ -31,23 +31,23 @@ func (s Server) endpoints() (map[string]http.HandlerFunc, error) {
 
 	// note: with the trailing slash, any non-trailing slash requests will get a 301 redirect
 	return map[string]http.HandlerFunc{
-		"/publish/CacheStats/":       s.dataRequestFunc(CacheStats),
-		"/publish/CrConfig":          s.dataRequestFunc(TRConfig),
-		"/publish/CrStates":          s.handleCrStatesFunc(),
-		"/publish/DsStats":           s.dataRequestFunc(DSStats),
-		"/publish/EventLog":          s.dataRequestFunc(EventLog),
-		"/publish/PeerStates":        s.dataRequestFunc(PeerStates),
-		"/publish/StatSummary":       s.dataRequestFunc(StatSummary),
-		"/publish/Stats":             s.dataRequestFunc(Stats),
-		"/publish/ConfigDoc":         s.dataRequestFunc(ConfigDoc),
-		"/api/cache-count":           s.dataRequestFunc(APICacheCount),
-		"/api/cache-available-count": s.dataRequestFunc(APICacheAvailableCount),
-		"/api/cache-down-count":      s.dataRequestFunc(APICacheDownCount),
-		"/api/version":               s.dataRequestFunc(APIVersion),
-		"/api/traffic-ops-uri":       s.dataRequestFunc(APITrafficOpsURI),
-		"/api/cache-statuses":        s.dataRequestFunc(APICacheStates),
-		"/api/bandwidth-kbps":        s.dataRequestFunc(APIBandwidthKbps),
-		"/api/bandwidth-capacity":    s.dataRequestFunc(APIBandwidthCapacity),
+		"/publish/CacheStats/":         s.dataRequestFunc(CacheStats),
+		"/publish/CrConfig":            s.dataRequestFunc(TRConfig),
+		"/publish/CrStates":            s.handleCrStatesFunc(),
+		"/publish/DsStats":             s.dataRequestFunc(DSStats),
+		"/publish/EventLog":            s.dataRequestFunc(EventLog),
+		"/publish/PeerStates":          s.dataRequestFunc(PeerStates),
+		"/publish/StatSummary":         s.dataRequestFunc(StatSummary),
+		"/publish/Stats":               s.dataRequestFunc(Stats),
+		"/publish/ConfigDoc":           s.dataRequestFunc(ConfigDoc),
+		"/api/cache-count":             s.dataRequestFunc(APICacheCount),
+		"/api/cache-available-count":   s.dataRequestFunc(APICacheAvailableCount),
+		"/api/cache-down-count":        s.dataRequestFunc(APICacheDownCount),
+		"/api/version":                 s.dataRequestFunc(APIVersion),
+		"/api/traffic-ops-uri":         s.dataRequestFunc(APITrafficOpsURI),
+		"/api/cache-statuses":          s.dataRequestFunc(APICacheStates),
+		"/api/bandwidth-kbps":          s.dataRequestFunc(APIBandwidthKbps),
+		"/api/bandwidth-capacity-kbps": s.dataRequestFunc(APIBandwidthCapacityKbps),
 		"/":             handleRoot,
 		"/sorttable.js": handleSortableJs,
 	}, nil
@@ -134,7 +134,7 @@ const (
 	APITrafficOpsURI
 	APICacheStates
 	APIBandwidthKbps
-	APIBandwidthCapacity
+	APIBandwidthCapacityKbps
 )
 
 type Format int

--- a/traffic_monitor/experimental/traffic_monitor/index.html
+++ b/traffic_monitor/experimental/traffic_monitor/index.html
@@ -161,6 +161,9 @@
 		 function getBandwidth() {
 			 ajax("/api/bandwidth-kbps", function(r) {
 				 document.getElementById("bandwidth").innerHTML = parseFloat(r).toFixed(2);
+				 ajax("/api/bandwidth-capacity-kbps", function(r) {
+					 document.getElementById("bandwidth-capacity").innerHTML = parseInt(r);
+				 });
 			 });
 		 }
 
@@ -437,7 +440,7 @@
 				<li class="endpoint"><a href="/api/traffic-ops-uri">/api/traffic-ops-uri</a></li>
 				<li class="endpoint"><a href="/api/cache-statuses">/api/cache-statuses</a></li>
 				<li class="endpoint"><a href="/api/bandwidth-kbps">/api/bandwidth-kbps</a></li>
-				<li class="endpoint"><a href="/api/bandwidth-capacity">/api/bandwidth-capacity</a></li>
+				<li class="endpoint"><a href="/api/bandwidth-capacity-kbps">/api/bandwidth-capacity-kbps</a></li>
 			</ul>
 		</div>
 

--- a/traffic_monitor/experimental/traffic_monitor/index.html
+++ b/traffic_monitor/experimental/traffic_monitor/index.html
@@ -125,6 +125,11 @@
 			 setInterval(getDsStats, 4003);
 		 }
 
+		 // source: http://stackoverflow.com/a/2901298/292623
+		 function numberStrWithCommas(x) {
+			 return x.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+		 }
+
 		 function openTab(tabName) {
 			 var i, x, tablinks;
 			 x = document.getElementsByClassName("tabcontent");
@@ -160,10 +165,13 @@
 
 		 function getBandwidth() {
 			 ajax("/api/bandwidth-kbps", function(r) {
-				 document.getElementById("bandwidth").innerHTML = parseFloat(r).toFixed(2);
-				 ajax("/api/bandwidth-capacity-kbps", function(r) {
-					 document.getElementById("bandwidth-capacity").innerHTML = parseInt(r);
-				 });
+				 document.getElementById("bandwidth").innerHTML = numberStrWithCommas(parseFloat(r).toFixed(2));
+			 });
+		 }
+
+		 function getBandwidthCapacity() {
+			 ajax("/api/bandwidth-capacity-kbps", function(r) {
+				 document.getElementById("bandwidth-capacity").innerHTML = numberStrWithCommas(parseInt(r).toString());
 			 });
 		 }
 

--- a/traffic_monitor/experimental/traffic_monitor/manager/datarequest.go
+++ b/traffic_monitor/experimental/traffic_monitor/manager/datarequest.go
@@ -154,14 +154,14 @@ func dataRequestManagerListen(dr <-chan http_server.DataRequest, opsConfig OpsCo
 					sum += data.Kbps
 				}
 				body = []byte(fmt.Sprintf("%f", sum))
-			case http_server.APIBandwidthCapacity:
+			case http_server.APIBandwidthCapacityKbps:
 				statHistory := statHistory.Get()
 				cap := int64(0)
 				for _, results := range statHistory {
 					if len(results) == 0 {
 						continue
 					}
-					cap += results[0].MaxBytes
+					cap += results[0].MaxKbps
 				}
 				body = []byte(fmt.Sprintf("%d", cap))
 			default:


### PR DESCRIPTION
Fixes TM2 bandwidth capacity to expect mbps from ATS and return kbps.

Adds commas to the GUI bandwidth numbers.