### PR TITLE
Traffic Stats now uses its config file for InfluxDb Connections

### DIFF
--- a/traffic_stats/build/build_rpm.sh
+++ b/traffic_stats/build/build_rpm.sh
@@ -39,7 +39,7 @@ function initBuildArea() {
 	cd "$TS_DIR" || \
 		 { echo "Could not cd to $TS_DIR: $?"; exit 1; }
 	rsync -av ./ "$ts_dest"/ || \
-		 { echo "Could not copy to $to_dest: $?"; exit 1; }
+		 { echo "Could not copy to $ts_dest: $?"; exit 1; }
 	cp "$TS_DIR"/build/*.spec "$RPMBUILD"/SPECS/. || \
 		 { echo "Could not copy spec files: $?"; exit 1; }
 

--- a/traffic_stats/build/traffic_stats.spec
+++ b/traffic_stats/build/traffic_stats.spec
@@ -67,7 +67,7 @@ oldpwd=$(pwd)
   cd "$godir" && \
   cp -r "$TC_DIR"/traffic_stats/* . && \
   go get -d -v && \
-  go_get_version "$oldpwd"/src/github.com/influxdata/influxdb v0.11.1 && \
+  go_get_version "$oldpwd"/src/github.com/influxdata/influxdb v1.0.1 && \
   go install -v \
 ) || { echo "Could not build go program at $(pwd): $!"; exit 1; }
 

--- a/traffic_stats/influxdb_tools/sync_ts_databases.go
+++ b/traffic_stats/influxdb_tools/sync_ts_databases.go
@@ -439,7 +439,7 @@ func getDeliveryServiceStats(res []influx.Result) map[string]deliveryServiceStat
 
 func getDailyStats(res []influx.Result) map[string]dailyStats {
 	response := make(map[string]dailyStats)
-	if res != nil && len(res[0].Series) > 0 {
+	if len(res) > 0 && len(res[0].Series) > 0 {
 		for _, row := range res[0].Series {
 			for _, record := range row.Values {
 				data := new(dailyStats)

--- a/traffic_stats/influxdb_tools/sync_ts_databases.go
+++ b/traffic_stats/influxdb_tools/sync_ts_databases.go
@@ -439,7 +439,7 @@ func getDeliveryServiceStats(res []influx.Result) map[string]deliveryServiceStat
 
 func getDailyStats(res []influx.Result) map[string]dailyStats {
 	response := make(map[string]dailyStats)
-	if len(res[0].Series) > 0 {
+	if res != nil && len(res[0].Series) > 0 {
 		for _, row := range res[0].Series {
 			for _, record := range row.Values {
 				data := new(dailyStats)

--- a/traffic_stats/traffic_stats.cfg
+++ b/traffic_stats/traffic_stats.cfg
@@ -13,6 +13,5 @@
 	"cacheRetentionPolicy": "daily",
 	"dsRetentionPolicy": "daily",
 	"dailySummaryRetentionPolicy": "indefinite",
-	"influxProtocol": "http",
 	"influxUrls": ["http://localhost:8086"]
 }

--- a/traffic_stats/traffic_stats.cfg
+++ b/traffic_stats/traffic_stats.cfg
@@ -13,6 +13,6 @@
 	"cacheRetentionPolicy": "daily",
 	"dsRetentionPolicy": "daily",
 	"dailySummaryRetentionPolicy": "indefinite",
-	"influxProtocol": "http"
+	"influxProtocol": "http",
 	"influxUrls": ["http://localhost:8086"]
 }

--- a/traffic_stats/traffic_stats.cfg
+++ b/traffic_stats/traffic_stats.cfg
@@ -14,4 +14,5 @@
 	"dsRetentionPolicy": "daily",
 	"dailySummaryRetentionPolicy": "indefinite",
 	"influxProtocol": "http"
+	"influxUrls": ["http://localhost:8086"]
 }


### PR DESCRIPTION
Traffic Stats now uses its config file to determine which influxdb urls to use.  This allows a user to run a single instance of influxdb, an enterprise clustered solution, or a HA solution using influxdb-relay (https://github.com/influxdata/influxdb-relay).  

This version of Traffic Stats requires Influxdb version 1.0.0 or greater.

This fixes #1668