### PR TITLE
Change TO client to not log

### DIFF
--- a/traffic_monitor/experimental/traffic_monitor/trafficopswrapper/trafficopswrapper.go
+++ b/traffic_monitor/experimental/traffic_monitor/trafficopswrapper/trafficopswrapper.go
@@ -27,7 +27,7 @@ func (s TrafficOpsSessionThreadsafe) CRConfigRaw(cdn string) ([]byte, error) {
 	if s.session == nil || *s.session == nil {
 		return nil, fmt.Errorf("nil session")
 	}
-	b, e := (*s.session).CRConfigRaw(cdn)
+	b, _, e := (*s.session).GetCRConfig(cdn)
 	s.m.Unlock()
 	return b, e
 }

--- a/traffic_ops/client/crconfig.go
+++ b/traffic_ops/client/crconfig.go
@@ -18,12 +18,14 @@ package client
 
 import "fmt"
 
-// CRConfigRaw ...
+// CRConfigRaw Deprecated: use GetCRConfig instead
 func (to *Session) CRConfigRaw(cdn string) ([]byte, error) {
+	bytes, _, err := to.GetCRConfig(cdn)
+	return bytes, err
+}
+
+// GetCRConfig returns the raw JSON bytes of the CRConfig from Traffic Ops, and whether the bytes were from the client's internal cache.
+func (to *Session) GetCRConfig(cdn string) ([]byte, CacheHitStatus, error) {
 	url := fmt.Sprintf("/CRConfig-Snapshots/%s/CRConfig.json", cdn)
-	body, err := to.getBytesWithTTL(url, tmPollingInterval)
-	if err != nil {
-		return nil, err
-	}
-	return body, nil
+	return to.getBytesWithTTL(url, tmPollingInterval)
 }

--- a/traffic_ops/client/traffic_router_config.go
+++ b/traffic_ops/client/traffic_router_config.go
@@ -161,30 +161,42 @@ type SOA struct {
 	Expire  int    `json:"expire"`
 }
 
-// TrafficRouterConfigMap gets a bunch of maps
+// TrafficRouterConfigMap Deprecated: use GetTrafficRouterConfigMap instead.
 func (to *Session) TrafficRouterConfigMap(cdn string) (*TrafficRouterConfigMap, error) {
-	trConfig, err := to.TrafficRouterConfig(cdn)
+	cfg, _, err := to.GetTrafficRouterConfigMap(cdn)
+	return cfg, err
+}
+
+// TrafficRouterConfigMap gets a bunch of maps
+func (to *Session) GetTrafficRouterConfigMap(cdn string) (*TrafficRouterConfigMap, CacheHitStatus, error) {
+	trConfig, cacheHitStatus, err := to.GetTrafficRouterConfig(cdn)
 	if err != nil {
-		return nil, err
+		return nil, CacheHitStatusInvalid, err
 	}
 
 	trConfigMap := TRTransformToMap(*trConfig)
-	return &trConfigMap, nil
+	return &trConfigMap, cacheHitStatus, nil
 }
 
-// TrafficRouterConfig gets the json arrays
+// TrafficRouterConfig Deprecated: use GetTrafficRouterConfig instead.
 func (to *Session) TrafficRouterConfig(cdn string) (*TrafficRouterConfig, error) {
+	cfg, _, err := to.GetTrafficRouterConfig(cdn)
+	return cfg, err
+}
+
+// GetTrafficRouterConfig gets the json arrays
+func (to *Session) GetTrafficRouterConfig(cdn string) (*TrafficRouterConfig, CacheHitStatus, error) {
 	url := fmt.Sprintf("/api/1.2/cdns/%s/configs/routing.json", cdn)
-	body, err := to.getBytesWithTTL(url, tmPollingInterval)
+	body, cacheHitStatus, err := to.getBytesWithTTL(url, tmPollingInterval)
 	if err != nil {
-		return nil, err
+		return nil, CacheHitStatusInvalid, err
 	}
 
 	var data TRConfigResponse
 	if err := json.Unmarshal(body, &data); err != nil {
-		return nil, err
+		return nil, CacheHitStatusInvalid, err
 	}
-	return &data.Response, nil
+	return &data.Response, cacheHitStatus, nil
 }
 
 // TRTransformToMap ...


### PR DESCRIPTION
Changes the Traffic Ops Client to not log, and to return all formerly
logged information so users can decide whether to log, and in their
own format.

Fixes #1925