### PR TITLE
Change TM2 manager params to be multiline

### DIFF
--- a/traffic_monitor/experimental/traffic_monitor/manager/datarequest.go
+++ b/traffic_monitor/experimental/traffic_monitor/manager/datarequest.go
@@ -400,8 +400,26 @@ func NewPeerStateFilter(params url.Values, cacheTypes map[enum.CacheName]enum.Ca
 }
 
 // DataRequest takes an `http_server.DataRequest`, and the monitored data objects, and returns the appropriate response, and the status code.
-func DataRequest(req http_server.DataRequest, opsConfig OpsConfigThreadsafe, toSession towrap.ITrafficOpsSession, localStates peer.CRStatesThreadsafe, peerStates peer.CRStatesPeersThreadsafe, combinedStates peer.CRStatesThreadsafe, statHistory StatHistoryThreadsafe, dsStats DSStatsThreadsafe, events EventsThreadsafe, staticAppData StaticAppData, healthPollInterval time.Duration, lastHealthDurations DurationMapThreadsafe, fetchCount UintThreadsafe, healthIteration UintThreadsafe, errorCount UintThreadsafe, toData todata.TODataThreadsafe, localCacheStatus CacheAvailableStatusThreadsafe, lastStats LastStatsThreadsafe) (body []byte, responseCode int) {
-
+func DataRequest(
+	req http_server.DataRequest,
+	opsConfig OpsConfigThreadsafe,
+	toSession towrap.ITrafficOpsSession,
+	localStates peer.CRStatesThreadsafe,
+	peerStates peer.CRStatesPeersThreadsafe,
+	combinedStates peer.CRStatesThreadsafe,
+	statHistory StatHistoryThreadsafe,
+	dsStats DSStatsThreadsafe,
+	events EventsThreadsafe,
+	staticAppData StaticAppData,
+	healthPollInterval time.Duration,
+	lastHealthDurations DurationMapThreadsafe,
+	fetchCount UintThreadsafe,
+	healthIteration UintThreadsafe,
+	errorCount UintThreadsafe,
+	toData todata.TODataThreadsafe,
+	localCacheStatus CacheAvailableStatusThreadsafe,
+	lastStats LastStatsThreadsafe,
+) (body []byte, responseCode int) {
 	// handleErr takes an error, and the request type it came from, and logs. It is ok to call with a nil error, in which case this is a no-op.
 	handleErr := func(err error, requestType http_server.Type) {
 		if err == nil {
@@ -524,7 +542,14 @@ func DataRequest(req http_server.DataRequest, opsConfig OpsConfigThreadsafe, toS
 	}
 }
 
-func createCacheStatuses(cacheTypes map[enum.CacheName]enum.CacheType, statHistory map[enum.CacheName][]cache.Result, lastHealthDurations map[enum.CacheName]time.Duration, cacheStates map[enum.CacheName]peer.IsAvailable, lastStats ds.LastStats, localCacheStatusThreadsafe CacheAvailableStatusThreadsafe) map[enum.CacheName]CacheStatus {
+func createCacheStatuses(
+	cacheTypes map[enum.CacheName]enum.CacheType,
+	statHistory map[enum.CacheName][]cache.Result,
+	lastHealthDurations map[enum.CacheName]time.Duration,
+	cacheStates map[enum.CacheName]peer.IsAvailable,
+	lastStats ds.LastStats,
+	localCacheStatusThreadsafe CacheAvailableStatusThreadsafe,
+) map[enum.CacheName]CacheStatus {
 	conns := createCacheConnections(statHistory)
 	statii := map[enum.CacheName]CacheStatus{}
 	localCacheStatus := localCacheStatusThreadsafe.Get()

--- a/traffic_monitor/experimental/traffic_monitor/manager/manager.go
+++ b/traffic_monitor/experimental/traffic_monitor/manager/manager.go
@@ -75,8 +75,18 @@ func Start(opsConfigFile string, cfg config.Config, staticAppData StaticAppData)
 		cfg,
 		staticAppData)
 
-	combinedStates := StartPeerManager(peerHandler.ResultChannel, localStates, peerStates)
-	statHistory, _, lastKbpsStats, dsStats := StartStatHistoryManager(cacheStatHandler.ResultChannel, combinedStates, toData, errorCount, cfg)
+	combinedStates := StartPeerManager(
+		peerHandler.ResultChannel,
+		localStates,
+		peerStates)
+
+	statHistory, _, lastKbpsStats, dsStats := StartStatHistoryManager(
+		cacheStatHandler.ResultChannel,
+		combinedStates,
+		toData,
+		errorCount,
+		cfg)
+
 	lastHealthDurations, events, localCacheStatus := StartHealthResultManager(
 		cacheHealthHandler.ResultChannel,
 		toData,

--- a/traffic_monitor/experimental/traffic_monitor/manager/monitorconfig.go
+++ b/traffic_monitor/experimental/traffic_monitor/manager/monitorconfig.go
@@ -64,15 +64,40 @@ func (t *TrafficMonitorConfigMapThreadsafe) Set(c to.TrafficMonitorConfigMap) {
 	t.m.Unlock()
 }
 
-func StartMonitorConfigManager(monitorConfigPollChan <-chan to.TrafficMonitorConfigMap, localStates peer.CRStatesThreadsafe, statUrlSubscriber chan<- poller.HttpPollerConfig, healthUrlSubscriber chan<- poller.HttpPollerConfig, peerUrlSubscriber chan<- poller.HttpPollerConfig, cfg config.Config, staticAppData StaticAppData) TrafficMonitorConfigMapThreadsafe {
+func StartMonitorConfigManager(
+	monitorConfigPollChan <-chan to.TrafficMonitorConfigMap,
+	localStates peer.CRStatesThreadsafe,
+	statUrlSubscriber chan<- poller.HttpPollerConfig,
+	healthUrlSubscriber chan<- poller.HttpPollerConfig,
+	peerUrlSubscriber chan<- poller.HttpPollerConfig,
+	cfg config.Config,
+	staticAppData StaticAppData,
+) TrafficMonitorConfigMapThreadsafe {
 	monitorConfig := NewTrafficMonitorConfigMapThreadsafe()
-	go monitorConfigListen(monitorConfig, monitorConfigPollChan, localStates, statUrlSubscriber, healthUrlSubscriber, peerUrlSubscriber, cfg, staticAppData)
+	go monitorConfigListen(monitorConfig,
+		monitorConfigPollChan,
+		localStates,
+		statUrlSubscriber,
+		healthUrlSubscriber,
+		peerUrlSubscriber,
+		cfg,
+		staticAppData,
+	)
 	return monitorConfig
 }
 
 // TODO timing, and determine if the case, or its internal `for`, should be put in a goroutine
 // TODO determine if subscribers take action on change, and change to mutexed objects if not.
-func monitorConfigListen(monitorConfigTS TrafficMonitorConfigMapThreadsafe, monitorConfigPollChan <-chan to.TrafficMonitorConfigMap, localStates peer.CRStatesThreadsafe, statUrlSubscriber chan<- poller.HttpPollerConfig, healthUrlSubscriber chan<- poller.HttpPollerConfig, peerUrlSubscriber chan<- poller.HttpPollerConfig, cfg config.Config, staticAppData StaticAppData) {
+func monitorConfigListen(
+	monitorConfigTS TrafficMonitorConfigMapThreadsafe,
+	monitorConfigPollChan <-chan to.TrafficMonitorConfigMap,
+	localStates peer.CRStatesThreadsafe,
+	statUrlSubscriber chan<- poller.HttpPollerConfig,
+	healthUrlSubscriber chan<- poller.HttpPollerConfig,
+	peerUrlSubscriber chan<- poller.HttpPollerConfig,
+	cfg config.Config,
+	staticAppData StaticAppData,
+) {
 	for {
 		select {
 		case monitorConfig := <-monitorConfigPollChan:

--- a/traffic_monitor/experimental/traffic_monitor/manager/peer.go
+++ b/traffic_monitor/experimental/traffic_monitor/manager/peer.go
@@ -9,7 +9,11 @@ import (
 )
 
 // StartPeerManager listens for peer results, and when it gets one, it adds it to the peerStates list, and optimistically combines the good results into combinedStates
-func StartPeerManager(peerChan <-chan peer.Result, localStates peer.CRStatesThreadsafe, peerStates peer.CRStatesPeersThreadsafe) peer.CRStatesThreadsafe {
+func StartPeerManager(
+	peerChan <-chan peer.Result,
+	localStates peer.CRStatesThreadsafe,
+	peerStates peer.CRStatesPeersThreadsafe,
+) peer.CRStatesThreadsafe {
 	combinedStates := peer.NewCRStatesThreadsafe()
 	go func() {
 		for {

--- a/traffic_monitor/experimental/traffic_monitor/manager/stathistory.go
+++ b/traffic_monitor/experimental/traffic_monitor/manager/stathistory.go
@@ -72,7 +72,13 @@ func pruneHistory(history []cache.Result, limit uint64) []cache.Result {
 // StartStatHistoryManager fetches the full statistics data from ATS Astats. This includes everything needed for all calculations, such as Delivery Services. This is expensive, though, and may be hard on ATS, so it should poll less often.
 // For a fast 'is it alive' poll, use the Health Result Manager poll.
 // Returns the stat history, the duration between the stat poll for each cache, the last Kbps data, and the calculated Delivery Service stats.
-func StartStatHistoryManager(cacheStatChan <-chan cache.Result, combinedStates peer.CRStatesThreadsafe, toData todata.TODataThreadsafe, errorCount UintThreadsafe, cfg config.Config) (StatHistoryThreadsafe, DurationMapThreadsafe, LastStatsThreadsafe, DSStatsThreadsafe) {
+func StartStatHistoryManager(
+	cacheStatChan <-chan cache.Result,
+	combinedStates peer.CRStatesThreadsafe,
+	toData todata.TODataThreadsafe,
+	errorCount UintThreadsafe,
+	cfg config.Config,
+) (StatHistoryThreadsafe, DurationMapThreadsafe, LastStatsThreadsafe, DSStatsThreadsafe) {
 	statHistory := NewStatHistoryThreadsafe(cfg.MaxStatHistory)
 	lastStatDurations := NewDurationMapThreadsafe()
 	lastStatEndTimes := map[enum.CacheName]time.Time{}
@@ -107,7 +113,17 @@ func StartStatHistoryManager(cacheStatChan <-chan cache.Result, combinedStates p
 }
 
 // processStatResults processes the given results, creating and setting DSStats, LastStats, and other stats. Note this is NOT threadsafe, and MUST NOT be called from multiple threads.
-func processStatResults(results []cache.Result, statHistoryThreadsafe StatHistoryThreadsafe, combinedStates peer.Crstates, lastStats LastStatsThreadsafe, toData todata.TOData, errorCount UintThreadsafe, dsStats DSStatsThreadsafe, lastStatEndTimes map[enum.CacheName]time.Time, lastStatDurationsThreadsafe DurationMapThreadsafe) {
+func processStatResults(
+	results []cache.Result,
+	statHistoryThreadsafe StatHistoryThreadsafe,
+	combinedStates peer.Crstates,
+	lastStats LastStatsThreadsafe,
+	toData todata.TOData,
+	errorCount UintThreadsafe,
+	dsStats DSStatsThreadsafe,
+	lastStatEndTimes map[enum.CacheName]time.Time,
+	lastStatDurationsThreadsafe DurationMapThreadsafe,
+) {
 	statHistory := statHistoryThreadsafe.Get().Copy()
 	maxStats := statHistoryThreadsafe.Max()
 	for _, result := range results {


### PR DESCRIPTION
Changes function definitions and calls to put each param on its own
line. These managers have a large number of parameters. This makes it
easier to read, and makes diffs better.

Fixes #2012