### PR TITLE
Google::ProtocolBuffers to previous version

### DIFF
--- a/traffic_ops/app/cpanfile
+++ b/traffic_ops/app/cpanfile
@@ -93,6 +93,7 @@ requires 'File::Spec::Functions';
 requires 'File::Temp';
 requires 'Getopt::Long';
 requires 'Getopt::Std';
+requires 'Google::ProtocolBuffers', '<= 0.11';
 requires 'HTML::Entities';
 requires 'HTML::Parser';
 requires 'HTML::Tagset';


### PR DESCRIPTION
Fixes #2027 for 1.7.x

(cherry picked from commit ec58ab8248a6dcf1552040ae2fae2a9b9472c59f)