### PR TITLE
Fix Traffic Monitor 2.0 DeliveryService Kbps

### DIFF
--- a/traffic_monitor/experimental/traffic_monitor/deliveryservice/stat.go
+++ b/traffic_monitor/experimental/traffic_monitor/deliveryservice/stat.go
@@ -216,6 +216,10 @@ func addKbps(statHistory map[enum.CacheName][]cache.Result, dsStats Stats, lastK
 		cacheTypes := map[enum.CacheType]LastKbpsData{}
 		total := LastKbpsData{}
 		for cacheName, cacheStats := range lastKbpsStat.Caches {
+			if !stat.CommonStats.CachesReporting[cacheName] {
+				continue
+			}
+
 			cacheGroup, ok := serverCachegroups[cacheName]
 			if !ok {
 				log.Errorf("addkbps cache %v not in cachegroups\n", cacheName)

--- a/traffic_monitor/experimental/traffic_monitor/deliveryservice/stat.go
+++ b/traffic_monitor/experimental/traffic_monitor/deliveryservice/stat.go
@@ -134,24 +134,37 @@ func (a StatsLastKbps) Copy() StatsLastKbps {
 
 // TODO figure a way to associate this type with StatHTTP, with which its members correspond.
 type StatLastKbps struct {
+	Caches      map[enum.CacheName]LastKbpsData
 	CacheGroups map[enum.CacheGroupName]LastKbpsData
 	Type        map[enum.CacheType]LastKbpsData
 	Total       LastKbpsData
 }
 
 func (a StatLastKbps) Copy() StatLastKbps {
-	b := StatLastKbps{CacheGroups: map[enum.CacheGroupName]LastKbpsData{}, Type: map[enum.CacheType]LastKbpsData{}, Total: a.Total}
+	b := StatLastKbps{
+		CacheGroups: map[enum.CacheGroupName]LastKbpsData{},
+		Type:        map[enum.CacheType]LastKbpsData{},
+		Caches:      map[enum.CacheName]LastKbpsData{},
+		Total:       a.Total,
+	}
 	for k, v := range a.CacheGroups {
 		b.CacheGroups[k] = v
 	}
 	for k, v := range a.Type {
 		b.Type[k] = v
 	}
+	for k, v := range a.Caches {
+		b.Caches[k] = v
+	}
 	return b
 }
 
 func newStatLastKbps() StatLastKbps {
-	return StatLastKbps{CacheGroups: map[enum.CacheGroupName]LastKbpsData{}, Type: map[enum.CacheType]LastKbpsData{}}
+	return StatLastKbps{
+		CacheGroups: map[enum.CacheGroupName]LastKbpsData{},
+		Type:        map[enum.CacheType]LastKbpsData{},
+		Caches:      map[enum.CacheName]LastKbpsData{},
+	}
 }
 
 type LastKbpsData struct {
@@ -170,76 +183,77 @@ const BytesPerKilobit = 125
 //
 // This specifically returns the given dsStats and lastKbpsStats on error, so it's safe to do persistentStats, persistentLastKbpsStats, err = addKbps(...)
 // TODO handle ATS byte rolling (when the `out_bytes` overflows back to 0)
-func addKbps(statHistory map[enum.CacheName][]cache.Result, dsStats Stats, lastKbpsStats StatsLastKbps, dsStatsTime time.Time) (Stats, StatsLastKbps, error) {
+// TODO break this function up, it's too big.
+func addKbps(statHistory map[enum.CacheName][]cache.Result, dsStats Stats, lastKbpsStats StatsLastKbps, dsStatsTime time.Time, serverCachegroups map[enum.CacheName]enum.CacheGroupName, serverTypes map[enum.CacheName]enum.CacheType) (Stats, StatsLastKbps, error) {
 	for dsName, stat := range dsStats.DeliveryService {
 		lastKbpsStat, lastKbpsStatExists := lastKbpsStats.DeliveryServices[dsName]
 		if !lastKbpsStatExists {
 			lastKbpsStat = newStatLastKbps()
 		}
 
-		for cgName, cacheStats := range stat.CacheGroups {
-			lastKbpsData, _ := lastKbpsStat.CacheGroups[cgName]
+		for cacheName, cacheStats := range stat.Caches {
+			lastCacheStat, lastCacheStatExists := lastKbpsStat.Caches[cacheName]
 
-			if cacheStats.OutBytes.Value == lastKbpsData.Bytes {
-				cacheStats.Kbps.Value = lastKbpsData.Kbps
-				stat.CacheGroups[cgName] = cacheStats
+			if cacheStats.OutBytes.Value == lastCacheStat.Bytes {
+				cacheStats.Kbps.Value = lastCacheStat.Kbps
+				stat.Caches[cacheName] = cacheStats
 				continue
 			}
 
-			if lastKbpsStatExists && lastKbpsData.Bytes != 0 {
-				cacheStats.Kbps.Value = float64(cacheStats.OutBytes.Value-lastKbpsData.Bytes) / BytesPerKilobit / dsStatsTime.Sub(lastKbpsData.Time).Seconds()
+			if lastCacheStatExists && lastCacheStat.Bytes != 0 {
+				lastCacheStat.Kbps = float64(cacheStats.OutBytes.Value-lastCacheStat.Bytes) / BytesPerKilobit / stat.CachesTimeReceived[cacheName].Sub(lastCacheStat.Time).Seconds()
 			}
+			lastCacheStat.Bytes = cacheStats.OutBytes.Value
+			lastCacheStat.Time = stat.CachesTimeReceived[cacheName]
+			lastKbpsStat.Caches[cacheName] = lastCacheStat
 
-			if cacheStats.Kbps.Value < 0 {
-				cacheStats.Kbps.Value = 0
-				log.Errorf("addkbps negative cachegroup cacheStats.Kbps.Value: '%v' '%v' %v - %v / %v\n", dsName, cgName, cacheStats.OutBytes.Value, lastKbpsData.Bytes, dsStatsTime.Sub(lastKbpsData.Time).Seconds())
-			}
-
-			lastKbpsStat.CacheGroups[cgName] = LastKbpsData{Time: dsStatsTime, Bytes: cacheStats.OutBytes.Value, Kbps: cacheStats.Kbps.Value}
-			stat.CacheGroups[cgName] = cacheStats
+			cacheStats.Kbps.Value = lastCacheStat.Kbps // TODO determine if necessary
+			stat.Caches[cacheName] = cacheStats
 		}
 
-		for cacheType, cacheStats := range stat.Types {
-			lastKbpsData, _ := lastKbpsStat.Type[cacheType]
-			if cacheStats.OutBytes.Value == lastKbpsData.Bytes {
-				if cacheStats.OutBytes.Value == lastKbpsData.Bytes {
-					if lastKbpsData.Kbps < 0 {
-						log.Errorf("addkbps negative cachetype cacheStats.Kbps.Value!\n")
-						lastKbpsData.Kbps = 0
-					}
-					cacheStats.Kbps.Value = lastKbpsData.Kbps
-					stat.Types[cacheType] = cacheStats
-					continue
-				}
-				if lastKbpsStatExists && lastKbpsData.Bytes != 0 {
-					cacheStats.Kbps.Value = float64(cacheStats.OutBytes.Value-lastKbpsData.Bytes) / BytesPerKilobit / dsStatsTime.Sub(lastKbpsData.Time).Seconds()
-				}
-				if cacheStats.Kbps.Value < 0 {
-					log.Errorf("addkbps negative cachetype cacheStats.Kbps.Value.\n")
-					cacheStats.Kbps.Value = 0
-				}
-				lastKbpsStat.Type[cacheType] = LastKbpsData{Time: dsStatsTime, Bytes: cacheStats.OutBytes.Value, Kbps: cacheStats.Kbps.Value}
-				stat.Types[cacheType] = cacheStats
+		// TODO don't add kbps for caches which didn't respond to their last request
+		cacheGroups := map[enum.CacheGroupName]LastKbpsData{}
+		cacheTypes := map[enum.CacheType]LastKbpsData{}
+		total := LastKbpsData{}
+		for cacheName, cacheStats := range lastKbpsStat.Caches {
+			cacheGroup, ok := serverCachegroups[cacheName]
+			if !ok {
+				log.Errorf("addkbps cache %v not in cachegroups\n", cacheName)
+			} else {
+				c := cacheGroups[cacheGroup]
+				c.Kbps += cacheStats.Kbps
+				cacheGroups[cacheGroup] = c
 			}
+
+			cacheType, ok := serverTypes[cacheName]
+			if !ok {
+				log.Errorf("addkbps cache %v not in types\n", cacheName)
+			} else {
+				c := cacheTypes[cacheType]
+				c.Kbps += cacheStats.Kbps
+				cacheTypes[cacheType] = c
+			}
+
+			total.Kbps += cacheStats.Kbps
 		}
 
-		totalChanged := lastKbpsStat.Total.Bytes != stat.TotalStats.OutBytes.Value
-		if lastKbpsStatExists && lastKbpsStat.Total.Bytes != 0 && totalChanged && lastKbpsStat.Total.Bytes != 0 {
-			stat.TotalStats.Kbps.Value = float64(stat.TotalStats.OutBytes.Value-lastKbpsStat.Total.Bytes) / BytesPerKilobit / dsStatsTime.Sub(lastKbpsStat.Total.Time).Seconds()
-			if dsName == "le-vod-g2" {
-				fmt.Printf("debug9 changing le-vod-g2 from %v to %v\n", lastKbpsStat.Total.Bytes, stat.TotalStats.OutBytes.Value)
-			}
-			if stat.TotalStats.Kbps.Value < 0 {
-				stat.TotalStats.Kbps.Value = 0
-				log.Errorf("addkbps negative stat.Total.Kbps.Value! Deliveryservice '%v' %v - %v / %v\n", dsName, stat.TotalStats.OutBytes.Value, lastKbpsStat.Total.Bytes, dsStatsTime.Sub(lastKbpsStat.Total.Time).Seconds())
-			}
-		} else {
-			stat.TotalStats.Kbps.Value = lastKbpsStat.Total.Kbps
+		for cacheGroup, lastKbpsData := range cacheGroups {
+			g := stat.CacheGroups[cacheGroup]
+			g.Kbps.Value = lastKbpsData.Kbps
+			stat.CacheGroups[cacheGroup] = g
 		}
 
-		if totalChanged {
-			lastKbpsStat.Total = LastKbpsData{Time: dsStatsTime, Bytes: stat.TotalStats.OutBytes.Value, Kbps: stat.TotalStats.Kbps.Value}
+		for cacheType, lastKbpsData := range cacheTypes {
+			t := stat.Types[cacheType]
+			t.Kbps.Value = lastKbpsData.Kbps
+			stat.Types[cacheType] = t
 		}
+
+		lastKbpsStat.CacheGroups = cacheGroups
+		lastKbpsStat.Type = cacheTypes
+		lastKbpsStat.Total = total
+
+		stat.TotalStats.Kbps.Value = total.Kbps
 
 		lastKbpsStats.DeliveryServices[dsName] = lastKbpsStat
 		dsStats.DeliveryService[dsName] = stat
@@ -345,11 +359,14 @@ func CreateStats(statHistory map[enum.CacheName][]cache.Result, toData todata.TO
 			httpDsStat.TotalStats = httpDsStat.TotalStats.Sum(resultStat.TotalStats)
 			httpDsStat.CacheGroups[cachegroup] = httpDsStat.CacheGroups[cachegroup].Sum(resultStat.CacheGroups[cachegroup])
 			httpDsStat.Types[serverType] = httpDsStat.Types[serverType].Sum(resultStat.Types[serverType])
+			httpDsStat.Caches[server] = httpDsStat.Caches[server].Sum(resultStat.Caches[server])
+			httpDsStat.CachesTimeReceived[server] = resultStat.CachesTimeReceived[server]
+			httpDsStat.CommonStats = dsStats.DeliveryService[ds].CommonStats
 			dsStats.DeliveryService[ds] = httpDsStat // TODO determine if necessary
 		}
 	}
 
-	kbpsStats, kbpsStatsLastKbps, kbpsErr := addKbps(statHistory, dsStats, lastKbpsStats, now)
+	kbpsStats, kbpsStatsLastKbps, kbpsErr := addKbps(statHistory, dsStats, lastKbpsStats, now, toData.ServerCachegroups, toData.ServerTypes)
 	log.Infof("CreateStats took %v\n", time.Since(start))
 	return kbpsStats, kbpsStatsLastKbps, kbpsErr
 }

--- a/traffic_monitor/experimental/traffic_monitor/deliveryservice/stat.go
+++ b/traffic_monitor/experimental/traffic_monitor/deliveryservice/stat.go
@@ -224,8 +224,11 @@ func addKbps(statHistory map[enum.CacheName][]cache.Result, dsStats Stats, lastK
 		}
 
 		totalChanged := lastKbpsStat.Total.Bytes != stat.TotalStats.OutBytes.Value
-		if lastKbpsStatExists && lastKbpsStat.Total.Bytes != 0 && totalChanged {
+		if lastKbpsStatExists && lastKbpsStat.Total.Bytes != 0 && totalChanged && lastKbpsStat.Total.Bytes != 0 {
 			stat.TotalStats.Kbps.Value = float64(stat.TotalStats.OutBytes.Value-lastKbpsStat.Total.Bytes) / BytesPerKilobit / dsStatsTime.Sub(lastKbpsStat.Total.Time).Seconds()
+			if dsName == "le-vod-g2" {
+				fmt.Printf("debug9 changing le-vod-g2 from %v to %v\n", lastKbpsStat.Total.Bytes, stat.TotalStats.OutBytes.Value)
+			}
 			if stat.TotalStats.Kbps.Value < 0 {
 				stat.TotalStats.Kbps.Value = 0
 				log.Errorf("addkbps negative stat.Total.Kbps.Value! Deliveryservice '%v' %v - %v / %v\n", dsName, stat.TotalStats.OutBytes.Value, lastKbpsStat.Total.Bytes, dsStatsTime.Sub(lastKbpsStat.Total.Time).Seconds())

--- a/traffic_monitor/experimental/traffic_monitor/deliveryservicedata/stat.go
+++ b/traffic_monitor/experimental/traffic_monitor/deliveryservicedata/stat.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/Comcast/traffic_control/traffic_monitor/experimental/traffic_monitor/enum"
 	"net/url"
+	"time"
 )
 
 // Filter encapsulates functions to filter a given set of Stats, e.g. from HTTP query parameters.
@@ -161,25 +162,46 @@ func (a StatCacheStats) Sum(b StatCacheStats) StatCacheStats {
 }
 
 type Stat struct {
-	CommonStats StatCommon
-	CacheGroups map[enum.CacheGroupName]StatCacheStats
-	Types       map[enum.CacheType]StatCacheStats
-	TotalStats  StatCacheStats
+	CommonStats        StatCommon
+	CacheGroups        map[enum.CacheGroupName]StatCacheStats
+	Types              map[enum.CacheType]StatCacheStats
+	Caches             map[enum.CacheName]StatCacheStats
+	CachesTimeReceived map[enum.CacheName]time.Time
+	TotalStats         StatCacheStats
 }
 
 var ErrNotProcessedStat = errors.New("This stat is not used.")
 
 func NewStat() *Stat {
-	return &Stat{CacheGroups: map[enum.CacheGroupName]StatCacheStats{}, Types: map[enum.CacheType]StatCacheStats{}, CommonStats: StatCommon{CachesReporting: map[enum.CacheName]bool{}}}
+	return &Stat{
+		CacheGroups:        map[enum.CacheGroupName]StatCacheStats{},
+		Types:              map[enum.CacheType]StatCacheStats{},
+		CommonStats:        StatCommon{CachesReporting: map[enum.CacheName]bool{}},
+		Caches:             map[enum.CacheName]StatCacheStats{},
+		CachesTimeReceived: map[enum.CacheName]time.Time{},
+	}
 }
 
 func (a Stat) Copy() Stat {
-	b := Stat{CommonStats: a.CommonStats.Copy(), TotalStats: a.TotalStats, CacheGroups: map[enum.CacheGroupName]StatCacheStats{}, Types: map[enum.CacheType]StatCacheStats{}}
+	b := Stat{
+		CommonStats:        a.CommonStats.Copy(),
+		TotalStats:         a.TotalStats,
+		CacheGroups:        map[enum.CacheGroupName]StatCacheStats{},
+		Types:              map[enum.CacheType]StatCacheStats{},
+		Caches:             map[enum.CacheName]StatCacheStats{},
+		CachesTimeReceived: map[enum.CacheName]time.Time{},
+	}
 	for k, v := range a.CacheGroups {
 		b.CacheGroups[k] = v
 	}
 	for k, v := range a.Types {
 		b.Types[k] = v
+	}
+	for k, v := range a.Caches {
+		b.Caches[k] = v
+	}
+	for k, v := range a.CachesTimeReceived {
+		b.CachesTimeReceived[k] = v
 	}
 	return b
 }

--- a/traffic_monitor/experimental/traffic_monitor/index.html
+++ b/traffic_monitor/experimental/traffic_monitor/index.html
@@ -333,9 +333,6 @@
 							 document.getElementById("deliveryservice-stats-" + deliveryService + "-2xx").textContent = perSec.toFixed(2);
 						 }
 						 if (previousDeliveryserviceStats2xx[deliveryService] != new2xx && previousDeliveryserviceStats2xx.hasOwnProperty(deliveryService)) {
-							 /* if(deliveryService == 'le-vod-g2') {
-									alert("previous le-vod-g2 2xx " + previousDeliveryserviceStats2xx[deliveryService] + " new " + new2xx)
-									} */
 						 	previousDeliveryserviceStatsTime2xx[deliveryService] = now;
 						 }
 						 previousDeliveryserviceStats2xx[deliveryService] = new2xx;

--- a/traffic_monitor/experimental/traffic_monitor/index.html
+++ b/traffic_monitor/experimental/traffic_monitor/index.html
@@ -332,7 +332,10 @@
 							 var perSec = (new2xx - previousDeliveryserviceStats2xx[deliveryService]) / ((now - previousDeliveryserviceStatsTime2xx[deliveryService]) / millisecondsInSecond);
 							 document.getElementById("deliveryservice-stats-" + deliveryService + "-2xx").textContent = perSec.toFixed(2);
 						 }
-						 if (previousDeliveryserviceStats2xx[deliveryService] != new2xx) {
+						 if (previousDeliveryserviceStats2xx[deliveryService] != new2xx && previousDeliveryserviceStats2xx.hasOwnProperty(deliveryService)) {
+							 /* if(deliveryService == 'le-vod-g2') {
+									alert("previous le-vod-g2 2xx " + previousDeliveryserviceStats2xx[deliveryService] + " new " + new2xx)
+									} */
 						 	previousDeliveryserviceStatsTime2xx[deliveryService] = now;
 						 }
 						 previousDeliveryserviceStats2xx[deliveryService] = new2xx;
@@ -343,7 +346,7 @@
 							 var perSec = (new3xx - previousDeliveryserviceStats3xx[deliveryService]) / ((now - previousDeliveryserviceStatsTime3xx[deliveryService]) / millisecondsInSecond);
 							 document.getElementById("deliveryservice-stats-" + deliveryService + "-3xx").textContent = perSec.toFixed(2);
 						 }
-						 if (previousDeliveryserviceStats3xx[deliveryService] != new3xx) {
+						 if (previousDeliveryserviceStats3xx[deliveryService] != new3xx && previousDeliveryserviceStats3xx.hasOwnProperty(deliveryService)) {
 						 	previousDeliveryserviceStatsTime3xx[deliveryService] = now;
 						 }
 						 previousDeliveryserviceStats3xx[deliveryService] = new3xx;
@@ -354,7 +357,7 @@
 							 var perSec = (new4xx - previousDeliveryserviceStats4xx[deliveryService]) / ((now - previousDeliveryserviceStatsTime4xx[deliveryService]) / millisecondsInSecond);
 							 document.getElementById("deliveryservice-stats-" + deliveryService + "-4xx").textContent = perSec.toFixed(2);
 						 }
-						 if (previousDeliveryserviceStats4xx[deliveryService] != new4xx) {
+						 if (previousDeliveryserviceStats4xx[deliveryService] != new4xx && previousDeliveryserviceStats4xx.hasOwnProperty(deliveryService)) {
 						 	previousDeliveryserviceStatsTime4xx[deliveryService] = now;
 						 }
 						 previousDeliveryserviceStats4xx[deliveryService] = new4xx;
@@ -365,7 +368,7 @@
 							 var perSec = (new5xx - previousDeliveryserviceStats5xx[deliveryService]) / ((now - previousDeliveryserviceStatsTime5xx[deliveryService]) / millisecondsInSecond);
 							 document.getElementById("deliveryservice-stats-" + deliveryService + "-5xx").textContent = perSec.toFixed(2);
 						 }
-						 if (previousDeliveryserviceStats5xx[deliveryService] != new5xx) {
+						 if (previousDeliveryserviceStats5xx[deliveryService] != new5xx && previousDeliveryserviceStats5xx.hasOwnProperty(deliveryService)) {
 						 	previousDeliveryserviceStatsTime5xx[deliveryService] = now;
 						 }
 						 previousDeliveryserviceStats5xx[deliveryService] = new5xx;


### PR DESCRIPTION
This required completely rewriting the DS KBPS logic, to track per-cache bytes, and compute kbps for each cache, then sum them. Because otherwise, if a cache doesn't respond, it may be in a previous total DS bytes, but not the new one, resulting in wrong (and even negative) kbps.