### PR TITLE
close old connections explicitly to prevent tcp conn leak

### DIFF
--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -248,6 +248,13 @@ func loadStartupConfig(configFile string, oldConfig StartupConfig) (StartupConfi
 		config.InfluxDBs = append(config.InfluxDBs, &influxDBProps)
 	}
 
+	//Close old connections explicitly
+	for _, host := range oldConfig.InfluxDBs {
+		if host.InfluxClient != nil {
+			host.InfluxClient.Close()
+		}
+	}
+
 	return config, nil
 }
 
@@ -741,6 +748,11 @@ func influxConnect(config StartupConfig) (influx.Client, error) {
 			errHndlr(fmt.Errorf("An error occurred creating HTTP client.  %v\n", err), ERROR)
 			continue
 		}
+		//Close old connections explicitly
+		if host.InfluxClient != nil {
+			host.InfluxClient.Close()
+		}
+		host.InfluxClient = con
 		_, _, err = con.Ping(10)
 		if err != nil {
 			errHndlr(err, WARN)


### PR DESCRIPTION
fixed #1825 

We found the tcp connections leak in traffic_stats 1.6.0. And verified the solution in 1.6.0.

The root cause is go "net/http" Client will keep idle connections for reuse. If we leave the influxDB client w/o explicitly close the transport, go GC could not re-collect the resources.

Please refer to https://github.com/influxdata/influxdb/pull/6425

Not sure why the recent code in master discard the original logic to re-use influxDB client like traffic_stats 1.6.0. But anyway, we need to close old client explicitly. Otherwise, there will be lots of tcp connections leak quickly.